### PR TITLE
Fix event handler cancellation

### DIFF
--- a/Source/EventHorizon/Consumer/SubscriptionFailures.cs
+++ b/Source/EventHorizon/Consumer/SubscriptionFailures.cs
@@ -19,5 +19,10 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
         /// Gets the <see cref="FailureId" /> that represents the 'DidNotReceiveSubscriptionResponse' failure type.
         /// </summary>
         public static FailureId DidNotReceiveSubscriptionResponse => FailureId.Create("a1b791cf-b704-4eb8-9877-de918c36b948");
+
+        /// <summary>
+        /// Gets the <see cref="FailureId" /> that represents the 'SubscriptionCancelled' failure type.
+        /// </summary>
+        public static FailureId SubscriptionCancelled => FailureId.Create("2ed211ce-7f9b-4a9f-ae9d-973bfe8aaf2b");
     }
 }

--- a/Source/EventHorizon/Consumer/SubscriptionsService.cs
+++ b/Source/EventHorizon/Consumer/SubscriptionsService.cs
@@ -71,14 +71,9 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
                     _ => new Contracts.SubscriptionResponse(),
                 };
             }
-            catch (TaskCanceledException ex)
+            catch (TaskCanceledException)
             {
-                if (!context.CancellationToken.IsCancellationRequested)
-                {
-                    _logger.Warning(ex, "An error occurred while trying to handling event horizon subscription: {Subscription}", subscriptionId);
-                }
-
-                return new Contracts.SubscriptionResponse { Failure = new Failure(SubscriptionFailures.SubscriptionCancelled, "Event Horizon subscription cancelled by client") };
+                return new Contracts.SubscriptionResponse { Failure = new Failure(SubscriptionFailures.SubscriptionCancelled, "Event Horizon subscription was cancelled") };
             }
             catch (Exception ex)
             {

--- a/Source/EventHorizon/Consumer/SubscriptionsService.cs
+++ b/Source/EventHorizon/Consumer/SubscriptionsService.cs
@@ -51,18 +51,17 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
         /// <inheritdoc/>
         public override async Task<Contracts.SubscriptionResponse> Subscribe(Contracts.Subscription subscriptionRequest, ServerCallContext context)
         {
+            _executionContextManager.CurrentFor(subscriptionRequest.CallContext.ExecutionContext);
+            var consumerTenant = _executionContextManager.Current.Tenant;
+            var subscriptionId = new SubscriptionId(
+                consumerTenant,
+                subscriptionRequest.MicroserviceId.To<Microservice>(),
+                subscriptionRequest.TenantId.To<TenantId>(),
+                subscriptionRequest.ScopeId.To<ScopeId>(),
+                subscriptionRequest.StreamId.To<StreamId>(),
+                subscriptionRequest.PartitionId.To<PartitionId>());
             try
             {
-                _executionContextManager.CurrentFor(subscriptionRequest.CallContext.ExecutionContext);
-                var consumerTenant = _executionContextManager.Current.Tenant;
-                var subscriptionId = new SubscriptionId(
-                    consumerTenant,
-                    subscriptionRequest.MicroserviceId.To<Microservice>(),
-                    subscriptionRequest.TenantId.To<TenantId>(),
-                    subscriptionRequest.ScopeId.To<ScopeId>(),
-                    subscriptionRequest.StreamId.To<StreamId>(),
-                    subscriptionRequest.PartitionId.To<PartitionId>());
-
                 _logger.Information("Incoming event horizon subscription request from head to runtime. {SubscriptionId}", subscriptionId);
                 var subscriptionResponse = await _getConsumerClient().HandleSubscription(subscriptionId).ConfigureAwait(false);
 
@@ -72,11 +71,20 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
                     _ => new Contracts.SubscriptionResponse(),
                 };
             }
+            catch (TaskCanceledException ex)
+            {
+                if (!context.CancellationToken.IsCancellationRequested)
+                {
+                    _logger.Warning(ex, "An error occurred while trying to handling event horizon subscription: {Subscription}", subscriptionId);
+                }
+
+                return new Contracts.SubscriptionResponse { Failure = new Failure(SubscriptionFailures.SubscriptionCancelled, "Event Horizon subscription cancelled by client") };
+            }
             catch (Exception ex)
             {
                 if (!context.CancellationToken.IsCancellationRequested)
                 {
-                    _logger.Warning(ex, "An error occurred while trying to Subscribe SubscriptionRequest: {Request}", subscriptionRequest);
+                    _logger.Warning(ex, "An error occurred while trying to handling event horizon subscription: {Subscription}", subscriptionId);
                 }
 
                 return new Contracts.SubscriptionResponse { Failure = new Failure(FailureId.Other, "InternalServerError") };

--- a/Source/Events.Processing/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlersService.cs
@@ -136,7 +136,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
                 {
                     var exception = tryRegisterFilterStreamProcessor.Exception;
                     _logger.Warning(exception, "An error occurred while registering Event Handler: {eventHandlerId}", eventHandlerId);
-                    ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                    ExceptionDispatchInfo.Capture(exception).Throw();
                 }
                 else
                 {
@@ -168,7 +168,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
                 {
                     var exception = tryRegisterEventProcessorStreamProcessor.Exception;
                     _logger.Warning(exception, "An error occurred while registering Event Handler: {eventHandlerId}", eventHandlerId);
-                    ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                    ExceptionDispatchInfo.Capture(exception).Throw();
                 }
                 else
                 {
@@ -201,7 +201,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
                 {
                     var exception = tryStartEventHandler.Exception;
                     _logger.Debug(exception, "An error occurred while starting Event Handler: '{EventHandlerId}' in Scope: {ScopeId}", eventHandlerId, scopeId);
-                    ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                    ExceptionDispatchInfo.Capture(exception).Throw();
                 }
                 else
                 {
@@ -218,7 +218,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
                 _logger.Warning(ex, "An error occurred while processing Event Handler: '{EventHandlerId}' in Scope: '{ScopeId}'", eventHandlerId, scopeId);
                 linkedTokenSource.Cancel();
                 await Task.WhenAll(tasks).ConfigureAwait(false);
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                ExceptionDispatchInfo.Capture(ex).Throw();
             }
             else
             {

--- a/Source/Events.Processing/Events.Processing.csproj
+++ b/Source/Events.Processing/Events.Processing.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Dolittle.Resilience" Version="$(FundamentalsVersion)" />
         <PackageReference Include="Dolittle.Services.Clients" Version="$(FundamentalsVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Events.Processing/Filters/FiltersService.cs
+++ b/Source/Events.Processing/Filters/FiltersService.cs
@@ -259,6 +259,8 @@ namespace Dolittle.Runtime.Events.Processing.Filters
             using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(internalCancellationTokenSource.Token, externalCancellationToken);
             var cancellationToken = linkedTokenSource.Token;
 
+            _logger.Debug("Connecting Filter '{FilterId}'", filterDefinition.TargetStream);
+
             var tryRegisterFilter = TryRegisterStreamProcessor(scopeId, filterDefinition, getFilterProcessor, cancellationToken);
             if (!tryRegisterFilter.Success)
             {
@@ -267,7 +269,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                 {
                     var exception = tryRegisterFilter.Exception;
                     _logger.Warning(exception, "An error occurred while registering Filter: {filterId}", filterDefinition.TargetStream);
-                    ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                    ExceptionDispatchInfo.Capture(exception).Throw();
                 }
                 else
                 {
@@ -295,7 +297,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                 {
                     var exception = tryStartFilter.Exception;
                     _logger.Debug(exception, "An error occurred while starting Filter: '{filterId}' in Scope: {scopeId}", filterDefinition.TargetStream, scopeId);
-                    ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                    ExceptionDispatchInfo.Capture(exception).Throw();
                 }
                 else
                 {
@@ -311,7 +313,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                 internalCancellationTokenSource.Cancel();
                 _logger.Warning(ex, "An error occurred while processing Filter: '{filterId}' in Scope: '{scopeId}'", filterDefinition.TargetStream, scopeId);
                 await Task.WhenAll(tasks).ConfigureAwait(false);
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                ExceptionDispatchInfo.Capture(ex).Throw();
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);

--- a/Source/Events.Processing/Streams/StreamProcessor.cs
+++ b/Source/Events.Processing/Streams/StreamProcessor.cs
@@ -78,6 +78,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <returns>A <see cref="Task" />that represents the asynchronous operation.</returns>
         public async Task Initialize()
         {
+            _logger.Debug("Initializing StreamProcessor with Id: {StreamProcessorId}", _identifier);
             _externalCancellationToken.ThrowIfCancellationRequested();
             if (_initialized) throw new StreamProcessorAlreadyInitialized(_identifier);
             await _onAllTenants.PerformAsync(async tenant =>
@@ -99,6 +100,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task Start()
         {
+            _logger.Debug("Starting StreamProcessor with Id: {StreamProcessorId}", _identifier);
             if (!_initialized) throw new StreamProcessorNotInitialized(_identifier);
             if (_started) throw new StreamProcessorAlreadyProcessingStream(_identifier);
             _started = true;


### PR DESCRIPTION
We had a bug with all of the StreamProcessors not shutting down properly, causing the `EventHandlersService.Connect()` method to never end.
We never caught exceptions in the `TryGetExceptions()` call so we never
cancelled the `linkedTokenSource` meaning the code would hang forever on
the `WhenAll()`.

This PR fixes this by cancelling the `linkedTokenSource` after any of the StreamProcessors or the dispatcher finishes running.
Also adds more logging.

Added:
* More Logging
* EventHorizon SubscriptionFailures.SubscriptionCancelled FailureId
* Catch 'TaskCancelledException' when attempting to subscribe to an event horizon. This exception can occur when the subscription is cancelled by client or server before it actually manages to connect to the other runtime for the event horizon. Returns a failed subscription response
* Use IHostApplicationLifetime in Event.Processing services to successfully cancel all running tasks when server shuts down. There was a problem where the background task that pings the client was never killed / finished / cancelled when the server was killed by a SIGINT. I don't actually like this that much, but I could not find any better alternatives

Changed:
* Overall logging improvements
* Cancel linked token source in Events.Processing services before waiting for all tasks to finish to make sure that they are actually cancelled
Fixed:
* Used Exception.InnerException in a bad way many places which could result in null-references