### PR TITLE
Conservative logging

### DIFF
--- a/Source/Events.Processing/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlersService.cs
@@ -292,7 +292,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
             CancellationToken cancellationToken)
             where TFilterDefinition : IFilterDefinition
             {
-                _logger.Debug("Registering stream processor for Filter '{Filter}' on Event Log", eventHandlerId);
+                _logger.Trace("Registering stream processor for Filter '{Filter}' on Event Log", eventHandlerId);
                 try
                 {
                     return (_streamProcessors.TryRegister(
@@ -324,7 +324,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
             Func<IEventProcessor> getEventProcessor,
             CancellationToken cancellationToken)
             {
-                _logger.Debug("Registering stream processor for Event Processor '{EventProcessor}' on Stream '{SourceStream}'", eventHandlerId, sourceStreamDefinition.StreamId);
+                _logger.Trace("Registering stream processor for Event Processor '{EventProcessor}' on Stream '{SourceStream}'", eventHandlerId, sourceStreamDefinition.StreamId);
                 try
                 {
                     return (_streamProcessors.TryRegister(
@@ -356,7 +356,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
             CancellationToken cancellationToken)
             where TFilterDefinition : IFilterDefinition
         {
-            _logger.Debug("Validating Filter '{Filter}'", filterDefinition.TargetStream);
+            _logger.Trace("Validating Filter '{Filter}'", filterDefinition.TargetStream);
             var filterValidationResults = await _filterForAllTenants.Validate(getFilterProcessor, cancellationToken).ConfigureAwait(false);
 
             if (filterValidationResults.Any(_ => !_.Value.Succeeded))
@@ -367,7 +367,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
             }
 
             var filteredStreamDefinition = new StreamDefinition(filterDefinition);
-            _logger.Debug("Persisting definition for Stream '{Stream}'", filteredStreamDefinition.StreamId);
+            _logger.Trace("Persisting definition for Stream '{Stream}'", filteredStreamDefinition.StreamId);
             await _streamDefinitions.Persist(scopeId, filteredStreamDefinition, cancellationToken).ConfigureAwait(false);
         }
 

--- a/Source/Events.Processing/EventHandlers/EventProcessor.cs
+++ b/Source/Events.Processing/EventHandlers/EventProcessor.cs
@@ -50,7 +50,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
         /// <inheritdoc />
         public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "{LogMessagePrefix} is processing event '{EventTypeId}' for partition '{PartitionId}'",
                 _logMessagePrefix,
                 @event.Type.Id.Value,
@@ -66,7 +66,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
         /// <inheritdoc/>
         public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "{LogMessagePrefix} is processing event '{EventTypeId}' for partition '{PartitionId}' again for the {RetryCount}. time because: {FailureReason}",
                 _logMessagePrefix,
                 @event.Type.Id.Value,

--- a/Source/Events.Processing/Filters/AbstractFilterProcessor.cs
+++ b/Source/Events.Processing/Filters/AbstractFilterProcessor.cs
@@ -60,7 +60,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <inheritdoc />
         public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "{LogMessagePrefix} is filtering event '{EventTypeId}' for partition '{PartitionId}'",
                 _logMessagePrefix,
                 @event.Type.Id.Value,
@@ -75,7 +75,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <inheritdoc/>
         public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "{LogMessagePrefix} is filtering event '{EventTypeId}' for partition '{PartitionId}' again for the {RetryCount}. time because: {FailureReason}",
                 _logMessagePrefix,
                 @event.Type.Id.Value,
@@ -91,14 +91,14 @@ namespace Dolittle.Runtime.Events.Processing.Filters
 
         Task HandleResult(IFilterResult result, CommittedEvent @event, PartitionId partitionId, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "{LogMessagePrefix} filtered event '{EventTypeId}' for partition '{PartitionId}'  with result 'Succeeded' = {result.Succeeded}",
                 _logMessagePrefix,
                 @event.Type.Id.Value,
                 result.Succeeded);
             if (result.Succeeded && result.IsIncluded)
             {
-                _logger.Debug(
+                _logger.Trace(
                     "{LogMessagePrefix} writing event '{EventTypeId}' to stream '{TargetStream}' in partition '{PartitionId}'",
                     _logMessagePrefix,
                     @event.Type.Id.Value,

--- a/Source/Events.Processing/Filters/EventHorizon/PublicFilterProcessor.cs
+++ b/Source/Events.Processing/Filters/EventHorizon/PublicFilterProcessor.cs
@@ -43,7 +43,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "Filter event that occurred @ {Occurred} to public events stream '{TargetStream}'",
                 @event.Occurred,
                 Definition.TargetStream);
@@ -60,7 +60,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, string failureReason, uint retryCount, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "Filter event that occurred @ {Occurred} to public events stream '{TargetStream}' again for the {RetryCount}. time because: {FailureReason}",
                 @event.Occurred,
                 Definition.TargetStream,

--- a/Source/Events.Processing/Filters/FilterProcessor.cs
+++ b/Source/Events.Processing/Filters/FilterProcessor.cs
@@ -44,7 +44,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, CancellationToken cancellationToken)
         {
-            _logger.Debug("Filter event that occurred @ {Occurred}", @event.Occurred);
+            _logger.Trace("Filter event that occurred @ {Occurred}", @event.Occurred);
 
             var request = new FilterEventRequest
                 {
@@ -58,7 +58,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, string failureReason, uint retryCount, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "Filter event that occurred @ {Occurred} again for the {RetryCount}. time because: {FailureReason}",
                 @event.Occurred,
                 retryCount,

--- a/Source/Events.Processing/Filters/FiltersService.cs
+++ b/Source/Events.Processing/Filters/FiltersService.cs
@@ -394,7 +394,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
             CancellationToken cancellationToken)
             where TFilterDefinition : IFilterDefinition
             {
-                _logger.Debug("Registering stream processor for Filter '{Filter}' on Source Stream {SourceStream}", filterDefinition.TargetStream, filterDefinition.SourceStream);
+                _logger.Trace("Registering stream processor for Filter '{Filter}' on Source Stream {SourceStream}", filterDefinition.TargetStream, filterDefinition.SourceStream);
                 try
                 {
                     return (_streamProcessors.TryRegister(
@@ -426,7 +426,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
             CancellationToken cancellationToken)
             where TFilterDefinition : IFilterDefinition
         {
-            _logger.Debug("Validating Filter '{Filter}'", filterDefinition.TargetStream);
+            _logger.Trace("Validating Filter '{Filter}'", filterDefinition.TargetStream);
             var filterValidationResults = await _filterForAllTenants.Validate(getFilterProcessor, cancellationToken).ConfigureAwait(false);
 
             if (filterValidationResults.Any(_ => !_.Value.Succeeded))
@@ -437,7 +437,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
             }
 
             var filteredStreamDefinition = new StreamDefinition(filterDefinition);
-            _logger.Debug("Persisting definition for Stream '{Stream}'", filteredStreamDefinition.StreamId);
+            _logger.Trace("Persisting definition for Stream '{Stream}'", filteredStreamDefinition.StreamId);
             await _streamDefinitions.Persist(scopeId, filteredStreamDefinition, cancellationToken).ConfigureAwait(false);
         }
 

--- a/Source/Events.Processing/Filters/Partitioned/FilterProcessor.cs
+++ b/Source/Events.Processing/Filters/Partitioned/FilterProcessor.cs
@@ -44,7 +44,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.Partitioned
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, CancellationToken cancellationToken)
         {
-            _logger.Debug("Filter event that occurred @ {Occurred}", @event.Occurred);
+            _logger.Trace("Filter event that occurred @ {Occurred}", @event.Occurred);
 
             var request = new FilterEventRequest
                 {
@@ -58,7 +58,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.Partitioned
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, string failureReason, uint retryCount, CancellationToken cancellationToken)
         {
-            _logger.Debug(
+            _logger.Trace(
                 "Filter event that occurred @ {Occurred} again for the {RetryCount}. time because: {FailureReason}",
                 @event.Occurred,
                 retryCount,

--- a/Source/Events.Processing/Filters/ValidateFilterForAllTenants.cs
+++ b/Source/Events.Processing/Filters/ValidateFilterForAllTenants.cs
@@ -49,7 +49,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
             var result = new Dictionary<TenantId, FilterValidationResult>();
             await _onAllTenants.PerformAsync(async tenantId =>
                 {
-                    _logger.Debug("Validating Filter for Tenant '{Tenant}'", tenantId);
+                    _logger.Trace("Validating Filter for Tenant '{Tenant}'", tenantId);
                     var filterProcessor = getFilterProcessor();
                     var filterId = filterProcessor.Definition.TargetStream;
                     _logger.Trace("Trying to get definition of Filter '{Filter}' for Tenant '{Tenant}'", filterId, tenantId);
@@ -62,7 +62,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                     }
                     else
                     {
-                        _logger.Debug("Could not get definition of Filter '{Filter}' for Tenant '{Tenant}'", filterId, tenantId);
+                        _logger.Trace("Could not get definition of Filter '{Filter}' for Tenant '{Tenant}'", filterId, tenantId);
                         result.Add(tenantId, new FilterValidationResult());
                     }
                 }).ConfigureAwait(false);

--- a/Source/Events.Store/EventStoreService.cs
+++ b/Source/Events.Store/EventStoreService.cs
@@ -51,7 +51,7 @@ namespace Dolittle.Runtime.Events.Store
                 var events = request.Events.Select(_ => new UncommittedEvent(_.EventSourceId.To<EventSourceId>(), new Artifact(_.Artifact.Id.To<ArtifactId>(), _.Artifact.Generation), _.Public, _.Content));
                 var uncommittedEvents = new UncommittedEvents(new ReadOnlyCollection<UncommittedEvent>(events.ToList()));
                 var committedEvents = await _eventStoreFactory().CommitEvents(uncommittedEvents, context.CancellationToken).ConfigureAwait(false);
-                _logger.Debug("Events were successfully committed");
+                _logger.Trace("Events were successfully committed");
                 response.Events.AddRange(committedEvents.ToProtobuf());
             }
             catch (Exception ex)
@@ -81,7 +81,7 @@ namespace Dolittle.Runtime.Events.Store
                     request.Events.ExpectedAggregateRootVersion,
                     new ReadOnlyCollection<UncommittedEvent>(events.ToList()));
                 var committedEventsResult = await _eventStoreFactory().CommitAggregateEvents(uncommittedAggregateEvents, context.CancellationToken).ConfigureAwait(false);
-                _logger.Debug("Aggregate Events were successfully committed");
+                _logger.Trace("Aggregate Events were successfully committed");
                 response.Events = committedEventsResult.ToProtobuf();
             }
             catch (Exception ex)
@@ -105,7 +105,7 @@ namespace Dolittle.Runtime.Events.Store
             try
             {
                 var committedEventsResult = await _eventStoreFactory().FetchForAggregate(eventSource, aggregate, context.CancellationToken).ConfigureAwait(false);
-                _logger.Debug("Successfully fetched events for aggregate");
+                _logger.Trace("Successfully fetched events for aggregate");
                 response.Events = committedEventsResult.ToProtobuf();
             }
             catch (Exception ex)


### PR DESCRIPTION
This may be a little controversial, but I think that we are generally logging too much noise. I'm not completely sure on the "Filter" and "Event Processor" part though

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1199616782132166)
