### PR TITLE
Change GRPC listening adress to listen on all interfaces.

### DIFF
--- a/Source/Server/InteractionServer.cs
+++ b/Source/Server/InteractionServer.cs
@@ -80,7 +80,7 @@ namespace Dolittle.Runtime.Server
             var server = new grpc::Server
             {
                 Ports = {
-                    new grpc.ServerPort("localhost", _configuration.Interaction.Port, grpc::SslServerCredentials.Insecure)//,
+                    new grpc.ServerPort("0.0.0.0", _configuration.Interaction.Port, grpc::SslServerCredentials.Insecure)//,
                     //new grpc.ServerPort($"unix:{_configurationManager.Current.Interaction.UnixSocket}", 0, grpc::SslServerCredentials.Insecure)
                 }
             };


### PR DESCRIPTION
When listening to localhost, incoming connections from other hosts are rejected. Listening to this port accepts connections on any interface, although I believe only IPv4 addresses will work.