### PR TITLE
Fix committed events getting their proper eventsourceid's set

### DIFF
--- a/Source/Events.Store.MongoDB/Events/EventCommitter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventCommitter.cs
@@ -36,13 +36,11 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             UncommittedEvent @event,
             CancellationToken cancellationToken)
         {
-            var eventSource = EventSourceId.NotSet;
-
             await InsertEvent(
                 transaction,
                 sequenceNumber,
                 occurred,
-                eventSource,
+                @event.EventSource,
                 @event,
                 new AggregateMetadata(),
                 executionContext,
@@ -51,7 +49,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             return new CommittedEvent(
                 sequenceNumber,
                 occurred,
-                eventSource,
+                @event.EventSource,
                 executionContext,
                 @event.Type,
                 @event.Public,


### PR DESCRIPTION
Regular committed events always had their `EventSourceId` set to an empty Guid.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1191736805436063)
