### PR TITLE
Refactor out ping handling

### DIFF
--- a/Source/Services/RequestId.cs
+++ b/Source/Services/RequestId.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Services
+{
+    /// <summary>
+    /// Represents an unique identifier (correlation id) for service requests.
+    /// </summary>
+    public record RequestId(string Value) : ConceptAs<string>(Value)
+    {
+        /// <summary>
+        /// Generates a new <see cref="RequestId"/>.
+        /// </summary>
+        /// <returns>A <see cref="Guid"/> based request id.</returns>
+        public static RequestId Generate() => Guid.NewGuid();
+
+        /// <summary>
+        /// Implicitly convert a <see cref="string" /> to a <see cref="RequestId" />.
+        /// </summary>
+        /// <param name="requestId">The request id.</param>
+        public static implicit operator RequestId(string requestId) => new(requestId);
+
+        /// <summary>
+        /// Implicitly convert a <see cref="Guid" /> to a <see cref="RequestId" />.
+        /// </summary>
+        /// <param name="requestId">The request id.</param>
+        public static implicit operator RequestId(Guid requestId) => new(requestId.ToString());
+
+        /// <summary>
+        /// Implicitly convert a <see cref="RequestId" /> to a <see cref="string" />.
+        /// </summary>
+        /// <param name="requestId">The request id.</param>
+        public static implicit operator string(RequestId requestId) => requestId.Value;
+    }
+}

--- a/Source/Services/ReverseCalls/ArgumentsContextNotReceivedInFirstMessage.cs
+++ b/Source/Services/ReverseCalls/ArgumentsContextNotReceivedInFirstMessage.cs
@@ -9,13 +9,13 @@ namespace Dolittle.Runtime.Services.ReverseCalls
     /// <summary>
     /// Exception that gets thrown when the first message of a reverse call connection does not contain a <see cref="ReverseCallArgumentsContext"/>.
     /// </summary>
-    public class ReverseCallArgumentsContextNotReceivedInFirstMessage : Exception
+    public class ArgumentsContextNotReceivedInFirstMessage : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ReverseCallArgumentsContextNotReceivedInFirstMessage"/> class.
+        /// Initializes a new instance of the <see cref="ArgumentsContextNotReceivedInFirstMessage"/> class.
         /// </summary>
         /// <param name="reason">The reason for the missing reverse call arguments context.</param>
-        public ReverseCallArgumentsContextNotReceivedInFirstMessage(string reason)
+        public ArgumentsContextNotReceivedInFirstMessage(string reason)
             : base($"The first message received for the reverse call connection did not contain a {nameof(ReverseCallArgumentsContext)} because {reason}")
         {
         }

--- a/Source/Services/ReverseCalls/ICancelTokenIfDeadlineIsMissed.cs
+++ b/Source/Services/ReverseCalls/ICancelTokenIfDeadlineIsMissed.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+namespace Dolittle.Runtime.Services.ReverseCalls
+{
+    /// <summary>
+    /// Defines a system that cancels a <see cref="CancellationToken"/> if a deadline for refreshing the timeout is missed.
+    /// </summary>
+    /// <remarks>
+    /// The deadline starts out as infinite, and the token will never be cancelled if the initial refresh is never called.
+    /// Disposing of the system will leave the token in whatever state it is currently in.
+    /// </remarks>
+    public interface ICancelTokenIfDeadlineIsMissed : IDisposable
+    {
+        /// <summary>
+        /// Refreshes the deadline for cancellation.
+        /// </summary>
+        /// <param name="nextRefreshBefore">The time to wait for a new refresh before cancelling the token.</param>
+        /// <remarks>
+        /// Refreshing with <see cref="TimeSpan.Zero"/> will cancel the token immediately.
+        /// <remarks>
+        void RefreshDeadline(TimeSpan nextRefreshBefore);
+
+        /// <summary>
+        /// Gets the token that will be cancelled if a refresh deadline is missed.
+        /// </summary>
+        CancellationToken Token { get; }
+    }
+}

--- a/Source/Services/ReverseCalls/IKeepConnectionsAlive.cs
+++ b/Source/Services/ReverseCalls/IKeepConnectionsAlive.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
     /// <summary>
     /// Defines a system that can create pinged reverse call connections from gRPC duplex streaming method calls. 
     /// </summary>
-    public interface IKeepReverseCallConnectionsAlive
+    public interface IKeepConnectionsAlive
     {
         /// <summary>
         /// Creates a pinged reverse call connection from a gRPC duplex streaming method call.
@@ -26,8 +26,8 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <typeparam name="TConnectResponse">Type of the response that is received after the initial Connect call.</typeparam>
         /// <typeparam name="TRequest">Type of the requests sent from the Runtime to the Client.</typeparam>
         /// <typeparam name="TResponse">Type of the responses sent from the Client to the Runtime.</typeparam>
-        /// <returns>A <see cref="IPingedReverseCallConnection{TClientMessage, TServerMessage}"/> that will be kept alive using ping messages.</returns>
-        IPingedReverseCallConnection<TClientMessage, TServerMessage> CreatePingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+        /// <returns>A <see cref="IPingedConnection{TClientMessage, TServerMessage}"/> that will be kept alive using ping messages.</returns>
+        IPingedConnection<TClientMessage, TServerMessage> CreatePingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
             RequestId requestId,
             IAsyncStreamReader<TClientMessage> runtimeStream,
             IAsyncStreamWriter<TServerMessage> clientStream,

--- a/Source/Services/ReverseCalls/IKeepReverseCallConnectionsAlive.cs
+++ b/Source/Services/ReverseCalls/IKeepReverseCallConnectionsAlive.cs
@@ -15,6 +15,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <summary>
         /// Creates a pinged reverse call connection from a gRPC duplex streaming method call.
         /// </summary>
+        /// <param name="requestId">The request id for the gRPC method call.</param>
         /// <param name="runtimeStream">The <see cref="IAsyncStreamReader{TClientMessage}"/> to read messages to the Runtime.</param>
         /// <param name="clientStream">The <see cref="IServerStreamWriter{TServerMessage}"/> to write messages to the Client.</param>
         /// <param name="context">The <see cref="ServerCallContext"/> of the method call.</param>
@@ -27,6 +28,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <typeparam name="TResponse">Type of the responses sent from the Client to the Runtime.</typeparam>
         /// <returns>A <see cref="IPingedReverseCallConnection{TClientMessage, TServerMessage}"/> that will be kept alive using ping messages.</returns>
         IPingedReverseCallConnection<TClientMessage, TServerMessage> CreatePingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+            RequestId requestId,
             IAsyncStreamReader<TClientMessage> runtimeStream,
             IAsyncStreamWriter<TServerMessage> clientStream,
             ServerCallContext context,

--- a/Source/Services/ReverseCalls/IMetricsCollector.cs
+++ b/Source/Services/ReverseCalls/IMetricsCollector.cs
@@ -17,5 +17,9 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         void IncrementTotalStreamReadBytes(int writtenBytes);
         void IncrementTotalPingsSent();
         void IncrementTotalPongsReceived();
+        void IncrementTotalKeepaliveTokenResets();
+        void IncrementTotalKeepaliveTimeouts();
+        void AddToTotalWaitForFirstMessageTime(TimeSpan waitTime);
+        void AddToTotalWaitForPingStarterToCompleteTime(TimeSpan waitTime);
     }
 }

--- a/Source/Services/ReverseCalls/IPingedConnection.cs
+++ b/Source/Services/ReverseCalls/IPingedConnection.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
     /// </summary>
     /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Client to the Runtime.</typeparam>
     /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Runtime to the Client.</typeparam>
-    public interface IPingedReverseCallConnection<TClientMessage, TServerMessage> : IDisposable
+    public interface IPingedConnection<TClientMessage, TServerMessage> : IDisposable
         where TClientMessage : IMessage, new()
         where TServerMessage : IMessage, new()
     {

--- a/Source/Services/ReverseCalls/Logging.cs
+++ b/Source/Services/ReverseCalls/Logging.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.Runtime.Services.ReverseCalls
+{
+    internal static class Logging
+    {
+#region WrappedAsyncStreamWriter
+        static readonly Action<ILogger, RequestId, Type, Exception> _writingMessage = LoggerMessage.Define<RequestId, Type>(
+            LogLevel.Debug,
+            new EventId(629413668, nameof(WritingMessage)),
+            "Writing message {Type} for {Request}");
+        internal static void WritingMessage(this ILogger logger, RequestId requestId, Type messageType)
+            => _writingMessage(logger, requestId, messageType, null);
+
+        static readonly Action<ILogger, RequestId, Type, Exception> _writingMessageBlockedByAnotherWrite = LoggerMessage.Define<RequestId, Type>(
+            LogLevel.Trace,
+            new EventId(825683084, nameof(WritingMessageBlockedByAnotherWrite)),
+            "Writing message {Type} for {Request} is blocked by anoter write operation");
+        internal static void WritingMessageBlockedByAnotherWrite(this ILogger logger, RequestId requestId, Type messageType)
+            => _writingMessageBlockedByAnotherWrite(logger, requestId, messageType, null);
+
+        static readonly Action<ILogger, RequestId, Type, TimeSpan, Exception> _writingMessageUnblockedAfter = LoggerMessage.Define<RequestId, Type, TimeSpan>(
+            LogLevel.Trace,
+            new EventId(257847899, nameof(WritingMessageUnblockedAfter)),
+            "Writing message {Type} for {Request} was unblocked after {BlockedTime}");
+        internal static void WritingMessageUnblockedAfter(this ILogger logger, RequestId requestId, Type messageType, TimeSpan blockedTime)
+            => _writingMessageUnblockedAfter(logger, requestId, messageType, blockedTime, null);
+        
+        static readonly Action<ILogger, RequestId, Exception> _writingPing = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(629413668, nameof(WritingPing)),
+            "Writing ping for {Request}");
+        internal static void WritingPing(this ILogger logger, RequestId requestId)
+            => _writingPing(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _writingPingSkipped = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(519331416, nameof(WritingPingSkipped)),
+            "Writing ping for {Request} was skipped because anoter write operation is in progress");
+        internal static void WritingPingSkipped(this ILogger logger, RequestId requestId)
+            => _writingPingSkipped(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, TimeSpan, Exception> _wrotePing = LoggerMessage.Define<RequestId, TimeSpan>(
+            LogLevel.Trace,
+            new EventId(874759618, nameof(WrotePing)),
+            "Wrote ping for {Request}, it took {WriteTime}");
+        internal static void WrotePing(this ILogger logger, RequestId requestId, TimeSpan writeTime)
+            => _wrotePing(logger, requestId, writeTime, null);
+
+        static readonly Action<ILogger, RequestId, TimeSpan, int, Exception> _wroteMessage = LoggerMessage.Define<RequestId, TimeSpan, int>(
+            LogLevel.Trace,
+            new EventId(485273449, nameof(WroteMessage)),
+            "Wrote message for {Request}, it took {WriteTime} and was {MessageSize} bytes");
+        internal static void WroteMessage(this ILogger logger, RequestId requestId, TimeSpan writeTime, int messageSize)
+            => _wroteMessage(logger, requestId, writeTime, messageSize, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _disposingWrappedAsyncStreamWriter = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(740791129, nameof(DisposingWrappedAsyncStreamWriter)),
+            "Disposing of WrappedAsyncStreamWriter for {Request}");
+        internal static void DisposingWrappedAsyncStreamWriter(this ILogger logger, RequestId requestId)
+            => _disposingWrappedAsyncStreamWriter(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _disposedWrappedAsyncStreamWriter = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(920975132, nameof(DisposedWrappedAsyncStreamWriter)),
+            "Disposed of WrappedAsyncStreamWriter for {Request}");
+        internal static void DisposedWrappedAsyncStreamWriter(this ILogger logger, RequestId requestId)
+            => _disposedWrappedAsyncStreamWriter(logger, requestId, null);
+#endregion
+
+#region WrappedAsyncStreamReader
+        static readonly Action<ILogger, RequestId, Exception> _readingMessage = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(001299866, nameof(ReadingMessage)),
+            "Reading message for {Request}");
+        internal static void ReadingMessage(this ILogger logger, RequestId requestId)
+            => _readingMessage(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, int, Exception> _readMessage = LoggerMessage.Define<RequestId, int>(
+            LogLevel.Trace,
+            new EventId(514062882, nameof(ReadMessage)),
+            "Read message for for {Request}, it was {MessageSize} bytes");
+        internal static void ReadMessage(this ILogger logger, RequestId requestId, int messageSize)
+            => _readMessage(logger, requestId, messageSize, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _readPong = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(696612534, nameof(ReadPong)),
+            "Read pong for {Request}");
+        internal static void ReadPong(this ILogger logger, RequestId requestId)
+            => _readPong(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _noMoreMessagesToRead = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(571047019, nameof(NoMoreMessagesToRead)),
+            "No more messages to read for {Request}");
+        internal static void NoMoreMessagesToRead(this ILogger logger, RequestId requestId)
+            => _noMoreMessagesToRead(logger, requestId, null);
+#endregion
+
+#region PingedReverseCallConnection
+
+        static readonly Action<ILogger, RequestId, Exception> _waitingForReverseCallContext = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(869827038, nameof(WaitingForReverseCallContext)),
+            "Waiting for reverse call arguments context for {Request}");
+        internal static void WaitingForReverseCallContext(this ILogger logger, RequestId requestId)
+            => _waitingForReverseCallContext(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _receivedReverseCallContext = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(234474181, nameof(ReceivedReverseCallContext)),
+            "Received for reverse call arguments context for {Request}");
+        internal static void ReceivedReverseCallContext(this ILogger logger, RequestId requestId)
+            => _receivedReverseCallContext(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, TimeSpan, Exception> _startPings = LoggerMessage.Define<RequestId, TimeSpan>(
+            LogLevel.Trace,
+            new EventId(722585538, nameof(StartPings)),
+            "Starting pings for {Request} every {PingInterval}");
+        internal static void StartPings(this ILogger logger, RequestId requestId, TimeSpan pingInterval)
+            => _startPings(logger, requestId, pingInterval, null);
+
+        static readonly Action<ILogger, RequestId, TimeSpan, Exception> _startKeepaliveTokenTimeout = LoggerMessage.Define<RequestId, TimeSpan>(
+            LogLevel.Trace,
+            new EventId(057218397, nameof(StartKeepaliveTokenTimeout)),
+            "Starting the keepalive token timeout for {Request} to cancel after {PingInterval} of inactivity");
+        internal static void StartKeepaliveTokenTimeout(this ILogger logger, RequestId requestId, TimeSpan pingInterval)
+            => _startKeepaliveTokenTimeout(logger, requestId, pingInterval, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _stoppingPings = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(126021885, nameof(StoppingPings)),
+            "Stopping pings for {Request}");
+        internal static void StoppingPings(this ILogger logger, RequestId requestId)
+            => _stoppingPings(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _notStoppingPingsBecauseItWasNotStarted = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(614035582, nameof(NotStoppingPingsBecauseItWasNotStarted)),
+            "Not stopping pings for {Request} as they were not started");
+        internal static void NotStoppingPingsBecauseItWasNotStarted(this ILogger logger, RequestId requestId)
+            => _notStoppingPingsBecauseItWasNotStarted(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _resettingKeepaliveToken = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(251671244, nameof(ResettingKeepaliveToken)),
+            "Resetting keepalive token for {Request}");
+        internal static void ResettingKeepaliveToken(this ILogger logger, RequestId requestId)
+            => _resettingKeepaliveToken(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _keepaliveTimedOut = LoggerMessage.Define<RequestId>(
+            LogLevel.Debug,
+            new EventId(703967180, nameof(KeepaliveTimedOut)),
+            "Keepalive timed out for {Request}");
+        internal static void KeepaliveTimedOut(this ILogger logger, RequestId requestId)
+            => _keepaliveTimedOut(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _waitingForPingStarterToComplete = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(762374155, nameof(WaitingForPingStarterToComplete)),
+            "Waiting for ping starter to complete for {Request}");
+        internal static void WaitingForPingStarterToComplete(this ILogger logger, RequestId requestId)
+            => _waitingForPingStarterToComplete(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _pingStarterCompleted = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(051164892, nameof(PingStarterCompleted)),
+            "Ping starter finished for {Request}");
+        internal static void PingStarterCompleted(this ILogger logger, RequestId requestId)
+            => _pingStarterCompleted(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _disposingPingedReverseCallConnection = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(102323333, nameof(DisposingPingedReverseCallConnection)),
+            "Disposing of PingedReverseCallConnection for {Request}");
+        internal static void DisposingPingedReverseCallConnection(this ILogger logger, RequestId requestId)
+            => _disposingPingedReverseCallConnection(logger, requestId, null);
+
+        static readonly Action<ILogger, RequestId, Exception> _disposedPingedReverseCallConnection = LoggerMessage.Define<RequestId>(
+            LogLevel.Trace,
+            new EventId(458986405, nameof(DisposedPingedReverseCallConnection)),
+            "Disposed of PingedReverseCallConnection for {Request}");
+        internal static void DisposedPingedReverseCallConnection(this ILogger logger, RequestId requestId)
+            => _disposedPingedReverseCallConnection(logger, requestId, null);
+#endregion
+    }
+}

--- a/Source/Services/ReverseCalls/Logging.cs
+++ b/Source/Services/ReverseCalls/Logging.cs
@@ -75,7 +75,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
 
 #region WrappedAsyncStreamReader
         static readonly Action<ILogger, RequestId, Exception> _readingMessage = LoggerMessage.Define<RequestId>(
-            LogLevel.Trace,
+            LogLevel.Debug,
             new EventId(001299866, nameof(ReadingMessage)),
             "Reading message for {Request}");
         internal static void ReadingMessage(this ILogger logger, RequestId requestId)
@@ -133,6 +133,13 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         internal static void StartKeepaliveTokenTimeout(this ILogger logger, RequestId requestId, TimeSpan pingInterval)
             => _startKeepaliveTokenTimeout(logger, requestId, pingInterval, null);
 
+        static readonly Action<ILogger, RequestId, Exception> _failedToStartPingAndTimeout = LoggerMessage.Define<RequestId>(
+            LogLevel.Warning,
+            new EventId(670097578, nameof(FailedToStartPingAndTimeout)),
+            "Failed to start pinging and keepalive timeout for {Request}, the connection will be cancelled");
+        internal static void FailedToStartPingAndTimeout(this ILogger logger, RequestId requestId, Exception exception)
+            => _failedToStartPingAndTimeout(logger, requestId, exception);
+
         static readonly Action<ILogger, RequestId, Exception> _stoppingPings = LoggerMessage.Define<RequestId>(
             LogLevel.Trace,
             new EventId(126021885, nameof(StoppingPings)),
@@ -175,19 +182,19 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         internal static void PingStarterCompleted(this ILogger logger, RequestId requestId)
             => _pingStarterCompleted(logger, requestId, null);
 
-        static readonly Action<ILogger, RequestId, Exception> _disposingPingedReverseCallConnection = LoggerMessage.Define<RequestId>(
+        static readonly Action<ILogger, RequestId, Exception> _disposingPingedConnection = LoggerMessage.Define<RequestId>(
             LogLevel.Trace,
-            new EventId(102323333, nameof(DisposingPingedReverseCallConnection)),
-            "Disposing of PingedReverseCallConnection for {Request}");
-        internal static void DisposingPingedReverseCallConnection(this ILogger logger, RequestId requestId)
-            => _disposingPingedReverseCallConnection(logger, requestId, null);
+            new EventId(102323333, nameof(DisposingPingedConnection)),
+            "Disposing of PingedConnection for {Request}");
+        internal static void DisposingPingedConnection(this ILogger logger, RequestId requestId)
+            => _disposingPingedConnection(logger, requestId, null);
 
-        static readonly Action<ILogger, RequestId, Exception> _disposedPingedReverseCallConnection = LoggerMessage.Define<RequestId>(
+        static readonly Action<ILogger, RequestId, Exception> _disposedPingedConnection = LoggerMessage.Define<RequestId>(
             LogLevel.Trace,
-            new EventId(458986405, nameof(DisposedPingedReverseCallConnection)),
-            "Disposed of PingedReverseCallConnection for {Request}");
-        internal static void DisposedPingedReverseCallConnection(this ILogger logger, RequestId requestId)
-            => _disposedPingedReverseCallConnection(logger, requestId, null);
+            new EventId(458986405, nameof(DisposedPingedConnection)),
+            "Disposed of PingedConnection for {Request}");
+        internal static void DisposedPingedConnection(this ILogger logger, RequestId requestId)
+            => _disposedPingedConnection(logger, requestId, null);
 #endregion
     }
 }

--- a/Source/Services/ReverseCalls/MessageReceived.cs
+++ b/Source/Services/ReverseCalls/MessageReceived.cs
@@ -3,5 +3,8 @@
 
 namespace Dolittle.Runtime.Services.ReverseCalls
 {
+    /// <summary>
+    /// Defines the signature of a message received event.
+    /// </summary>
     public delegate void MessageReceived();
 }

--- a/Source/Services/ReverseCalls/PingedConnection.cs
+++ b/Source/Services/ReverseCalls/PingedConnection.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace Dolittle.Runtime.Services.ReverseCalls
 {
     /// <summary>
-    /// Represents an implementation of <see cref="IPingedReverseCallConnection{TClientMessage, TServerMessage}"/>.
+    /// Represents an implementation of <see cref="IPingedConnection{TClientMessage, TServerMessage}"/>.
     /// </summary>
     /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Client to the Runtime.</typeparam>
     /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Runtime to the Client.</typeparam>
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
     /// <typeparam name="TConnectResponse">Type of the response that is received after the initial Connect call.</typeparam>
     /// <typeparam name="TRequest">Type of the requests sent from the Runtime to the Client.</typeparam>
     /// <typeparam name="TResponse">Type of the responses sent from the Client to the Runtime.</typeparam>
-    public class PingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> : IPingedReverseCallConnection<TClientMessage, TServerMessage>
+    public class PingedConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> : IPingedConnection<TClientMessage, TServerMessage>
         where TClientMessage : IMessage, new()
         where TServerMessage : IMessage, new()
         where TConnectArguments : class
@@ -41,7 +41,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         bool _disposed;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PingedReverseCallConnection{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> class.
+        /// Initializes a new instance of the <see cref="PingedConnection{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> class.
         /// </summary>
         /// <param name="requestId">The request id for the gRPC method call.</param>
         /// <param name="requestId">The request id for the gRPC method call.</param>
@@ -51,7 +51,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <param name="messageConverter">The <see cref="MethodConverter"/> to use for decoding the connect arguments and reading the desired ping interval from.</param>
         /// <param name="metrics">The metrics collector to use for metrics about reverse calls.</param>
         /// <param name="loggerFactory">The logger factory to use to create loggers.</param>
-        public PingedReverseCallConnection(
+        public PingedConnection(
             RequestId requestId,
             IAsyncStreamReader<TClientMessage> runtimeStream,
             IAsyncStreamWriter<TServerMessage> clientStream,
@@ -80,7 +80,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
                 _cancellationTokenSource.Token);
 
             _metrics = metrics;
-            _logger = loggerFactory.CreateLogger<PingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>();
+            _logger = loggerFactory.CreateLogger<PingedConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>();
 
             _pingStarter = WaitForFirstMessageThenStartPinging(_cancellationTokenSource.Token);
             _keepAliveExpiredRegistration = _keepAliveTokenSource.Token.Register(NotifyKeepaliveTimedOut);

--- a/Source/Services/ReverseCalls/PingedReverseCallConnection.cs
+++ b/Source/Services/ReverseCalls/PingedReverseCallConnection.cs
@@ -2,14 +2,24 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Services.Contracts;
 using Google.Protobuf;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Dolittle.Runtime.Services.ReverseCalls
 {
+    /// <summary>
+    /// Represents an implementation of <see cref="IPingedReverseCallConnection{TClientMessage, TServerMessage}"/>.
+    /// </summary>
+    /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Client to the Runtime.</typeparam>
+    /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Runtime to the Client.</typeparam>
+    /// <typeparam name="TConnectArguments">Type of the arguments that are sent along with the initial Connect call.</typeparam>
+    /// <typeparam name="TConnectResponse">Type of the response that is received after the initial Connect call.</typeparam>
+    /// <typeparam name="TRequest">Type of the requests sent from the Runtime to the Client.</typeparam>
+    /// <typeparam name="TResponse">Type of the responses sent from the Client to the Runtime.</typeparam>
     public class PingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> : IPingedReverseCallConnection<TClientMessage, TServerMessage>
         where TClientMessage : IMessage, new()
         where TServerMessage : IMessage, new()
@@ -20,27 +30,60 @@ namespace Dolittle.Runtime.Services.ReverseCalls
     {
         readonly CancellationTokenSource _keepAliveTokenSource;
         readonly CancellationTokenSource _cancellationTokenSource;
+        readonly RequestId _requestId;
+        readonly IMetricsCollector _metrics;
         readonly WrappedAsyncStreamReader<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> _wrappedReader;
         readonly WrappedAsyncStreamWriter<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> _wrappedWriter;
-        readonly CancellationTokenRegistration  _keepAliveTokenRegistration;
+        readonly ILogger _logger;
         readonly Task _pingStarter;
+        readonly CancellationTokenRegistration  _keepAliveExpiredRegistration;
         TimeSpan _keepaliveTimeout;
         bool _disposed;
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PingedReverseCallConnection{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> class.
+        /// </summary>
+        /// <param name="requestId">The request id for the gRPC method call.</param>
+        /// <param name="requestId">The request id for the gRPC method call.</param>
+        /// <param name="runtimeStream">The <see cref="IAsyncStreamReader{TClientMessage}"/> to read messages to the Runtime.</param>
+        /// <param name="clientStream">The <see cref="IServerStreamWriter{TServerMessage}"/> to write messages to the Client.</param>
+        /// <param name="context">The <see cref="ServerCallContext"/> of the method call.</param>
+        /// <param name="messageConverter">The <see cref="MethodConverter"/> to use for decoding the connect arguments and reading the desired ping interval from.</param>
+        /// <param name="metrics">The metrics collector to use for metrics about reverse calls.</param>
+        /// <param name="loggerFactory">The logger factory to use to create loggers.</param>
         public PingedReverseCallConnection(
+            RequestId requestId,
             IAsyncStreamReader<TClientMessage> runtimeStream,
             IAsyncStreamWriter<TServerMessage> clientStream,
             ServerCallContext context,
             IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> messageConverter,
-            IMetricsCollector metrics)
+            IMetricsCollector metrics,
+            ILoggerFactory loggerFactory)
         {
             _keepAliveTokenSource = new CancellationTokenSource();
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken, _keepAliveTokenSource.Token);
-            _wrappedReader = new(runtimeStream, messageConverter, metrics, _cancellationTokenSource.Token);
-            _wrappedWriter = new(clientStream, messageConverter, metrics, _cancellationTokenSource.Token);
+
+            _requestId = requestId;
+            _wrappedReader = new(
+                requestId,
+                runtimeStream,
+                messageConverter,
+                metrics,
+                loggerFactory.CreateLogger<WrappedAsyncStreamReader<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>(),
+                _cancellationTokenSource.Token);
+            _wrappedWriter = new(
+                requestId,
+                clientStream,
+                messageConverter,
+                metrics,
+                loggerFactory.CreateLogger<WrappedAsyncStreamWriter<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>(),
+                _cancellationTokenSource.Token);
+
+            _metrics = metrics;
+            _logger = loggerFactory.CreateLogger<PingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>();
+
             _pingStarter = WaitForFirstMessageThenStartPinging(_cancellationTokenSource.Token);
-            _keepAliveTokenRegistration = _keepAliveTokenSource.Token.Register(NotifyKeepaliveTimedOut);
+            _keepAliveExpiredRegistration = _keepAliveTokenSource.Token.Register(NotifyKeepaliveTimedOut);
         }
 
         /// <inheritdoc/>
@@ -65,13 +108,15 @@ namespace Dolittle.Runtime.Services.ReverseCalls
 
             if (disposing)
             {
+                _logger.DisposingPingedReverseCallConnection(_requestId);
                 _cancellationTokenSource.Cancel();
                 WaitForPingStarterToCompleteIgnoringExceptions();
                 MaybeStopPinging();
-                _keepAliveTokenRegistration.Dispose();
+                _keepAliveExpiredRegistration.Dispose();
                 _wrappedReader.MessageReceived -= ResetKeepaliveTokenCancellation;
                 _cancellationTokenSource.Dispose();
                 _wrappedWriter.Dispose();
+                _logger.DisposedPingedReverseCallConnection(_requestId);
             }
 
             _disposed = true;
@@ -80,24 +125,37 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         Task WaitForFirstMessageThenStartPinging(CancellationToken cancellationToken) =>
             Task.Run(async () =>
             {
+                var stopwatch = Stopwatch.StartNew();
+                _logger.WaitingForReverseCallContext(_requestId);
+
                 var context = await _wrappedReader.ReverseCallContext.ConfigureAwait(false);
-                StartPinging(context);
-                StartKeepaliveTokenTimeout(context);
+
+                stopwatch.Stop();
+                _metrics.AddToTotalWaitForFirstMessageTime(stopwatch.Elapsed);
+                _logger.ReceivedReverseCallContext(_requestId);
+
+                var pingInterval = context.PingInterval.ToTimeSpan();
+                StartPinging(pingInterval);
+                StartKeepaliveTokenTimeout(pingInterval);
             }, cancellationToken);
 
-        void StartPinging(ReverseCallArgumentsContext context)
+        void StartPinging(TimeSpan pingInterval)
         {
+            _logger.StartPings(_requestId, pingInterval);
             // TODO: to be implemented once the "ping service" is ready
             // _wrappedWriter.MaybeWritePing();
         }
 
         void MaybeStopPinging()
         {
+            // _logger.StoppingPings(_requestId);
+            // _logger.NotStoppingPingsBecauseItWasNotStarted(_requestId);
         }
 
-        void StartKeepaliveTokenTimeout(ReverseCallArgumentsContext context)
+        void StartKeepaliveTokenTimeout(TimeSpan pingInterval)
         {
-            _keepaliveTimeout = context.PingInterval.ToTimeSpan();
+            _logger.StartKeepaliveTokenTimeout(_requestId, pingInterval);
+            _keepaliveTimeout = pingInterval;
             _wrappedReader.MessageReceived += ResetKeepaliveTokenCancellation;
             ResetKeepaliveTokenCancellation();
         }
@@ -105,14 +163,26 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         void ResetKeepaliveTokenCancellation()
         {
             _cancellationTokenSource.CancelAfter(_keepaliveTimeout);
+            _metrics.IncrementTotalKeepaliveTokenResets();
+            _logger.ResettingKeepaliveToken(_requestId);
         }
 
         void NotifyKeepaliveTimedOut()
         {
-            // TODO: Logger
+            _metrics.IncrementTotalKeepaliveTimeouts();
+            _logger.KeepaliveTimedOut(_requestId);
         }
 
-        void WaitForPingStarterToCompleteIgnoringExceptions() =>
+        void WaitForPingStarterToCompleteIgnoringExceptions()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            _logger.WaitingForPingStarterToComplete(_requestId);
+
             _pingStarter.ContinueWith(_ => {}).GetAwaiter().GetResult();
+
+            stopwatch.Stop();
+            _metrics.AddToTotalWaitForPingStarterToCompleteTime(stopwatch.Elapsed);
+            _logger.PingStarterCompleted(_requestId);
+        }
     }
 }

--- a/Source/Services/ReverseCalls/ReverseCallArgumentsContextNotReceivedInFirstMessage.cs
+++ b/Source/Services/ReverseCalls/ReverseCallArgumentsContextNotReceivedInFirstMessage.cs
@@ -14,8 +14,9 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <summary>
         /// Initializes a new instance of the <see cref="ReverseCallArgumentsContextNotReceivedInFirstMessage"/> class.
         /// </summary>
-        public ReverseCallArgumentsContextNotReceivedInFirstMessage()
-            : base($"The first message received for the reverse call connection did not contain a {nameof(ReverseCallArgumentsContext)}")
+        /// <param name="reason">The reason for the missing reverse call arguments context.</param>
+        public ReverseCallArgumentsContextNotReceivedInFirstMessage(string reason)
+            : base($"The first message received for the reverse call connection did not contain a {nameof(ReverseCallArgumentsContext)} because {reason}")
         {
         }
     }

--- a/Source/Services/ReverseCalls/TokenSourceDeadline.cs
+++ b/Source/Services/ReverseCalls/TokenSourceDeadline.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+namespace Dolittle.Runtime.Services.ReverseCalls
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="ICancelTokenIfDeadlineIsMissed"/> that uses a <see cref="CancellationTokenSource"/>.
+    /// </summary>
+    public class TokenSourceDeadline : ICancelTokenIfDeadlineIsMissed
+    {
+        readonly CancellationTokenSource _source = new();
+        bool _disposed;
+
+        /// <inheritdoc/>
+        public void RefreshDeadline(TimeSpan nextRefreshBefore)
+        {
+            if (nextRefreshBefore == TimeSpan.Zero)
+            {
+                _source.Cancel();
+                return;
+            }
+
+            _source.CancelAfter(nextRefreshBefore);
+        }
+
+        /// <inheritdoc/>
+        public CancellationToken Token => _source.Token;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                _source.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/Source/Services/ReverseCalls/WrappedAsyncStreamReader.cs
+++ b/Source/Services/ReverseCalls/WrappedAsyncStreamReader.cs
@@ -174,12 +174,12 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         }
 
         void SetReversCallArgumentsNotReceivedBecauseNoFirstMessage()
-            => _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage("no message was received"));
+            => _reverseCallContext.SetException(new ArgumentsContextNotReceivedInFirstMessage("no message was received"));
 
         void SetReversCallArgumentsNotReceivedBecauseNoConnectArgumentsInFirstMessage()
-            => _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage("first message did not contain connect arguments"));
+            => _reverseCallContext.SetException(new ArgumentsContextNotReceivedInFirstMessage("first message did not contain connect arguments"));
 
         void SetReversCallArgumentsNotReceivedBecauseNoContextOnConnectArguments()
-            => _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage("connect arguments did not contain a context"));
+            => _reverseCallContext.SetException(new ArgumentsContextNotReceivedInFirstMessage("connect arguments did not contain a context"));
     }
 }

--- a/Source/Services/ReverseCalls/WrappedAsyncStreamReader.cs
+++ b/Source/Services/ReverseCalls/WrappedAsyncStreamReader.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Dolittle.Services.Contracts;
 using Google.Protobuf;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Dolittle.Runtime.Services.ReverseCalls
 {
@@ -14,12 +15,12 @@ namespace Dolittle.Runtime.Services.ReverseCalls
     /// Represents a wrapper of <see cref="IAsyncStreamReader{TClientMessage}"/> that collects the <see cref="ReverseCallArgumentsContext"/> from the first received message and records metrics.
     /// The wrapped stream will also filter out pong messages from the exposed stream, and instead raise events to be handled.
     /// </summary>
-    /// <typeparam name="TClientMessage"></typeparam>
-    /// <typeparam name="TServerMessage"></typeparam>
-    /// <typeparam name="TConnectArguments"></typeparam>
-    /// <typeparam name="TConnectResponse"></typeparam>
-    /// <typeparam name="TRequest"></typeparam>
-    /// <typeparam name="TResponse"></typeparam>
+    /// <typeparam name="TClientMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Client to the Runtime.</typeparam>
+    /// <typeparam name="TServerMessage">Type of the <see cref="IMessage">messages</see> that is sent from the Runtime to the Client.</typeparam>
+    /// <typeparam name="TConnectArguments">Type of the arguments that are sent along with the initial Connect call.</typeparam>
+    /// <typeparam name="TConnectResponse">Type of the response that is received after the initial Connect call.</typeparam>
+    /// <typeparam name="TRequest">Type of the requests sent from the Runtime to the Client.</typeparam>
+    /// <typeparam name="TResponse">Type of the responses sent from the Client to the Runtime.</typeparam>
     public class WrappedAsyncStreamReader<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> : IAsyncStreamReader<TClientMessage>
         where TClientMessage : IMessage, new()
         where TServerMessage : IMessage, new()
@@ -28,9 +29,11 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         where TRequest : class
         where TResponse : class
     {
+        readonly RequestId _requestId;
         readonly IAsyncStreamReader<TClientMessage> _originalStream;
         readonly IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> _messageConverter;
         readonly IMetricsCollector _metrics;
+        readonly ILogger _logger;
         readonly CancellationToken _cancellationToken;
         readonly TaskCompletionSource<ReverseCallArgumentsContext> _reverseCallContext = new(TaskCreationOptions.RunContinuationsAsynchronously);
         bool _firstMoveNextCalled;
@@ -38,19 +41,25 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <summary>
         /// Initializes a new instance of the <see cref="WrappedAsyncStreamReader{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> class.
         /// </summary>
+        /// <param name="requestId">The request id for the gRPC method call.</param>
         /// <param name="originalStream">The original gRPC stream reader to wrap.</param>
         /// <param name="messageConverter">The message converter to use to convert the first message received.</param>
         /// <param name="metrics">The metrics collector to use for metrics about reverse call stream reads.</param>
+        /// <param name="logger">The logger to use.</param>
         /// <param name="cancellationToken">A cancellation token to use for cancelling pending and future reads.</param>
         public WrappedAsyncStreamReader(
+            RequestId requestId,
             IAsyncStreamReader<TClientMessage> originalStream,
             IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> messageConverter,
             IMetricsCollector metrics,
+            ILogger logger,
             CancellationToken cancellationToken)
         {
+            _requestId = requestId;
             _originalStream = originalStream;
             _messageConverter = messageConverter;
             _metrics = metrics;
+            _logger = logger;
             _cancellationToken = cancellationToken;
         }
 
@@ -71,6 +80,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <inheritdoc/>
         public Task<bool> MoveNext(CancellationToken cancellationToken)
         {
+            _logger.ReadingMessage(_requestId);
             if (_firstMoveNextCalled)
             {
                 return MoveNextSkippingPongsAndRecordMetrics(cancellationToken);
@@ -90,7 +100,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls
                     return true;
                 }
                 
-                SetReverseCallArgumentsContextNotReceived();
+                SetReversCallArgumentsNotReceivedBecauseNoFirstMessage();
                 return false;
             }
             catch (TaskCanceledException)
@@ -117,19 +127,24 @@ namespace Dolittle.Runtime.Services.ReverseCalls
             {
                 if (await _originalStream.MoveNext(combinedCancellationToken).ConfigureAwait(false))
                 {
+                    var messageSize = _originalStream.Current.CalculateSize();
                     _metrics.IncrementTotalStreamReads();
-                    _metrics.IncrementTotalStreamReadBytes(_originalStream.Current.CalculateSize());
+                    _metrics.IncrementTotalStreamReadBytes(messageSize);
+
+                    MessageReceived?.Invoke();
 
                     if (CurrentMessageIsPong())
                     {
                         _metrics.IncrementTotalPongsReceived();
+                        _logger.ReadPong(_requestId);
                         continue;
                     }
 
-                    MessageReceived?.Invoke();
+                    _logger.ReadMessage(_requestId, messageSize);
                     return true;
                 }
 
+                _logger.NoMoreMessagesToRead(_requestId);
                 return false;
             }
         }
@@ -144,23 +159,27 @@ namespace Dolittle.Runtime.Services.ReverseCalls
             var connectArguments = _messageConverter.GetConnectArguments(message);
             if (connectArguments == default)
             {
-                SetReverseCallArgumentsContextNotReceived();
+                SetReversCallArgumentsNotReceivedBecauseNoConnectArgumentsInFirstMessage();
                 return;
             }
 
             var argumentsContext = _messageConverter.GetArgumentsContext(connectArguments);
             if (argumentsContext == default)
             {
-                SetReverseCallArgumentsContextNotReceived();
+                SetReversCallArgumentsNotReceivedBecauseNoContextOnConnectArguments();
                 return;
             }
 
             _reverseCallContext.SetResult(argumentsContext);
         }
 
-        void SetReverseCallArgumentsContextNotReceived()
-        {
-            _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage());
-        }
+        void SetReversCallArgumentsNotReceivedBecauseNoFirstMessage()
+            => _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage("no message was received"));
+
+        void SetReversCallArgumentsNotReceivedBecauseNoConnectArgumentsInFirstMessage()
+            => _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage("first message did not contain connect arguments"));
+
+        void SetReversCallArgumentsNotReceivedBecauseNoContextOnConnectArguments()
+            => _reverseCallContext.SetException(new ReverseCallArgumentsContextNotReceivedInFirstMessage("connect arguments did not contain a context"));
     }
 }

--- a/Source/Services/ReverseCalls/WrappedAsyncStreamWriter.cs
+++ b/Source/Services/ReverseCalls/WrappedAsyncStreamWriter.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Dolittle.Services.Contracts;
 using Google.Protobuf;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Dolittle.Runtime.Services.ReverseCalls
 {
@@ -28,9 +29,11 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         where TRequest : class
         where TResponse : class
     {
+        readonly RequestId _requestId;
         readonly IAsyncStreamWriter<TServerMessage> _originalStream;
         readonly IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> _messageConverter;
         readonly IMetricsCollector _metrics;
+        readonly ILogger _logger;
         readonly CancellationToken _cancellationToken;
         readonly SemaphoreSlim _writeLock = new(1);
         bool _disposed;
@@ -38,19 +41,25 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <summary>
         /// Initializes a new instance of the <see cref="WrappedAsyncStreamWriter{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> class.
         /// </summary>
+        /// <param name="requestId">The request id for the gRPC method call.</param>
         /// <param name="originalStream">The original gRPC stream writer to wrap.</param>
         /// <param name="messageConverter">The message converter to use to create ping messages.</param>
         /// <param name="metrics">The metrics collector to use for metrics about reverse call stream writes.</param>
+        /// <param name="logger">The logger to use.</param>
         /// <param name="cancellationToken">A cancellation token to use for cancelling pending and future writes.</param>
         public WrappedAsyncStreamWriter(
+            RequestId requestId,
             IAsyncStreamWriter<TServerMessage> originalStream,
             IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> messageConverter,
             IMetricsCollector metrics,
+            ILogger logger,
             CancellationToken cancellationToken)
         {
+            _requestId = requestId;
             _originalStream = originalStream;
             _messageConverter = messageConverter;
             _metrics = metrics;
+            _logger = logger;
             _cancellationToken = cancellationToken;
         }
 
@@ -68,15 +77,22 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <returns>A task that will complete when the message is sent.</returns>
         public async Task WriteAsync(TServerMessage message)
         {
+            _logger.WritingMessage(_requestId, typeof(TServerMessage));
             _cancellationToken.ThrowIfCancellationRequested();
+
             if (!_writeLock.Wait(0))
             {
                 var stopwatch = Stopwatch.StartNew();
+
                 _metrics.IncrementPendingStreamWrites();
+                _logger.WritingMessageBlockedByAnotherWrite(_requestId, typeof(TServerMessage));
+
                 await _writeLock.WaitAsync(_cancellationToken).ConfigureAwait(false);
-                _metrics.DecrementPendingStreamWrites();
+
                 stopwatch.Stop();
+                _metrics.DecrementPendingStreamWrites();
                 _metrics.AddToTotalStreamWriteWaitTime(stopwatch.Elapsed);
+                _logger.WritingMessageUnblockedAfter(_requestId, typeof(TServerMessage), stopwatch.Elapsed);
             }
 
             await WriteRecordMetricsAndReleaseLock(message, false);
@@ -88,9 +104,12 @@ namespace Dolittle.Runtime.Services.ReverseCalls
         /// <returns>A task that will complete when the ping is sent or skipped.</returns>
         public Task MaybeWritePing()
         {
+            _logger.WritingPing(_requestId);
             _cancellationToken.ThrowIfCancellationRequested();
+
             if (!_writeLock.Wait(0))
             {
+                _logger.WritingPingSkipped(_requestId);
                 return Task.CompletedTask;
             }
 
@@ -114,8 +133,10 @@ namespace Dolittle.Runtime.Services.ReverseCalls
 
             if (disposing)
             {
+                _logger.DisposingWrappedAsyncStreamWriter(_requestId);
                 _writeLock.Wait();
                 _writeLock.Dispose();
+                _logger.DisposedWrappedAsyncStreamWriter(_requestId);
             }
 
             _disposed = true;
@@ -126,16 +147,25 @@ namespace Dolittle.Runtime.Services.ReverseCalls
             try
             {
                 _cancellationToken.ThrowIfCancellationRequested();
+
                 var stopwatch = Stopwatch.StartNew();
+
                 await _originalStream.WriteAsync(message).ConfigureAwait(false);
+
                 stopwatch.Stop();
+                var messageSize = message.CalculateSize();
                 _metrics.AddToTotalStreamWriteTime(stopwatch.Elapsed);
                 _metrics.IncrementTotalStreamWrites();
-                _metrics.IncrementTotalStreamWriteBytes(message.CalculateSize());
+                _metrics.IncrementTotalStreamWriteBytes(messageSize);
 
                 if (messageIsPing)
                 {
                     _metrics.IncrementTotalPingsSent();
+                    _logger.WrotePing(_requestId, stopwatch.Elapsed);
+                }
+                else
+                {
+                    _logger.WroteMessage(_requestId, stopwatch.Elapsed, messageSize);
                 }
             }
             finally

--- a/Specifications/Services/ReverseCall/for_PingedConnection/given/Scenario.cs
+++ b/Specifications/Services/ReverseCall/for_PingedConnection/given/Scenario.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Grpc.Core;
+using Machine.Specifications;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given
+{
+    public class Scenario
+    {
+        readonly List<Step> _steps = new();
+        Scenario() {}
+
+        public static Scenario New(Action<Builder> build)
+        {
+            var scenario = new Scenario();
+            
+            build(new Builder(scenario));
+
+            var error = scenario._steps.Select(_ => _.Validate()).FirstOrDefault(_ => _ != default);
+            if (error != default) throw error;
+            
+            scenario._steps.Sort((a, b) => a.At.Value - b.At.Value);
+
+            var lastStep = scenario._steps.LastOrDefault();
+            var finalStepTime = 0;
+            if (lastStep != default) finalStepTime = lastStep.At.Value + 100;
+
+            scenario._steps.Add(new FinalStep{ At = finalStepTime });
+            
+            return scenario;
+        }
+
+        public class Builder
+        {
+            public Builder(Scenario scenario)
+            {
+                Receive = new ReceiveBuilder(scenario);
+            }
+
+            public ReceiveBuilder Receive { get; private set; }
+
+            public class ReceiveBuilder
+            {
+                readonly Scenario _scenario;
+                public ReceiveBuilder(Scenario scenario) => _scenario = scenario;
+
+                public AtSetter Message(a_message message)
+                    => _scenario.AddStep(new ReceiveMessageStep{ Message = message });
+
+                public AtSetter Exception(Exception exception)
+                    => _scenario.AddStep(new ReceiveExceptionStep{ Exception = exception });
+            }
+        }
+
+        public class AtSetter
+        {
+            readonly Step _step;
+            public AtSetter(Step step) => _step = step;
+
+            public void AtTime(int time) => _step.At = time;
+        }
+
+        public abstract class Step
+        {
+            public int? At { get; set; }
+
+            public SpecificationUsageException Validate()
+            {
+                if (!At.HasValue) return new SpecificationUsageException("The time was not set for a step");
+
+                return default;
+            }
+
+            public abstract void Execute(Scenario scenario);
+        }
+
+        public class FinalStep : Step
+        {
+            public override void Execute(Scenario scenario)
+            {
+                scenario._nextPendingMessage.SetResult(new(false, null));
+                scenario._nextPendingMessage = new();
+            }
+        }
+
+        public class ReceiveMessageStep : Step
+        {
+            public a_message Message { get; set; }
+
+            public override void Execute(Scenario scenario)
+            {
+                scenario._nextPendingMessage.SetResult(new(true, Message));
+                scenario._nextPendingMessage = new();
+            }
+        }
+
+        public class ReceiveExceptionStep : Step
+        {
+            public Exception Exception { get; set; }
+
+            public override void Execute(Scenario scenario)
+            {
+                scenario._nextPendingMessage.SetException(Exception);
+                scenario._nextPendingMessage = new();
+            }
+        }
+
+        AtSetter AddStep(Step step)
+        {
+            _steps.Add(step);
+            return new(step);
+        }
+
+        public void Simulate(
+            RequestId requestId,
+            ServerCallContext context,
+            IConvertReverseCallMessages<a_message, a_message, object, object, object, object> messageConverter,
+            IMetricsCollector metrics,
+            ILoggerFactory loggerFactory)
+        {
+            _simulatedTime = 0;
+            _writtenMessages = new();
+            _receivedMessages = new();
+            _nextPendingMessage = new();
+            _readMessageException = new(-1, null);
+
+            var connection = new PingedConnection<a_message, a_message, object, object, object, object>(
+                requestId,
+                new SimulatedStreamReader(this),
+                new SimulatedStreamWriter(this),
+                context,
+                messageConverter,
+                metrics,
+                loggerFactory);
+
+            ConnectionCancellationToken = connection.CancellationToken;
+
+            var reader = ReadAllConnectionOutputs(connection);
+
+            foreach (var step in _steps)
+            {
+                _simulatedTime = step.At.Value;
+                step.Execute(this);
+            }
+
+            reader.GetAwaiter().GetResult();
+
+            Thread.Sleep(10);
+        }
+
+        public CancellationToken ConnectionCancellationToken { get; private set; }
+
+        int _simulatedTime;
+        List<Tuple<int, a_message>> _writtenMessages;
+        List<Tuple<int, a_message>> _receivedMessages;
+        Tuple<int, Exception> _readMessageException;
+        TaskCompletionSource<Tuple<bool, a_message>> _nextPendingMessage;
+
+        public Exception RuntimeStreamMoveNextException => _readMessageException.Item2;
+
+        class SimulatedStreamReader : IAsyncStreamReader<a_message>
+        {
+            readonly Scenario _scenario;
+            public SimulatedStreamReader(Scenario scenario) => _scenario = scenario;
+
+            public a_message Current { get; private set; }
+
+            public async Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                var result = await _scenario._nextPendingMessage.Task.ConfigureAwait(false);
+                if (result.Item1)
+                {
+                    Current = result.Item2;
+                }
+                return result.Item1;
+            }
+        }
+
+        class SimulatedStreamWriter : IAsyncStreamWriter<a_message>
+        {
+            readonly Scenario _scenario;
+            public SimulatedStreamWriter(Scenario scenario) => _scenario = scenario;
+
+            public WriteOptions WriteOptions { get; set; }
+
+            public Task WriteAsync(a_message message)
+            {
+                _scenario._writtenMessages.Add(new(_scenario._simulatedTime, message));
+                return Task.CompletedTask;
+            }
+        }
+
+        async Task ReadAllConnectionOutputs(PingedConnection<a_message, a_message, object, object, object, object> connection)
+        {
+            try
+            {
+                while (await connection.RuntimeStream.MoveNext(connection.CancellationToken).ConfigureAwait(false))
+                {
+                    _receivedMessages.Add(new(_simulatedTime, connection.RuntimeStream.Current));
+                }
+            }
+            catch (Exception exception)
+            {
+                _readMessageException = new(_simulatedTime, exception);
+            }
+        }
+    }
+}

--- a/Specifications/Services/ReverseCall/for_PingedConnection/given/Scenario.cs
+++ b/Specifications/Services/ReverseCall/for_PingedConnection/given/Scenario.cs
@@ -132,12 +132,15 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given
             _nextPendingMessage = new();
             _readMessageException = new(-1, null);
 
+            var fakeKeepaliveDeadline = new SimulatedKeepaliveDeadline(this);
+
             var connection = new PingedConnection<a_message, a_message, object, object, object, object>(
                 requestId,
                 new SimulatedStreamReader(this),
                 new SimulatedStreamWriter(this),
                 context,
                 messageConverter,
+                fakeKeepaliveDeadline,
                 metrics,
                 loggerFactory);
 
@@ -195,6 +198,23 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given
             {
                 _scenario._writtenMessages.Add(new(_scenario._simulatedTime, message));
                 return Task.CompletedTask;
+            }
+        }
+
+        class SimulatedKeepaliveDeadline : ICancelTokenIfDeadlineIsMissed
+        {
+            readonly CancellationTokenSource _source = new();
+            readonly Scenario _scenario;
+            public SimulatedKeepaliveDeadline(Scenario scenario) => _scenario = scenario;
+
+            public CancellationToken Token => _source.Token;
+
+            public void Dispose()
+                => _source.Dispose();
+
+            public void RefreshDeadline(TimeSpan nextRefreshBefore)
+            {
+                // TODO: Implement with fake time
             }
         }
 

--- a/Specifications/Services/ReverseCall/for_PingedConnection/when_first_read_fails.cs
+++ b/Specifications/Services/ReverseCall/for_PingedConnection/when_first_read_fails.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection
+{
+    public class when_first_read_fails : all_dependencies
+    {
+        static Exception exception;
+        static Scenario scenario;
+
+        Establish context = () =>
+        {
+            exception = new();
+
+            scenario = Scenario.New(_ => {
+                _.Receive.Exception(exception).AtTime(10);
+            });
+        };
+
+        Because of = () => scenario.Simulate(
+            request_id,
+            server_call_context,
+            message_converter.Object,
+            metrics,
+            logger_factory);
+
+        It should_set_the_cancellation_token = () => scenario.ConnectionCancellationToken.IsCancellationRequested.ShouldBeTrue();
+        It should_have_passed_along_the_read_exception = () => scenario.RuntimeStreamMoveNextException.ShouldEqual(exception);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_PingedConnection/when_receiving_no_messages.cs
+++ b/Specifications/Services/ReverseCall/for_PingedConnection/when_receiving_no_messages.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection
+{
+    public class when_receiving_no_messages : all_dependencies
+    {
+        static Scenario scenario;
+
+        Establish context = () =>
+        {
+            scenario = Scenario.New(_ => {});
+        };
+
+        Because of = () => scenario.Simulate(
+            request_id,
+            server_call_context,
+            message_converter.Object,
+            metrics,
+            logger_factory);
+
+        It should_set_the_cancellation_token = () => scenario.ConnectionCancellationToken.IsCancellationRequested.ShouldBeTrue();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_reading/and_stream_throws_an_exception.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_reading/and_stream_throws_an_exception.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_reading
+{
+    public class and_stream_throws_an_exception : all_dependencies
+    {
+        static Mock<MessageReceived> event_handler;
+        static a_message message;
+        static Exception exception;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            message = new();
+            exception = new();
+
+            event_handler = new Mock<MessageReceived>();
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(message)
+                    .throws(exception),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        Because of = () =>
+        {
+            wrapped_reader.MessageReceived += event_handler.Object;
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            Catch.Exception(() => wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult());
+        };
+
+        It should_call_the_event_handler_twice = () => event_handler.Verify(_ => _(), Times.Once);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_reading/and_there_are_no_messages.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_reading/and_there_are_no_messages.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_reading
+{
+    public class and_there_are_no_messages : all_dependencies
+    {
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => wrapped_reader = new(
+            request_id,
+            an_async_stream_reader<a_message>
+                .that()
+                .completes(),
+            message_converter.Object,
+            metrics,
+            logger,
+            cancellation_token);
+
+        static bool result;
+        Because of = () => result = wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+
+        It should_return_false = () => result.ShouldBeFalse();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_reading/and_there_are_two_messages.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_reading/and_there_are_two_messages.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_reading
+{
+    public class and_there_are_two_messages : all_dependencies
+    {
+        static a_message first_message;
+        static a_message second_message;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            first_message = new();
+            second_message = new();
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(first_message)
+                    .receives(second_message)
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static bool first_read;
+        static a_message first_result;
+        static a_message first_result_read_again;
+        static bool second_read;
+        static a_message second_result;
+        static bool third_read;
+        Because of = () =>
+        {
+            first_read = wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            first_result = wrapped_reader.Current;
+            first_result_read_again = wrapped_reader.Current;
+            second_read = wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            second_result = wrapped_reader.Current;
+            third_read = wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+        };
+
+        It should_return_true_for_the_first_read = () => first_read.ShouldBeTrue();
+        It should_return_the_first_message_after_the_first_read = () => first_result.ShouldEqual(first_message);
+        It should_return_the_first_message_after_the_first_read_when_current_is_read_again = () => first_result_read_again.ShouldEqual(first_message);
+        It should_return_true_for_the_second_read = () => second_read.ShouldBeTrue();
+        It should_return_the_first_message_after_the_second_result = () => second_result.ShouldEqual(second_message);
+        It should_return_true_for_the_third_read = () => third_read.ShouldBeFalse();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_subscribing_to_message_received/and_stream_throws_an_exception.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_subscribing_to_message_received/and_stream_throws_an_exception.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_subscribing_to_message_received
+{
+    public class and_stream_throws_an_exception : all_dependencies
+    {
+        static a_message message;
+        static Exception exception;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            message = new();
+            exception = new();
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(message)
+                    .throws(exception),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static bool first_read;
+        static a_message first_result;
+        static Exception second_read;
+        Because of = () =>
+        {
+            first_read = wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            first_result = wrapped_reader.Current;
+            second_read = Catch.Exception(() => wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult());
+        };
+
+        It should_return_true_for_the_first_read = () => first_read.ShouldBeTrue();
+        It should_return_the_first_message_after_the_first_read = () => first_result.ShouldEqual(message);
+        It should_throw_exception_for_the_second_read = () => second_read.ShouldEqual(exception);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_subscribing_to_message_received/and_there_are_no_messages.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_subscribing_to_message_received/and_there_are_no_messages.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_subscribing_to_message_received
+{
+    public class and_there_are_no_messages : all_dependencies
+    {
+        static Mock<MessageReceived> event_handler;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () =>
+        {
+            event_handler = new Mock<MessageReceived>();
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        Because of = () =>
+        {
+            wrapped_reader.MessageReceived += event_handler.Object;
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+        };
+
+        It should_not_call_the_event_handler = () => event_handler.VerifyNoOtherCalls();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_subscribing_to_message_received/and_there_are_two_messages.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_subscribing_to_message_received/and_there_are_two_messages.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_subscribing_to_message_received
+{
+    public class and_there_are_two_messages : all_dependencies
+    {
+        static a_message first_message;
+        static a_message second_message;
+        static Mock<MessageReceived> event_handler;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            first_message = new();
+            second_message = new();
+
+            event_handler = new Mock<MessageReceived>();
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(first_message)
+                    .receives(second_message)
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        Because of = () =>
+        {
+            wrapped_reader.MessageReceived += event_handler.Object;
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+        };
+
+        It should_call_the_event_handler_twice = () => event_handler.Verify(_ => _(), Times.Exactly(2));
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_stream_throws_an_exception_on_the_first_message.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_stream_throws_an_exception_on_the_first_message.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_stream_throws_an_exception_on_the_first_message : all_dependencies
+    {
+        static Exception exception;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () =>
+        {
+            exception = new();
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .throws(exception),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static Exception result;
+        Because of = () =>
+        {
+            Catch.Exception(() => wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult());
+            result = Catch.Exception(() => wrapped_reader.ReverseCallContext.GetAwaiter().GetResult());
+        };
+
+        It should_should_fail = () => result.ShouldEqual(exception);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_stream_throws_an_exception_on_the_second_message.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_stream_throws_an_exception_on_the_second_message.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Dolittle.Services.Contracts;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_stream_throws_an_exception_on_the_second_message : all_dependencies
+    {
+        static a_message message;
+        static object message_arguments;
+        static ReverseCallArgumentsContext message_arguments_context;
+        static Exception exception;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            message = new();
+            message_arguments = new();
+            message_arguments_context = new();
+            exception = new();
+
+            message_converter
+                .Setup(_ => _.GetConnectArguments(message))
+                .Returns(message_arguments);
+            message_converter
+                .Setup(_ => _.GetArgumentsContext(message_arguments))
+                .Returns(message_arguments_context);
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(message)
+                    .throws(exception),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static ReverseCallArgumentsContext result;
+        Because of = () =>
+        {
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            result = wrapped_reader.ReverseCallContext.GetAwaiter().GetResult();
+            Catch.Exception(() => wrapped_reader.ReverseCallContext.GetAwaiter().GetResult());
+        };
+
+        It should_return_the_arguments_context = () => result.ShouldEqual(message_arguments_context);
+        It should_call_the_converter_with_the_first_message = () => message_converter.Verify(_ => _.GetConnectArguments(message));
+        It should_call_the_converter_with_the_connect_arguments = () => message_converter.Verify(_ => _.GetArgumentsContext(message_arguments));
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_the_first_message_does_not_contain_arguments.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_the_first_message_does_not_contain_arguments.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_the_first_message_does_not_contain_arguments : all_dependencies
+    {
+        static a_message first_message;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            first_message = new();
+
+            message_converter
+                .Setup(_ => _.GetConnectArguments(first_message))
+                .Returns(null);
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(first_message)
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static Exception result;
+        Because of = () =>
+        {
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            result = Catch.Exception(() => wrapped_reader.ReverseCallContext.GetAwaiter().GetResult());
+        };
+
+        It should_fail = () => result.ShouldBeOfExactType<ArgumentsContextNotReceivedInFirstMessage>();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_the_first_message_does_not_contain_context.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_the_first_message_does_not_contain_context.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_the_first_message_does_not_contain_context : all_dependencies
+    {
+        static a_message first_message;
+        static object first_message_arguments;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            first_message = new();
+            first_message_arguments = new();
+
+            message_converter
+                .Setup(_ => _.GetConnectArguments(first_message))
+                .Returns(first_message_arguments);
+            message_converter
+                .Setup(_ => _.GetArgumentsContext(first_message_arguments))
+                .Returns<IConvertReverseCallMessages<a_message, a_message, object, object, object, object>>(null);
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(first_message)
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static Exception result;
+        Because of = () =>
+        {
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            result = Catch.Exception(() => wrapped_reader.ReverseCallContext.GetAwaiter().GetResult());
+        };
+
+        It should_fail = () => result.ShouldBeOfExactType<ArgumentsContextNotReceivedInFirstMessage>();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_there_are_no_messages.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_there_are_no_messages.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_there_are_no_messages : all_dependencies
+    {
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => wrapped_reader = new(
+            request_id,
+            an_async_stream_reader<a_message>
+                .that()
+                .completes(),
+            message_converter.Object,
+            metrics,
+            logger,
+            cancellation_token);
+
+        static Exception result;
+        Because of = () =>
+        {
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            result = Catch.Exception(() => wrapped_reader.ReverseCallContext.GetAwaiter().GetResult());
+        };
+
+        It should_should_fail = () => result.ShouldBeOfExactType<ArgumentsContextNotReceivedInFirstMessage>();
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_there_are_two_messages.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_there_are_two_messages.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Dolittle.Services.Contracts;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_there_are_two_messages : all_dependencies
+    {
+        static a_message first_message;
+        static object first_message_arguments;
+        static ReverseCallArgumentsContext first_message_arguments_context;
+        static a_message second_message;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            first_message = new();
+            first_message_arguments = new();
+            first_message_arguments_context = new();
+            second_message = new();
+
+            message_converter
+                .Setup(_ => _.GetConnectArguments(first_message))
+                .Returns(first_message_arguments);
+            message_converter
+                .Setup(_ => _.GetArgumentsContext(first_message_arguments))
+                .Returns(first_message_arguments_context);
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(first_message)
+                    .receives(second_message)
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static ReverseCallArgumentsContext first_result;
+        static ReverseCallArgumentsContext second_result;
+        Because of = () =>
+        {
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            first_result = wrapped_reader.ReverseCallContext.GetAwaiter().GetResult();
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            second_result = wrapped_reader.ReverseCallContext.GetAwaiter().GetResult();
+        };
+
+        It should_return_the_arguments_context_the_first_time = () => first_result.ShouldEqual(first_message_arguments_context);
+        It should_return_the_arguments_context_the_second_time = () => second_result.ShouldEqual(first_message_arguments_context);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_there_are_two_messages_with_arguments_context.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamReader/when_waiting_for_reverse_call_context/and_there_are_two_messages_with_arguments_context.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Dolittle.Services.Contracts;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamReader.when_waiting_for_reverse_call_context
+{
+    public class and_there_are_two_messages_with_arguments_context : all_dependencies
+    {
+        static a_message first_message;
+        static object first_message_arguments;
+        static ReverseCallArgumentsContext first_message_arguments_context;
+        static a_message second_message;
+        static object second_message_arguments;
+        static ReverseCallArgumentsContext second_message_arguments_context;
+        static WrappedAsyncStreamReader<a_message, a_message, object, object, object, object> wrapped_reader;
+
+        Establish context = () => 
+        {
+            first_message = new();
+            first_message_arguments = new();
+            first_message_arguments_context = new();
+            second_message = new();
+            second_message_arguments = new();
+            second_message_arguments_context = new();
+
+            message_converter
+                .Setup(_ => _.GetConnectArguments(first_message))
+                .Returns(first_message_arguments);
+            message_converter
+                .Setup(_ => _.GetArgumentsContext(first_message_arguments))
+                .Returns(first_message_arguments_context);
+            message_converter
+                .Setup(_ => _.GetConnectArguments(second_message))
+                .Returns(second_message_arguments);
+            message_converter
+                .Setup(_ => _.GetArgumentsContext(second_message_arguments))
+                .Returns(second_message_arguments_context);
+
+            wrapped_reader = new(
+                request_id,
+                an_async_stream_reader<a_message>
+                    .that()
+                    .receives(first_message)
+                    .receives(second_message)
+                    .completes(),
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+
+        static ReverseCallArgumentsContext first_result;
+        static ReverseCallArgumentsContext second_result;
+        Because of = () =>
+        {
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            first_result = wrapped_reader.ReverseCallContext.GetAwaiter().GetResult();
+            wrapped_reader.MoveNext(cancellation_token).GetAwaiter().GetResult();
+            second_result = wrapped_reader.ReverseCallContext.GetAwaiter().GetResult();
+        };
+
+        It should_return_the_first_arguments_context_the_first_time = () => first_result.ShouldEqual(first_message_arguments_context);
+        It should_return_the_first_arguments_context_the_second_time = () => second_result.ShouldEqual(first_message_arguments_context);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/given/a_wrapped_stream_writer.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/given/a_wrapped_stream_writer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Grpc.Core;
+using Machine.Specifications;
+using Moq;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.given
+{
+    public class a_wrapped_stream_writer : all_dependencies
+    {
+        protected static Mock<IAsyncStreamWriter<a_message>> original_writer;
+        protected static WrappedAsyncStreamWriter<a_message, a_message, object, object, object, object> wrapped_writer;
+
+        Establish context = () => 
+        {
+            original_writer = new Mock<IAsyncStreamWriter<a_message>>();
+
+            wrapped_writer = new(
+                request_id,
+                original_writer.Object,
+                message_converter.Object,
+                metrics,
+                logger,
+                cancellation_token);
+        };
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_getting_write_options.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_getting_write_options.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Grpc.Core;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter
+{
+    public class when_getting_write_options : given.a_wrapped_stream_writer
+    {
+        static WriteOptions options;
+
+        Establish context = () =>
+        {
+            options = new();
+            original_writer
+                .SetupGet(_ => _.WriteOptions)
+                .Returns(options);
+        };
+
+        static WriteOptions result;
+        Because of = () => result = wrapped_writer.WriteOptions;
+
+        It should_get_the_options_of_the_original_stream = () => original_writer.VerifyGet(_ => _.WriteOptions);
+        It should_return_the_options_from_the_original_stream = () => result.ShouldEqual(options);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_another_write_is_currently_blocking.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_another_write_is_currently_blocking.cs
@@ -27,7 +27,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.wh
         Because of = () =>
         {
             _ = wrapped_writer.WriteAsync(another_message);
-            wrapped_writer.MaybeWritePing().GetAwaiter().GetResult();
+            wrapped_writer.MaybeWritePing();
         };
 
         It should_not_write_the_ping_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(Moq.It.IsAny<a_message>()), Times.Once);

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_another_write_is_currently_blocking.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_another_write_is_currently_blocking.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Dolittle.Services.Contracts;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_pinging
+{
+    public class and_another_write_is_currently_blocking : given.a_wrapped_stream_writer
+    {
+        static a_message another_message;
+
+        Establish context = () =>
+        {
+            another_message = new();
+
+            original_writer
+                .Setup(_ => _.WriteAsync(another_message))
+                .Returns(Task.Delay(Timeout.Infinite));
+        };
+
+        Because of = () =>
+        {
+            _ = wrapped_writer.WriteAsync(another_message);
+            wrapped_writer.MaybeWritePing().GetAwaiter().GetResult();
+        };
+
+        It should_not_write_the_ping_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(Moq.It.IsAny<a_message>()), Times.Once);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_fails.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_fails.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Dolittle.Services.Contracts;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_pinging
+{
+    public class and_writing_fails : given.a_wrapped_stream_writer
+    {
+        static a_message ping_message;
+        static Exception exception;
+
+        Establish context = () =>
+        {
+            exception = new();
+
+            message_converter
+                .Setup(_ => _.SetPing(Moq.It.IsAny<a_message>(), Moq.It.IsAny<Ping>()))
+                .Callback<a_message, Ping>((message, _) => ping_message = message);
+
+            original_writer
+                .Setup(_ => _.WriteAsync(Moq.It.IsAny<a_message>()))
+                .Returns(Task.FromException(exception));
+        };
+
+        static Exception result;
+        Because of = () => result = Catch.Exception(() => wrapped_writer.MaybeWritePing().GetAwaiter().GetResult());
+
+        It should_write_the_ping_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(ping_message));
+        It should_fail_with_the_original_exception = () => result.ShouldEqual(exception);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_fails.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_fails.cs
@@ -28,7 +28,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.wh
         };
 
         static Exception result;
-        Because of = () => result = Catch.Exception(() => wrapped_writer.MaybeWritePing().GetAwaiter().GetResult());
+        Because of = () => result = Catch.Exception(() => wrapped_writer.MaybeWritePing());
 
         It should_write_the_ping_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(ping_message));
         It should_fail_with_the_original_exception = () => result.ShouldEqual(exception);

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_succeeds.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_succeeds.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.wh
                 .Returns(Task.CompletedTask);
         };
 
-        Because of = () => wrapped_writer.MaybeWritePing().GetAwaiter().GetResult();
+        Because of = () => wrapped_writer.MaybeWritePing();
 
         It should_write_the_ping_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(ping_message));
     }

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_succeeds.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_pinging/and_writing_succeeds.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Dolittle.Services.Contracts;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_pinging
+{
+    public class and_writing_succeeds : given.a_wrapped_stream_writer
+    {
+        static a_message ping_message;
+
+        Establish context = () =>
+        {
+            message_converter
+                .Setup(_ => _.SetPing(Moq.It.IsAny<a_message>(), Moq.It.IsAny<Ping>()))
+                .Callback<a_message, Ping>((message, _) => ping_message = message);
+
+            original_writer
+                .Setup(_ => _.WriteAsync(Moq.It.IsAny<a_message>()))
+                .Returns(Task.CompletedTask);
+        };
+
+        Because of = () => wrapped_writer.MaybeWritePing().GetAwaiter().GetResult();
+
+        It should_write_the_ping_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(ping_message));
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_setting_write_options.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_setting_write_options.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Grpc.Core;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter
+{
+    public class when_setting_write_options : given.a_wrapped_stream_writer
+    {
+        static WriteOptions options;
+
+        Establish context = () => options = new();
+
+        Because of = () => wrapped_writer.WriteOptions = options;
+
+        It should_set_the_options_of_the_original_stream = () => original_writer.VerifySet(_ => _.WriteOptions = options);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/and_writing_fails.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/and_writing_fails.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_writing
+{
+    public class and_writing_fails : given.a_wrapped_stream_writer
+    {
+        static a_message message;
+        static Exception exception;
+
+        Establish context = () =>
+        {
+            message = new();
+            exception = new();
+
+            original_writer
+                .Setup(_ => _.WriteAsync(message))
+                .Returns(Task.FromException(exception));
+        };
+
+        static Exception result;
+        Because of = () => result = Catch.Exception(() => wrapped_writer.WriteAsync(message).GetAwaiter().GetResult());
+
+        It should_write_the_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(message));
+        It should_fail_with_the_original_exception = () => result.ShouldEqual(exception);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/and_writing_fails_once_then_succeeds.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/and_writing_fails_once_then_succeeds.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_writing
+{
+    public class and_writing_fails_once_then_succeeds : given.a_wrapped_stream_writer
+    {
+        static a_message first_message;
+        static Exception exception;
+        static a_message second_message;
+
+        Establish context = () =>
+        {
+            first_message = new();
+            exception = new();
+            second_message = new();
+
+            original_writer
+                .Setup(_ => _.WriteAsync(first_message))
+                .Returns(Task.FromException(exception));
+            original_writer
+                .Setup(_ => _.WriteAsync(second_message))
+                .Returns(Task.CompletedTask);
+        };
+
+        static Exception result;
+        Because of = () =>
+        {
+            result = Catch.Exception(() => wrapped_writer.WriteAsync(first_message).GetAwaiter().GetResult());
+            wrapped_writer.WriteAsync(second_message).GetAwaiter().GetResult();
+        };
+
+        It should_write_the_first_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(first_message));
+        It should_fail_with_the_original_exception = () => result.ShouldEqual(exception);
+        It should_write_the_second_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(second_message));
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/and_writing_succeeds.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/and_writing_succeeds.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_writing
+{
+    public class and_writing_succeeds : given.a_wrapped_stream_writer
+    {
+        static a_message message;
+
+        Establish context = () =>
+        {
+            message = new();
+
+            original_writer
+                .Setup(_ => _.WriteAsync(message))
+                .Returns(Task.CompletedTask);
+        };
+
+        Because of = () => wrapped_writer.WriteAsync(message).GetAwaiter().GetResult();
+
+        It should_write_the_message_to_the_original_stream = () => original_writer.Verify(_ => _.WriteAsync(message));
+    }
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/concurrently.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/concurrently.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Services.ReverseCalls.given;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.for_WrappedAsyncStreamWriter.when_writing
+{
+    public class concurrently : given.a_wrapped_stream_writer
+    {
+        static a_message first_message;
+        static a_message second_message;
+        static a_message third_message;
+        static TaskCompletionSource first_message_write;
+        static TaskCompletionSource second_message_write;
+        static TaskCompletionSource third_message_write;
+        static int[] call_order;
+
+        Establish context = () =>
+        {
+            first_message = new();
+            second_message = new();
+            third_message = new();
+
+            first_message_write = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            second_message_write = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            third_message_write = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            call_order = new int[3];
+            var current_call = 1;
+
+            original_writer
+                .Setup(_ => _.WriteAsync(first_message))
+                .Callback(() => call_order[0] = current_call++)
+                .Returns(first_message_write.Task);
+            original_writer
+                .Setup(_ => _.WriteAsync(second_message))
+                .Callback(() => call_order[1] = current_call++)
+                .Returns(second_message_write.Task);
+            original_writer
+                .Setup(_ => _.WriteAsync(third_message))
+                .Callback(() => call_order[2] = current_call++)
+                .Returns(third_message_write.Task);
+        };
+
+        static bool first_write_first_check;
+        static bool second_write_first_check;
+        static bool third_write_first_check;
+        static bool first_write_second_check;
+        static bool second_write_second_check;
+        static bool third_write_second_check;
+        static bool first_write_third_check;
+        static bool second_write_third_check;
+        static bool third_write_third_check;
+
+        Because of = () =>
+        {
+            Task first_write_status = wrapped_writer.WriteAsync(first_message);
+            Task second_write_status = wrapped_writer.WriteAsync(second_message);
+            Task third_write_status = wrapped_writer.WriteAsync(third_message);
+
+            Thread.Sleep(5);
+            first_write_first_check = first_write_status.IsCompleted;
+            second_write_first_check = second_write_status.IsCompleted;
+            third_write_first_check = third_write_status.IsCompleted;
+
+            first_message_write.SetResult();
+            third_message_write.SetResult();
+            Thread.Sleep(5);
+            first_write_second_check = first_write_status.IsCompleted;
+            second_write_second_check = second_write_status.IsCompleted;
+            third_write_second_check = third_write_status.IsCompleted;
+
+            second_message_write.SetResult();
+            Thread.Sleep(5);
+            first_write_third_check = first_write_status.IsCompleted;
+            second_write_third_check = second_write_status.IsCompleted;
+            third_write_third_check = third_write_status.IsCompleted;
+        };
+
+        It should_not_have_completed_any_writes_after_the_first_check = () =>
+        {
+            first_write_first_check.ShouldBeFalse();
+            second_write_first_check.ShouldBeFalse();
+            third_write_first_check.ShouldBeFalse();
+        };
+        It should_have_completed_the_first_after_the_second_check = () =>
+        {
+            first_write_second_check.ShouldBeTrue();
+            second_write_second_check.ShouldBeFalse();
+            third_write_second_check.ShouldBeFalse();
+        };
+        It should_have_completed_all_writes_after_the_third_check = () =>
+        {
+            first_write_third_check.ShouldBeTrue();
+            second_write_third_check.ShouldBeTrue();
+            third_write_third_check.ShouldBeTrue();
+        };
+
+        It should_call_write_on_the_original_stream_in_order = () =>
+        {
+            call_order[0].ShouldEqual(1);
+            call_order[1].ShouldEqual(2);
+            call_order[2].ShouldEqual(3);
+        };
+    }
+}

--- a/Specifications/Services/ReverseCall/given/a_message.cs
+++ b/Specifications/Services/ReverseCall/given/a_message.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using Grpc.Core;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.given
+{
+    public class a_message : IMessage
+    {
+        public MessageDescriptor Descriptor => throw new NotImplementedException();
+
+        public int CalculateSize()
+            => 1;
+
+        public void MergeFrom(CodedInputStream input)
+        {
+        }
+
+        public void WriteTo(CodedOutputStream output)
+        {
+        }
+    }
+}

--- a/Specifications/Services/ReverseCall/given/all_dependencies.cs
+++ b/Specifications/Services/ReverseCall/given/all_dependencies.cs
@@ -1,10 +1,14 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading;
+using Grpc.Core;
 using Machine.Specifications;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using It = Moq.It;
 
 namespace Dolittle.Runtime.Services.ReverseCalls.given
 {
@@ -15,15 +19,22 @@ namespace Dolittle.Runtime.Services.ReverseCalls.given
         protected static ILoggerFactory logger_factory;
         protected static ILogger logger;
         protected static IMetricsCollector metrics;
+        protected static ServerCallContext server_call_context;
         protected static CancellationToken cancellation_token;
 
         Establish context = () =>
         {
             request_id = "request-id";
+
             message_converter = new Mock<IConvertReverseCallMessages<a_message, a_message, object, object, object, object>>();
-            logger_factory = Mock.Of<ILoggerFactory>();
-            logger = Mock.Of<ILogger>();
+
+            logger_factory = NullLoggerFactory.Instance;
+            logger = NullLogger.Instance;
+
             metrics = Mock.Of<IMetricsCollector>();
+
+            server_call_context = Mock.Of<ServerCallContext>();
+
             cancellation_token = CancellationToken.None;
         };
     }

--- a/Specifications/Services/ReverseCall/given/all_dependencies.cs
+++ b/Specifications/Services/ReverseCall/given/all_dependencies.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using Machine.Specifications;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.given
+{
+    public class all_dependencies
+    {
+        protected static RequestId request_id;
+        protected static Mock<IConvertReverseCallMessages<a_message, a_message, object, object, object, object>> message_converter;
+        protected static ILoggerFactory logger_factory;
+        protected static ILogger logger;
+        protected static IMetricsCollector metrics;
+        protected static CancellationToken cancellation_token;
+
+        Establish context = () =>
+        {
+            request_id = "request-id";
+            message_converter = new Mock<IConvertReverseCallMessages<a_message, a_message, object, object, object, object>>();
+            logger_factory = Mock.Of<ILoggerFactory>();
+            logger = Mock.Of<ILogger>();
+            metrics = Mock.Of<IMetricsCollector>();
+            cancellation_token = CancellationToken.None;
+        };
+    }
+}

--- a/Specifications/Services/ReverseCall/given/an_async_stream_reader.cs
+++ b/Specifications/Services/ReverseCall/given/an_async_stream_reader.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Dolittle.Runtime.Services.ReverseCalls.given
+{
+    public class an_async_stream_reader<T> : IAsyncStreamReader<T>
+    {
+        readonly List<Task<Tuple<bool, T>>> _messages_to_receive = new();
+        int _message_pointer;
+
+        private an_async_stream_reader()
+        {
+        }
+
+        public T Current { get; private set; }
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            if (_message_pointer > _messages_to_receive.Count)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return false;
+            }
+
+            var result = await _messages_to_receive[_message_pointer].ConfigureAwait(false);
+            _message_pointer ++;
+            Current = result.Item2;
+
+            return result.Item1;
+        }
+
+        public static an_async_stream_reader<T> that()
+            => new();
+
+        public an_async_stream_reader<T> receives(T message)
+        {
+            _messages_to_receive.Add(Task.FromResult(new Tuple<bool, T>(true, message)));
+            return this;
+        }
+
+        public an_async_stream_reader<T> completes()
+        {
+            _messages_to_receive.Add(Task.FromResult(new Tuple<bool, T>(false, default)));
+            return this;
+        }
+
+        public an_async_stream_reader<T> throws(Exception exception)
+        {
+            _messages_to_receive.Add(Task.FromException<Tuple<bool, T>>(exception));
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
We have already merged the interfaces so we could continue other work - sorry about that. Bat all the files have been changed here, so if you just look at the files (and ignore what GitHub says has been changed) you'll see what is new.

There are a few pieces still missing for this to work properly, that we can do later:
- Implement the `IKeepConnectionsAlive` interface (which is just a factory that will take some dependencies and pass them to the pinged connections).
- Implement and bind the `IMetricsCollector` (we can do a null implementation for now).

I purposefully did not bind the `TokenSourceDeadline` class to the interface, as I seem to recall we have issues with DI and disposables?

Also, a lot of specs for PingedConnection still missing - but it makes more sense to do that once the callback timer interface is ready.