### PR TITLE
Event Store documentation

### DIFF
--- a/Documentation/Concepts/event_sourcing.md
+++ b/Documentation/Concepts/event_sourcing.md
@@ -55,7 +55,7 @@ To negate the effect of an Event that has happened, another Event has to occur t
 
 ## Commit vs Publish
 
-Dolittle doesn't publish events, rather they are [_committed_]({{< ref "events#commit-vs-publish" >}}). Events are committed to the [event log]({{< ref "event_store#event-log" >}}), from which any potential subscribers will pick up the event from and process it. There is no way to "publish" to a particular subscriber as all the events are available on the event log, but you can create a [Filter]({{< ref "event_handlers_and_filters#filter" >}}) that creates a [Stream]({{< ref "streams" >}}).
+Dolittle doesn't publish events, rather they are [_committed_]({{< ref "event_store#commit-vs-publish" >}}). Events are committed to the [event log]({{< ref "event_store#event-log" >}}), from which any potential subscribers will pick up the event from and process it. There is no way to "publish" to a particular subscriber as all the events are available on the event log, but you can create a [Filter]({{< ref "event_handlers_and_filters#filter" >}}) that creates a [Stream]({{< ref "streams" >}}).
 
 ## Reason for change
 

--- a/Documentation/Concepts/event_store.md
+++ b/Documentation/Concepts/event_store.md
@@ -97,7 +97,7 @@ This is the structure of a committed event:
 
 ### `aggregates`
 
-This collection keeps track of all [Aggregates]({{< ref "aggregates#aggregates-in-dolittle" >}}) registered with the Runtime.
+This collection keeps track of all instances of [Aggregates]({{< ref "aggregates#aggregates-in-dolittle" >}}) registered with the Runtime.
 
 ```json
 {

--- a/Documentation/Concepts/events.md
+++ b/Documentation/Concepts/events.md
@@ -138,6 +138,3 @@ Handle(DishPrepared @event) { ... }
 For making development easier, you shouldn't worry about incrementing the generation until you're in production.
 {{< /alert >}}
 -->
-
-## Commit vs Publish
-We use the word `Commit` rather than `Publish` when talking about saving events to the [Event Store]({{< ref "event_store" >}}). We want to emphasize that it's the event store that is the source of truth in the system. The act of calling filters/event handlers comes _after_ the event has been committed to the event store. We also don't publish to any specific stream, event handler or microservice. After the event has been committed, it's ready to be picked up by any processor that listens to that type of event.

--- a/Documentation/Concepts/events.md
+++ b/Documentation/Concepts/events.md
@@ -41,7 +41,7 @@ For example, in the domain of opening up the kitchen for the day and adding a ne
 - ❌ `MenuListingElementUpdated`
 
 ## Main structure of an Event
-This is a simplified structure of the main parts of an event. For the Runtime, the event is only a JSON-string.
+This is a simplified structure of the main parts of an event. For the Runtime, the event is only a JSON-string which is saved into the [Event Store]({{< ref "event_store#event-log" >}}).
 
 ```csharp
 Event {

--- a/Documentation/Concepts/streams.md
+++ b/Documentation/Concepts/streams.md
@@ -41,17 +41,23 @@ Through the [Event Horizon]({{< ref "event_horizon" >}}) other microservices can
 
 ## Stream Processor
 
-A stream processor consists of an event stream and an event processor. It takes in a stream of events, calls the event processor to process the events in order, and keeps track of which events have already been processed. Each stream processor can be seen as the lowest level unit-of-work in regards to streams and they all run at the same time, side by side, in parallel.
+A stream processor consists of an event stream and an event processor. It takes in a stream of events, calls the event processor to process the events in order, keeps track of which events have already been processed, which have failed and when to retry. Each stream processor can be seen as the lowest level unit-of-work in regards to streams and they all run at the same time, side by side, in parallel.
 
 Since the streams are also uniquely identified by a stream id we can identify each stream processor by their `SourceStream, EventProcessor` pairing.
 
 ```csharp
-// simplified structure of a StreamProcessor
+// structure of a StreamProcessor
 StreamProcessor {
     SourceStream Guid
     EventProcessor Guid
     // the next event to be processed
     Position int
+    // for keeping track of failures and retry attempts
+    LastSuccesfullyProcessed DateTime
+    RetryTime DateTime
+    FailureReason string
+    ProcessingAttempts int
+    IsFailing bool
 }
 ```
 


### PR DESCRIPTION
- Added a big ol list of the whole structure of the MongoDB implementation of the event store. Would be nice if this could be like a generated thing or we could link to our runtime c# api docs to show the classes tha build them. Alas, this is quite nice for the users for now.
- Moved commit-vs-publish line to the Event Store page from Events.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1199539487825833)
