### PR TITLE
Pass EventHorizon Consent to Client when setting up a Subscription.

### DIFF
--- a/Source/EventHorizon/Consumer/SubscriptionsService.cs
+++ b/Source/EventHorizon/Consumer/SubscriptionsService.cs
@@ -68,7 +68,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
                 return subscriptionResponse switch
                 {
                     { Success: false } => new Contracts.SubscriptionResponse { Failure = subscriptionResponse.Failure },
-                    _ => new Contracts.SubscriptionResponse(),
+                    _ => new Contracts.SubscriptionResponse { ConsentId = subscriptionResponse.ConsentId.ToProtobuf() },
                 };
             }
             catch (TaskCanceledException)


### PR DESCRIPTION
For some reason this was not passed all the way back to the Head, I assume this was just forgotten.