### PR TITLE
Add IDetectEmbeddingLoop and EmbeddingLoopDetector

### DIFF
--- a/Source/Embeddings.Processing/EmbeddingLoopDetector.cs
+++ b/Source/Embeddings.Processing/EmbeddingLoopDetector.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Embeddings.Processing
+{
+    /// <inheritdoc/>
+    public class EmbeddingLoopDetector : IDetectEmdbeddingLoop
+    {
+        readonly ICompareStates _comparer = new CompareProjectionStates();
+
+        /// <inheritdoc/>
+        public Try<bool> TryCheckForProjectionStateLoop(IEnumerable<ProjectionState> previousStates, ProjectionState currentState)
+        {
+            try
+            {
+                return previousStates.All(previousState =>
+                {
+                    return !_comparer.TryCheckEquality(previousState, currentState).Result;
+                });
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+
+        }
+    }
+}

--- a/Source/Embeddings.Processing/EmbeddingLoopDetector.cs
+++ b/Source/Embeddings.Processing/EmbeddingLoopDetector.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,20 +15,20 @@ namespace Dolittle.Runtime.Embeddings.Processing
         readonly ICompareStates _comparer = new CompareProjectionStates();
 
         /// <inheritdoc/>
-        public Try<bool> TryCheckForProjectionStateLoop(IEnumerable<ProjectionState> previousStates, ProjectionState currentState)
+        public Try<bool> TryCheckForProjectionStateLoop(ProjectionState currentState, IEnumerable<ProjectionState> previousStates)
         {
             try
             {
-                return previousStates.All(previousState =>
+                return previousStates.AsParallel().Any(previousState =>
                 {
-                    return !_comparer.TryCheckEquality(previousState, currentState).Result;
+                    var tryResult = _comparer.TryCheckEquality(previousState, currentState);
+                    return tryResult.Success ? tryResult.Result : throw tryResult.Exception;
                 });
             }
             catch (Exception ex)
             {
                 return ex;
             }
-
         }
     }
 }

--- a/Source/Embeddings.Processing/IDetectEmbeddingLoop.cs
+++ b/Source/Embeddings.Processing/IDetectEmbeddingLoop.cs
@@ -16,9 +16,9 @@ namespace Dolittle.Runtime.Embeddings.Processing
         /// <summary>
         /// Try to check if a projection's state is equal to one of it's previous states.
         /// </summary>
-        /// <param name="previousStates">An <see cref="IEnumerable{ProjectionState}"/> of the previous states.</param>
         /// <param name="currentState">The current <see cref="ProjectionState"/>.</param>
+        /// <param name="previousStates">An <see cref="IEnumerable{ProjectionState}"/> of the previous states.</param>
         /// <returns>A <see cref= "Try" /> that indicates whether the operation was successful or not.</returns>
-        Try<bool> TryCheckForProjectionStateLoop(IEnumerable<ProjectionState> previousStates, ProjectionState currentState);
+        Try<bool> TryCheckForProjectionStateLoop(ProjectionState currentState, IEnumerable<ProjectionState> previousStates);
     }
 }

--- a/Source/Embeddings.Processing/IDetectEmbeddingLoop.cs
+++ b/Source/Embeddings.Processing/IDetectEmbeddingLoop.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Embeddings.Processing
+{
+
+    /// <summary>
+    /// Defines a system, that can detect when an embedding is looping.
+    /// </summary>
+    public interface IDetectEmdbeddingLoop
+    {
+        /// <summary>
+        /// Try to check if a projection's state is equal to one of it's previous states.
+        /// </summary>
+        /// <param name="previousStates">An <see cref="IEnumerable{ProjectionState}"/> of the previous states.</param>
+        /// <param name="currentState">The current <see cref="ProjectionState"/>.</param>
+        /// <returns>A <see cref= "Try" /> that indicates whether the operation was successful or not.</returns>
+        Try<bool> TryCheckForProjectionStateLoop(IEnumerable<ProjectionState> previousStates, ProjectionState currentState);
+    }
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/given/all_dependencies.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/given/all_dependencies.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingLoopDetector.given
+{
+
+    public class all_dependencies
+    {
+        protected static IDetectEmdbeddingLoop detector;
+        protected static IList<ProjectionState> previous_states;
+
+        Establish context = () =>
+        {
+            previous_states = new List<ProjectionState>
+            {
+                CreateStateWithKeyValue("FirstObject", "FirstObjectValue"),
+                CreateStateWithKeyValue("SecondObject", "SecondObjectValue"),
+                CreateStateWithKeyValue("ThirdObject", "ThirdObjectValue"),
+                CreateStateWithKeyValue("FourthObject", "FourthObjectValue"),
+                CreateStateWithKeyValue("FifthObject", "FifthObjectValue"),
+                CreateStateWithKeyValue("SixthObject", "SixthObjectValue")
+            };
+
+            detector = new EmbeddingLoopDetector();
+        };
+
+        protected static ProjectionState CreateStateWithKeyValue(string key, string value)
+        {
+            var jObject = new JObject
+            {
+                { key, value }
+            };
+            return new ProjectionState(JsonConvert.SerializeObject(jObject));
+        }
+    }
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_one_previous_state_is_the_same.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_one_previous_state_is_the_same.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingLoopDetector.when_detecting
+{
+
+    public class and_one_previous_state_is_the_same : given.all_dependencies
+    {
+
+        static ProjectionState current_state;
+
+        Establish context = () =>
+        {
+            var (key, value) = ("Duplicate", "Value");
+            current_state = CreateStateWithKeyValue(key, value);
+            previous_states.Add(CreateStateWithKeyValue(key, value));
+        };
+
+        static Try<bool> result;
+
+        Because of = () => result = detector.TryCheckForProjectionStateLoop(current_state, previous_states);
+
+        It should_succeed = () => result.Success.ShouldBeTrue();
+        It should_detect_a_loop = () => result.Result.ShouldBeTrue();
+    }
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_previous_states_are_different.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_previous_states_are_different.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingLoopDetector.when_detecting
+{
+
+    public class and_previous_states_are_different : given.all_dependencies
+    {
+        static ProjectionState current_state;
+
+        Establish context = () =>
+        {
+            current_state = CreateStateWithKeyValue("ImAUniqueKey", "AndAUniqueValue");
+        };
+
+        static Try<bool> result;
+
+        Because of = () => result = detector.TryCheckForProjectionStateLoop(current_state, previous_states);
+
+        It should_succeed = () => result.Success.ShouldBeTrue();
+        It should_not_detect_a_loop = () => result.Result.ShouldBeFalse();
+    }
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_the_current_state_isnt_valid_json.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_the_current_state_isnt_valid_json.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingLoopDetector.when_detecting
+{
+
+    public class and_the_current_state_isnt_valid_json : given.all_dependencies
+    {
+        static ProjectionState current_state;
+
+        Establish context = () =>
+        {
+            current_state = new ProjectionState("you 👉 wish i 🙋 was 👀👍 valid ✔✔ json haha 👌😂");
+        };
+
+        static Try<bool> result;
+
+        Because of = () => result = detector.TryCheckForProjectionStateLoop(current_state, previous_states);
+
+        It should_fail = () => result.Success.ShouldBeFalse();
+        It should_have_an_exception = () => result.HasException.ShouldBeTrue();
+        It should_not_detect_a_loop = () => result.Result.ShouldBeFalse();
+    }
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_there_are_no_previous_states.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingLoopDetector/when_detecting/and_there_are_no_previous_states.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Projections.Store.State;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingLoopDetector.when_detecting
+{
+
+    public class and_there_are_no_previous_states : given.all_dependencies
+    {
+        static ProjectionState current_state;
+
+        Establish context = () =>
+        {
+            current_state = CreateStateWithKeyValue("ImAUniqueKey", "AndAUniqueValue");
+            previous_states.Clear();
+        };
+
+        static Try<bool> result;
+
+        Because of = () => result = detector.TryCheckForProjectionStateLoop(current_state, previous_states);
+
+        It should_succeed = () => result.Success.ShouldBeTrue();
+        It should_not_detect_a_loop = () => result.Result.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
- Adds `IDetectEmbeddingLoop` and `EmbeddingLoopDetector`, which goes through the previous states in parallel using `AsParallel(IEnumerable)` and `ParallelEnumerable.Any` from LINQ.
- Adds specs for it.
    - As the class relies mostly on `CompareProjectionStates`, I don't think it makes sense to test out differently ordered properties/dictionaries etc, as those are already covered by tests by `CompareProjectionStates` specs.
