### PR TITLE
Key to an EventSource is the Id and the Artifact Type

### DIFF
--- a/Source/Events/EventMetadata.cs
+++ b/Source/Events/EventMetadata.cs
@@ -87,7 +87,7 @@ namespace Dolittle.Runtime.Events
         /// Gets the <see cref="EventSourceKey" /> from this EventMetadata
         /// </summary>
         /// <returns>the <see cref="EventSourceKey" /></returns>
-        public EventSourceKey EventSourceKey => new EventSourceKey(EventSourceId,Artifact.Id);
+        public EventSourceKey EventSourceKey => VersionedEventSource.Key;
 
     }
 }

--- a/Source/Events/EventMetadata.cs
+++ b/Source/Events/EventMetadata.cs
@@ -83,5 +83,11 @@ namespace Dolittle.Runtime.Events
                 &&  VersionedEventSource.Equals(other.VersionedEventSource);
         }
 
+        /// <summary>
+        /// Gets the <see cref="EventSourceKey" /> from this EventMetadata
+        /// </summary>
+        /// <returns>the <see cref="EventSourceKey" /></returns>
+        public EventSourceKey EventSourceKey => new EventSourceKey(EventSourceId,Artifact.Id);
+
     }
 }

--- a/Source/Events/EventSourceKey.cs
+++ b/Source/Events/EventSourceKey.cs
@@ -1,0 +1,36 @@
+﻿/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Dolittle. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+using System;
+using Dolittle.Artifacts;
+using Dolittle.Concepts;
+
+namespace Dolittle.Runtime.Events
+{
+    /// <summary>
+    /// Represents the key for an event source (the <see cref="EventSourceId">id </see> and <see cref="ArtifactId">artifact</see>)
+    /// </summary>
+    public class EventSourceKey : Value<EventSourceKey>
+    {
+        /// <summary>
+        /// Instantiates a new instance of an <see cref="EventSourceKey"/> with the Event Source Id and ArtifactId
+        /// </summary>
+        /// <param name="id">The Event Source Id</param>
+        ///  <param name="artifact">The Event Source Artifact</param>
+        public EventSourceKey(EventSourceId id, ArtifactId artifact) 
+        {
+            Id = id;
+            Artifact = artifact;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="EventSourceId" />
+        /// </summary>
+        public EventSourceId Id { get; }
+        /// <summary>
+        /// Gets the <see cref="Artifact" />
+        /// </summary>
+        public ArtifactId Artifact { get; }
+    }
+}

--- a/Source/Events/EventSourceKey.cs
+++ b/Source/Events/EventSourceKey.cs
@@ -5,11 +5,13 @@
 using System;
 using Dolittle.Artifacts;
 using Dolittle.Concepts;
+using Dolittle.Events;
 
 namespace Dolittle.Runtime.Events
 {
     /// <summary>
     /// Represents the key for an event source (the <see cref="EventSourceId">id </see> and <see cref="ArtifactId">artifact</see>)
+    /// NB:  An <see cref="EventSourceId" /> for an <see cref="IEventSource" /> is not unique.  Multiples event sources can share the same Id, given they are different artifact types (aggregates).
     /// </summary>
     public class EventSourceKey : Value<EventSourceKey>
     {

--- a/Source/Events/Relativity/Consumer/ParticleStreamProcessor.cs
+++ b/Source/Events/Relativity/Consumer/ParticleStreamProcessor.cs
@@ -73,10 +73,10 @@ namespace Dolittle.Runtime.Events.Relativity
                 _executionContextManager.CurrentFor(context);
                 using(var _ = _getEventStore())
                 {
-                    version = _.GetNextVersionFor(particleStream.Source.EventSource);
+                    version = _.GetNextVersionFor(particleStream.Source.Key);
                 }
 
-                var versionedEventSource = new VersionedEventSource(version, particleStream.Source.EventSource, particleStream.Source.Artifact);
+                var versionedEventSource = new VersionedEventSource(version, new EventSourceKey(particleStream.Source.EventSource, particleStream.Source.Artifact));
 
                 var eventEnvelopes = new List<EventEnvelope>();
 
@@ -86,7 +86,7 @@ namespace Dolittle.Runtime.Events.Relativity
                     var envelope = new EventEnvelope(
                         new EventMetadata(
                             _.Id,
-                            new VersionedEventSource(version, particleStream.Source.EventSource, particleStream.Source.Artifact),
+                            new VersionedEventSource(version, new EventSourceKey(particleStream.Source.EventSource, particleStream.Source.Artifact)),
                             _.Metadata.CorrelationId,
                             _.Metadata.Artifact,
                             _.Metadata.Occurred,

--- a/Source/Events/Relativity/Protobuf/Conversion/EventSourceExtensions.cs
+++ b/Source/Events/Relativity/Protobuf/Conversion/EventSourceExtensions.cs
@@ -44,8 +44,7 @@ namespace Dolittle.Runtime.Events.Relativity.Protobuf.Conversion
         {
             return new Dolittle.Runtime.Events.VersionedEventSource(
                 protobuf.Version.ToEventSourceVersion(),
-                protobuf.EventSource.ToConcept<EventSourceId>(),
-                protobuf.Artifact.ToConcept<ArtifactId>());
+                new EventSourceKey(protobuf.EventSource.ToConcept<EventSourceId>(),protobuf.Artifact.ToConcept<ArtifactId>()));
         }
 
         /// <summary>

--- a/Source/Events/Store/IFetchCommittedEvents.cs
+++ b/Source/Events/Store/IFetchCommittedEvents.cs
@@ -12,16 +12,16 @@ namespace Dolittle.Runtime.Events.Store
         /// <summary>
         /// Fetches all <see cref="CommittedEventStream" />s for an <see cref="IEventSource" />
         /// </summary>
-        /// <param name="eventSourceId">The Id of the <see cref="IEventSource" /></param>
+        /// <param name="eventSourceKey">The Key of the <see cref="IEventSource" /></param>
         /// <returns>All <see cref="CommittedEventStream" />s for the <see cref="IEventSource" /> in ascending order</returns>
-        Commits Fetch(EventSourceId eventSourceId);
+        Commits Fetch(EventSourceKey eventSourceKey);
         /// <summary>
         /// Fetches all <see cref="CommittedEventStream" />s for an <see cref="IEventSource" /> from the specified version
         /// </summary>
-        /// <param name="eventSourceId">The Id of the <see cref="IEventSource" /></param>
+        /// <param name="eventSourceKey">The Key for the <see cref="IEventSource" /></param>
         /// <param name="commitVersion">The <see cref="CommitVersion" /> to fetch events from</param>
         /// <returns>All <see cref="CommittedEventStream" />s for the <see cref="IEventSource" /> from the specified <see cref="CommitVersion" /> in ascending order</returns>
-        Commits FetchFrom(EventSourceId eventSourceId, CommitVersion commitVersion);
+        Commits FetchFrom(EventSourceKey eventSourceKey, CommitVersion commitVersion);
         /// <summary>
         /// Fetches all <see cref="CommittedEventStream" />s for all <see cref="IEventSource" />s greater than the specified <see cref="CommitSequenceNumber" />
         /// </summary>

--- a/Source/Events/Store/IFetchEventSourceVersion.cs
+++ b/Source/Events/Store/IFetchEventSourceVersion.cs
@@ -10,15 +10,15 @@
          /// <summary>
          /// Returns the current <see cref="EventSourceVersion" /> for a specific <see cref="EventSource" />
          /// </summary>
-         /// <param name="eventSource">The <see cref="EventSourceId" /> to get the verison for</param>
+         /// <param name="eventSource">The <see cref="EventSourceKey" /> to get the verison for</param>
          /// <returns>The <see cref="EventSourceVersion" /> for this <see cref="EventSource" />, <see cref="EventSourceVersion.NoVersion" /> if the <see cref="EventSource" /> has not been persisted before</returns>
-         EventSourceVersion GetCurrentVersionFor(EventSourceId eventSource);
+         EventSourceVersion GetCurrentVersionFor(EventSourceKey eventSource);
          
          /// <summary>
          /// Returns the next <see cref="EventSourceVersion" /> for a specific <see cref="EventSource" />
          /// </summary>
-         /// <param name="eventSource">The <see cref="EventSourceId" /> to get the next verison for</param>
+         /// <param name="eventSource">The <see cref="EventSourceKey" /> to get the next verison for</param>
          /// <returns>The next <see cref="EventSourceVersion" /> for this <see cref="EventSource" />, the  <see cref="EventSourceVersion.Initial" /> if the <see cref="EventSource" /> has not been persisted before</returns>
-         EventSourceVersion GetNextVersionFor(EventSourceId eventSource);
+         EventSourceVersion GetNextVersionFor(EventSourceKey eventSource);
     }
 }

--- a/Source/Events/VersionedEventSource.cs
+++ b/Source/Events/VersionedEventSource.cs
@@ -18,19 +18,18 @@ namespace Dolittle.Runtime.Events
         /// <param name="eventSource">The <see cref="EventSourceId">Id</see> for this particular <see cref="IEventSource" /></param>
         /// <param name="artifact">The <see cref="ArtifactId" /> that uniquely identifies the type of this event source</param>
         /// <returns></returns>
-        public VersionedEventSource(EventSourceId eventSource, ArtifactId artifact): this(EventSourceVersion.Initial, eventSource, artifact) { }
+        public VersionedEventSource(EventSourceId eventSource, ArtifactId artifact): this(EventSourceVersion.Initial, new EventSourceKey(eventSource, artifact))
+        {}
 
         /// <summary>
         /// Instantiates a new instance of a <see cref="VersionedEventSource" /> set to the supplied version
         /// </summary>
         /// <param name="version">The <see cref="EventSourceVersion" /> of this instance</param>
-        /// <param name="eventSource">The <see cref="EventSourceId">Id</see> for this particular <see cref="IEventSource" /></param>
-        /// <param name="artifact">The <see cref="ArtifactId" /> that uniquely identifies the type of this event source</param>
-        public VersionedEventSource(EventSourceVersion version, EventSourceId eventSource, ArtifactId artifact)
+        /// <param name="key">The <see cref="EventSourceKey">Key</see> for this particular <see cref="IEventSource" /></param>
+        public VersionedEventSource(EventSourceVersion version, EventSourceKey key)
         {
             Version = version;
-            EventSource = eventSource;
-            Artifact = artifact;
+            Key = key;
         }
         /// <summary>
         /// The <see cref="EventSourceVersion" /> of this instance
@@ -41,12 +40,18 @@ namespace Dolittle.Runtime.Events
         /// The <see cref="EventSourceId">Id</see> for this particular <see cref="IEventSource" />
         /// </summary>
         /// <value></value>
-        public EventSourceId EventSource { get; }
+        public EventSourceId EventSource => Key.Id;
         /// <summary>
         /// The <see cref="ArtifactId" /> that uniquely identifies the type of this event source
         /// </summary>
         /// <value></value>
-        public ArtifactId Artifact { get; }
+        public ArtifactId Artifact => Key.Artifact;
+        /// <summary>
+        /// The <see cref="EventSourceKey" /> that uniquely identifies this event source
+        /// </summary>
+        /// <value></value>
+        public EventSourceKey Key { get; }
+
 
         /// <summary>
         /// Creates a <see cref="CommittedEventVersion" /> based upon this <see cref="VersionedEventSource" /> 

--- a/Specifications/Events/Relativity/Protobuf/Conversion/for_EventSourceExtensions/when_converting_versioned_event_source_to_and_from_protobuf.cs
+++ b/Specifications/Events/Relativity/Protobuf/Conversion/for_EventSourceExtensions/when_converting_versioned_event_source_to_and_from_protobuf.cs
@@ -15,8 +15,7 @@ namespace Dolittle.Runtime.Events.Relativity.Protobuf.Conversion.for_EventSource
 
         Establish context = () => original = new Dolittle.Runtime.Events.VersionedEventSource(
             new Dolittle.Runtime.Events.EventSourceVersion(42,43),
-            EventSourceId.New(),
-            ArtifactId.New()
+            new EventSourceKey(EventSourceId.New(),ArtifactId.New())
         );
 
         Because of = () => 

--- a/Specifications/Events/given/Events.cs
+++ b/Specifications/Events/given/Events.cs
@@ -25,7 +25,7 @@
                 version = new CommittedEventVersion(1,1,0);
             }
 
-            var versionedEventSource = new VersionedEventSource(new EventSourceVersion(version.Minor,version.Revision),event_source_id,Artifacts.artifact_for_event_source.Id);
+            var versionedEventSource = new VersionedEventSource(new EventSourceVersion(version.Minor,version.Revision),new EventSourceKey(event_source_id,Artifacts.artifact_for_event_source.Id));
             var now = DateTimeOffset.UtcNow;
             var correlationId = CorrelationId.New();
             var eventStream = BuildEventStreamFrom(versionedEventSource,now,correlationId,BuildEvents());
@@ -48,7 +48,7 @@
             VersionedEventSource vsn = null;
             events.ForEach(e => 
             {
-                vsn = vsn == null ? version : new VersionedEventSource(vsn.Version.NextSequence(),vsn.EventSource,vsn.Artifact);
+                vsn = vsn == null ? version : new VersionedEventSource(vsn.Version.NextSequence(),new EventSourceKey(vsn.EventSource,vsn.Artifact));
                 var envelope = e.ToEnvelope(BuildEventMetadata(EventId.New(),vsn, e is SimpleEvent ? Artifacts.artifact_for_simple_event : Artifacts.artifact_for_another_event, correlationId, DateTimeOffset.UtcNow));
                 envelopes.Add(envelope);
             });


### PR DESCRIPTION
The EventSourceId is not a unique identifier across artifact types.  It's perfectly valid to have the same Id associated with different event source artifact types.