### PR TITLE
Fix null concept

### DIFF
--- a/Source/Events.Store/CommittedAggregateEventsExtensions.cs
+++ b/Source/Events.Store/CommittedAggregateEventsExtensions.cs
@@ -18,11 +18,12 @@ namespace Dolittle.Runtime.Events.Store
         /// <returns>The converted <see cref="Contracts.CommittedAggregateEvents" />.</returns>
         public static Contracts.CommittedAggregateEvents ToProtobuf(this CommittedAggregateEvents committedAggregateEvents)
         {
+            var aggregateRootVersion = committedAggregateEvents.AsEnumerable().LastOrDefault()?.AggregateRootVersion ?? 0;
             var protobuf = new Contracts.CommittedAggregateEvents
             {
-                AggregateRootId = committedAggregateEvents.AggregateRoot.Value.ToProtobuf(),
+                AggregateRootId = committedAggregateEvents.AggregateRoot.ToProtobuf(),
                 EventSourceId = committedAggregateEvents.EventSource.ToProtobuf(),
-                AggregateRootVersion = committedAggregateEvents.AsEnumerable().LastOrDefault()?.AggregateRootVersion
+                AggregateRootVersion = aggregateRootVersion
             };
             protobuf.Events.AddRange(committedAggregateEvents.Select(_ => _.ToProtobuf()));
             return protobuf;

--- a/Source/Rudimentary/ConceptAs.cs
+++ b/Source/Rudimentary/ConceptAs.cs
@@ -21,10 +21,10 @@ namespace Dolittle.Runtime.Rudimentary
         /// Implicitly convert from <see cref="ConceptAs{TValue}"/> to type of the <see cref="ConceptAs{TValue}"/>.
         /// </summary>
         /// <param name="value">The converted value.</param>
-        public static implicit operator TValue(ConceptAs<TValue> value) =>  value.Value;
+        public static implicit operator TValue(ConceptAs<TValue> value) =>  value == null ? default : value.Value;
 
         /// <inheritdoc/>
-        public override string ToString() => Value.ToString();
+        public override string ToString() => Value == null ? default(TValue).ToString() : Value.ToString();
 
         /// <inheritdoc/>
         public override int GetHashCode() => HashCodeHelper.Generate(typeof(TValue), Value);

--- a/Specifications/Rudimentary/for_ConceptAs/when_equating.cs
+++ b/Specifications/Rudimentary/for_ConceptAs/when_equating.cs
@@ -30,6 +30,7 @@ namespace Dolittle.Runtime.Rudimentary.for_ConceptAs
             result_of_inequality_operator = first_string != second_string;
             result_of_inequality_operator_on_same_value = second_string != same_value_as_second_string;
 
+
             result_of_equality_on_two_different_concept_types_based_on_same_underlying_type_with_same_values
                 = value_as_a_long.Equals(value_as_an_int);
         };

--- a/Specifications/Rudimentary/for_ConceptAs/when_getting_values.cs
+++ b/Specifications/Rudimentary/for_ConceptAs/when_getting_values.cs
@@ -9,14 +9,17 @@ namespace Dolittle.Runtime.Rudimentary.for_ConceptAs
     {
         static string result_of_empty_string;
         static string result_of_null_string;
+        static string result_of_null_value_string;
 
         Because of = () =>
         {
             result_of_empty_string = string_is_empty.Value;
-            result_of_null_string = string_is_null.Value;
+            result_of_null_string = (string) string_is_null;
+            result_of_null_value_string = (string) string_value_is_null;
         };
 
         It should_be_an_empty_string = () => result_of_empty_string.ShouldBeTheSameAs("");
         It should_be_a_default_string = () => result_of_null_string.ShouldBeTheSameAs(default(string));
+        It should_be_a_default_string_from_value = () => result_of_null_value_string.ShouldBeTheSameAs(default(string));
     }
 }

--- a/Specifications/Rudimentary/for_ConceptAs/when_getting_values.cs
+++ b/Specifications/Rudimentary/for_ConceptAs/when_getting_values.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Rudimentary.for_ConceptAs
+{
+    public class when_getting_values : Rudimentary.given.concepts
+    {
+        static string result_of_empty_string;
+        static string result_of_null_string;
+
+        Because of = () =>
+        {
+            result_of_empty_string = string_is_empty.Value;
+            result_of_null_string = string_is_null.Value;
+        };
+
+        It should_be_an_empty_string = () => result_of_empty_string.ShouldBeTheSameAs("");
+        It should_be_a_default_string = () => result_of_null_string.ShouldBeTheSameAs(default(string));
+    }
+}

--- a/Specifications/Rudimentary/for_ConceptAs/when_to_stringing.cs
+++ b/Specifications/Rudimentary/for_ConceptAs/when_to_stringing.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Rudimentary.for_ConceptAs
+{
+    public class when_to_stringing : Rudimentary.given.concepts
+    {
+        static string result;
+        static string result_of_empty_string;
+        static string result_of_null_string;
+
+        Because of = () =>
+        {
+            result = first_string.ToString();
+            result_of_empty_string = string_is_empty.ToString();
+            result_of_null_string = string_is_null.ToString();
+        };
+
+        It should_give_a_string = () => result.ShouldNotBeEmpty();
+        It should_give_a_string_from_empty = () => result_of_empty_string.ShouldNotBeEmpty();
+        It should_give_a_string_from_null = () => result_of_null_string.ShouldNotBeNull();
+    }
+}

--- a/Specifications/Rudimentary/for_ConceptAs/when_to_stringing.cs
+++ b/Specifications/Rudimentary/for_ConceptAs/when_to_stringing.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Rudimentary.for_ConceptAs
         {
             result = first_string.ToString();
             result_of_empty_string = string_is_empty.ToString();
-            result_of_null_string = string_is_null.ToString();
+            result_of_null_string = string_value_is_null.ToString();
         };
 
         It should_give_a_string = () => result.ShouldNotBeEmpty();

--- a/Specifications/Rudimentary/given/concepts.cs
+++ b/Specifications/Rudimentary/given/concepts.cs
@@ -12,6 +12,7 @@ namespace Dolittle.Runtime.Rudimentary.given
         protected static StringConcept same_value_as_second_string;
         protected static StringConcept string_is_empty;
         protected static StringConcept string_is_null;
+        protected static StringConcept string_value_is_null;
         protected static IntConcept value_as_an_int;
         protected static LongConcept value_as_a_long;
         protected static InheritingFromLongConcept value_as_a_long_inherited;
@@ -23,7 +24,8 @@ namespace Dolittle.Runtime.Rudimentary.given
             second_string = "second";
             same_value_as_second_string = "second";
             string_is_empty = string.Empty;
-            string_is_null = new StringConcept(null);
+            string_is_null = null;
+            string_value_is_null = new StringConcept(null);
 
             value_as_a_long = 1;
             value_as_an_int = 1;


### PR DESCRIPTION
## Summary

Fixes a bug with our new `ConceptAs` type, that when trying to fetch nonexistent aggregate events, we would get a NullPointerException due to the implicit operator  from `ConceptAs` not checking first for `null`.

### Fixed

- Fix the implicit conversion on `ConceptAs` to check first if it's `null`
- Fix the `ToString()` on `ConceptAs` to check first if it's `null`
- Fix the `AggregateRootVersion` when converting `CommittedAggregateEvents` to their Protobuf representation when it was `null`
