### PR TITLE
Fix bug in: Refactor out ping handling

### DIFF
--- a/Source/Services/ReverseCalls/WrappedAsyncStreamWriter.cs
+++ b/Source/Services/ReverseCalls/WrappedAsyncStreamWriter.cs
@@ -89,10 +89,16 @@ namespace Dolittle.Runtime.Services.ReverseCalls
 
                 await _writeLock.WaitAsync(_cancellationToken).ConfigureAwait(false);
 
-                stopwatch.Stop();
-                _metrics.DecrementPendingStreamWrites();
-                _metrics.AddToTotalStreamWriteWaitTime(stopwatch.Elapsed);
-                _logger.WritingMessageUnblockedAfter(_requestId, typeof(TServerMessage), stopwatch.Elapsed);
+                try
+                {
+                    stopwatch.Stop();
+                    _metrics.DecrementPendingStreamWrites();
+                    _metrics.AddToTotalStreamWriteWaitTime(stopwatch.Elapsed);
+                    _logger.WritingMessageUnblockedAfter(_requestId, typeof(TServerMessage), stopwatch.Elapsed);
+                }
+                catch
+                {
+                }
             }
 
             try


### PR DESCRIPTION
In the previous PR there was a problem with locks potentially being left locked by exceptions.

The easiest way I found to fix it was just ignore logging and metrics issues, and continue with the write as if nothing happened.