### PR TITLE
Change debug logs to trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.1] - 2021-01-19
+### Fixed
+- Reduced debug logging caused by waiting for new events for each stream processor.
+
 ## [5.3.0] - 2021-01-19
 ### Fixed
 - Significantly reduced CPU usage by drastically decreasing the number of requests to the EventStore. Now the stream processors will get notified when an event is available to be fetched. Has a 1-minute timeout in case of problems.

--- a/Source/Events.Store/Streams/StreamEventWatcher.cs
+++ b/Source/Events.Store/Streams/StreamEventWatcher.cs
@@ -58,7 +58,7 @@ namespace Dolittle.Runtime.Events.Store.Streams
 
         async Task WaitForWaiter(ScopeId scope, StreamId stream, StreamPosition position, TimeSpan timeout, bool isPublic, CancellationToken token)
         {
-            _logger.Debug("Start waiting for event coming in at position {Position} in {IsPublic}stream {StreamId} in scope {Scope}", position, isPublic ? "public " : string.Empty, stream, scope);
+            _logger.Trace("Start waiting for event coming in at position {Position} in {IsPublic}stream {StreamId} in scope {Scope}", position, isPublic ? "public " : string.Empty, stream, scope);
             var waiterId = new EventWaiterId(scope, stream);
 
             using var timeoutSource = new CancellationTokenSource(timeout);
@@ -73,13 +73,13 @@ namespace Dolittle.Runtime.Events.Store.Streams
             }
             catch (TaskCanceledException)
             {
-                _logger.Debug("Waiting timedout for {Position} with WaiterId {WaiterId}", position, waiter.Id);
+                _logger.Trace("Waiting timedout for {Position} with WaiterId {WaiterId}", position, waiter.Id);
             }
         }
 
         void NotifyForEvent(ScopeId scope, StreamId stream, StreamPosition position, bool isPublic)
         {
-            _logger.Debug("Notifying that an event has been written at position {Position} in {IsPublic}stream {StreamId} in scope {Scope}", position, isPublic ? "public " : string.Empty, stream, scope);
+            _logger.Trace("Notifying that an event has been written at position {Position} in {IsPublic}stream {StreamId} in scope {Scope}", position, isPublic ? "public " : string.Empty, stream, scope);
             var waiterId = new EventWaiterId(scope, stream);
 
             var waiter = isPublic


### PR DESCRIPTION
The debug logging was excessive as it would keep happening every 1min for every stream processor.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1199610671323804)
