### PR TITLE
Possible fix for deadlock issue when notifying and waiting for events

### DIFF
--- a/Source/Events.Store.Services/LoggerExtensions.cs
+++ b/Source/Events.Store.Services/LoggerExtensions.cs
@@ -8,13 +8,13 @@ namespace Dolittle.Runtime.Events.Store.Services
 {
     internal static class LoggerExtensions
     {
-        static readonly Action<ILogger, string, int, Exception> _eventsReceivedForCommitting = LoggerMessage
-            .Define<string, int>(
+        static readonly Action<ILogger, int, string, Exception> _eventsReceivedForCommitting = LoggerMessage
+            .Define<int, string>(
                 LogLevel.Debug,
                 new EventId(2059664795, nameof(EventsReceivedForCommitting)),
                 "{NumEvents} {EventType}events received for committing");
 
         internal static void EventsReceivedForCommitting(this ILogger logger, bool isAggregateEvents, int numEvents)
-            => _eventsReceivedForCommitting(logger, isAggregateEvents? "aggregate " : "", numEvents, null);
+            => _eventsReceivedForCommitting(logger, numEvents, isAggregateEvents? "aggregate " : "", null);
     }
 }

--- a/Source/Events.Store/Streams/EventWaiter.cs
+++ b/Source/Events.Store/Streams/EventWaiter.cs
@@ -66,14 +66,16 @@ namespace Dolittle.Runtime.Events.Store.Streams
         {
             if (NeverNotifiedOrNotNotifiedOfPosition(position))
             {
+                var shouldUpdate = false;
                 lock (_notifiedLock)
                 {
                     if (NeverNotifiedOrNotNotifiedOfPosition(position))
                     {
                         _lastNotified = position;
+                        shouldUpdate = true;
                     }
                 }
-                RemoveAllAtAndBelowLocking(position);
+                if (shouldUpdate) RemoveAllAtAndBelowLocking(position);
             }
         }
 
@@ -89,8 +91,7 @@ namespace Dolittle.Runtime.Events.Store.Streams
                         _taskCompletionSources[storedPosition].TrySetResult(true);
                         _taskCompletionSources.Remove(storedPosition);
                     }
-
-                    if (storedPosition.Value == position.Value) break;
+                    else break;
                 }
             }
         }
@@ -103,7 +104,7 @@ namespace Dolittle.Runtime.Events.Store.Streams
                 {
                     if (!_taskCompletionSources.TryGetValue(position, out tcs))
                     {
-                        tcs = new TaskCompletionSource<bool>();
+                        tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         _taskCompletionSources.Add(position, tcs);
                     }
                 }

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -199,7 +199,7 @@ namespace Dolittle.Runtime.Services
         {
             ThrowIfCompletedCall();
 
-            var completionSource = new TaskCompletionSource<TResponse>();
+            var completionSource = new TaskCompletionSource<TResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
             var callId = ReverseCallId.New();
             while (!_calls.TryAdd(callId, completionSource))
             {

--- a/Specifications/Events.Store/Streams/for_EventWaiter/when_trying_to_provoke_dead_lock.cs
+++ b/Specifications/Events.Store/Streams/for_EventWaiter/when_trying_to_provoke_dead_lock.cs
@@ -1,0 +1,60 @@
+using System;
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Events.Store.Streams.for_EventWaiter
+{
+    public class when_trying_to_provoke_dead_lock : given.an_event_waiter
+    {
+        static CancellationTokenSource token_source;
+        static CancellationToken token;
+
+        Establish context = () =>
+        {
+            token_source = new CancellationTokenSource();
+            token = token_source.Token;
+        };
+
+        Because of = () =>
+        {
+            // while (!System.Diagnostics.Debugger.IsAttached) System.Threading.Thread.Sleep(50);
+            token_source.CancelAfter(TimeSpan.FromSeconds(3));
+            try
+            {
+                dead_lock().Wait();
+            }
+            catch (Exception)
+            {
+            }
+            
+        };
+
+        It should_not_be_a_dead_lock = () => token_source.IsCancellationRequested.ShouldBeFalse();
+
+        Cleanup clean = () =>
+        {
+            token_source.Cancel();
+            token_source.Dispose();
+        };
+
+        static async Task dead_lock()
+        {
+            var first_wait = event_waiter.Wait(0, token).ConfigureAwait(false);
+            _ = Task.Run(() =>
+            {
+                event_waiter.Notify(0);
+            });
+            await first_wait;
+            var second_wait = event_waiter.Wait(1, token);
+            _ = Task.Run(() =>
+            {
+                event_waiter.Notify(1);
+            });
+            second_wait.Wait();        
+        }
+    }
+}


### PR DESCRIPTION
## Summary

We saw inconsistent issues while committing events in applications with event handlers that caused the runtime to deadlock when committing an event, never returning.

Inspired by this blog post https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/ we have a theory that it might be because when a TaskCompletionSource is being waited for and SetResult is called on it then all the task's async continuations will be invoked synchronously which could lead to a deadlock scenario. If that's the case then this issue can be resolved by giving the TaskCompletionSource the TaskCreationOptions.RunContinuationsAsynchronously flag when created to force the continuations to be run asynchronously. 

~~We have yet to be able to write tests that provoke this scenario. Until then we can never know whether the issue has been resolved or not, or that that was the problem to begin with.~~ I've added a single spec that failed when TaskCreationOptions.RunContinuationsAsynchronously was not given to the TaskCompletionSource and passes when it is. Thus IMO validating this fix

### Changed

- Made EventWaiter more robust
- Added TaskCreationOptions.RunContinuationsAsynchronously to all manually created TaskCompletionSources

### Added

- A spec that tries provoke the dead-lock by calling Notify and Wait in different threads and call Notify (running in separate thread from the thread calling Wait) between two Wait-calls. In this scenario the continuation of the first Wait call would be started synchronously, running on the thread that called Notify, after the Notify called TrySetResult on the TaskCompletionSource that the Wait-call awaits. And since the "Notify-thread" has the readWrite lock we get a dead-lock when the next Wait-call tries to get this lock.

### FIxed

- A wrongly formatted log message when committing events.
