### PR TITLE
Add request identifier for services

### DIFF
--- a/Source/Services/Bindings.cs
+++ b/Source/Services/Bindings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.DependencyInversion;
+
+namespace Dolittle.Runtime.Services
+{
+    /// <summary>
+    /// Represents a <see cref="ICanProvideBindings">binding provider</see> for services.
+    /// </summary>
+    public class Bindings : ICanProvideBindings
+    {
+        /// <inheritdoc/>
+        public void Provide(IBindingProviderBuilder builder)
+        {
+            builder.Bind<IIdentifyRequests>().To<HeaderRequestIdentifier>();
+        }
+    }
+}

--- a/Source/Services/HeaderRequestIdentifier.cs
+++ b/Source/Services/HeaderRequestIdentifier.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Grpc.Core;
+
+namespace Dolittle.Runtime.Services
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="IIdentifyRequests"/> that looks for an 'X-Request-ID' HTTP header, or generates a new random request id.
+    /// </summary>
+    public class HeaderRequestIdentifier : IIdentifyRequests
+    {
+        const string X_REQUEST_ID_HEADER_LOWERCASE = "x-request-id";
+
+        /// <inheritdoc/>
+        public RequestId GetRequestIdFor(ServerCallContext callContext)
+        {
+            foreach (var header in callContext.RequestHeaders)
+            {
+                if (!header.IsBinary && header.Key.ToLowerInvariant() == X_REQUEST_ID_HEADER_LOWERCASE)
+                {
+                    return header.Value;
+                }
+            }
+
+            return RequestId.Generate();
+        }
+    }
+}

--- a/Source/Services/IIdentifyRequests.cs
+++ b/Source/Services/IIdentifyRequests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Grpc.Core;
+
+namespace Dolittle.Runtime.Services
+{
+    /// <summary>
+    /// Defines a system that uniquely identifies service requests by assigning an unique <see cref="RequestId"/> to each request.
+    /// </summary>
+    public interface IIdentifyRequests
+    {
+        /// <summary>
+        /// Get the <see cref="RequestId"/> identifying a request from the corresponding <see cref="ServerCallContext"/>.
+        /// </summary>
+        /// <param name="callContext">The <see cref="ServerCallContext"/> of the request to identify.</param>
+        /// <returns>An identifier that identifies the request.</returns>
+        RequestId GetRequestIdFor(ServerCallContext callContext);
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/given/MockServerCallContext.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/given/MockServerCallContext.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.given
+{
+    public class MockServerCallContext : ServerCallContext
+    {
+        protected override Metadata RequestHeadersCore { get; } = new();
+        protected override string MethodCore
+            => throw new NotImplementedException();
+
+        protected override string HostCore
+            => throw new NotImplementedException();
+
+        protected override string PeerCore
+            => throw new NotImplementedException();
+
+        protected override DateTime DeadlineCore
+            => throw new NotImplementedException();
+
+        protected override CancellationToken CancellationTokenCore
+             => throw new NotImplementedException();
+
+        protected override Metadata ResponseTrailersCore
+             => throw new NotImplementedException();
+
+        protected override Status StatusCore
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        protected override WriteOptions WriteOptionsCore
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        protected override AuthContext AuthContextCore
+            => throw new NotImplementedException();
+
+        protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions options)
+            => throw new NotImplementedException();
+
+        protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders)
+            => throw new NotImplementedException();
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/given/an_identifier_and_a_call_context.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/given/an_identifier_and_a_call_context.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Grpc.Core;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.given
+{
+    public class an_identifier_and_a_call_context
+    {
+        protected static HeaderRequestIdentifier identifier;
+        protected static ServerCallContext call_context;
+
+        Establish context = () =>
+        {
+            identifier = new HeaderRequestIdentifier();
+
+            call_context = new MockServerCallContext();
+        };
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_does_not_have_id_header/but_has_a_binary_header.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_does_not_have_id_header/but_has_a_binary_header.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.when_getting_request_id_for.and_request_does_not_have_id_header
+{
+    public class but_has_a_binary_header : given.an_identifier_and_a_call_context
+    {
+        Establish context = () =>
+        {
+            call_context.RequestHeaders.Add("X-Request-ID-bin", Encoding.UTF8.GetBytes("M589apGPsYYmvXQpWk3m"));
+        };
+
+        static RequestId result;
+        Because of = () => result = identifier.GetRequestIdFor(call_context);
+
+        It should_return_a_non_empty_request_id = () => result.Value.Length.ShouldBeGreaterThan(0);
+        It should_not_have_the_content_of_the_binary_header = () => result.Value.ShouldNotEqual("M589apGPsYYmvXQpWk3m");
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_does_not_have_id_header/multiple_times.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_does_not_have_id_header/multiple_times.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.when_getting_request_id_for.and_request_does_not_have_id_header
+{
+    public class multiple_times : given.an_identifier_and_a_call_context
+    {
+        Establish context = () =>
+        {
+            call_context.RequestHeaders.Add("X-Request-ID-", "lU6dVasyXMzXUapqTWv");
+            call_context.RequestHeaders.Add("Other-Header", "Xq9IxGf6lVbDQiSykaVU");
+        };
+
+        static RequestId first_result;
+        static RequestId second_result;
+        static RequestId third_result;
+        Because of = () =>
+        {
+            first_result = identifier.GetRequestIdFor(call_context);
+            second_result = identifier.GetRequestIdFor(call_context);
+            third_result = identifier.GetRequestIdFor(call_context);
+        };
+
+        It should_return_a_non_empty_request_id_the_first_time = () => first_result.Value.Length.ShouldBeGreaterThan(0);
+        It should_return_a_non_empty_request_id_the_second_time = () => second_result.Value.Length.ShouldBeGreaterThan(0);
+        It should_return_a_non_empty_request_id_the_third_time = () => third_result.Value.Length.ShouldBeGreaterThan(0);
+        It should_return_a_different_id_the_first_and_second_time = () => first_result.ShouldNotEqual(second_result);
+        It should_return_a_different_id_the_first_and_third_time = () => first_result.ShouldNotEqual(third_result);
+        It should_return_a_different_id_the_second_and_third_time = () => second_result.ShouldNotEqual(third_result);
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_does_not_have_id_header/once.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_does_not_have_id_header/once.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.when_getting_request_id_for.and_request_does_not_have_id_header
+{
+    public class once : given.an_identifier_and_a_call_context
+    {
+        Establish context = () =>
+        {
+            call_context.RequestHeaders.Add("X-Request-ID-", "JVek8zo52uqFKvAXdHc");
+            call_context.RequestHeaders.Add("Other-Header", "TO5KFlZX3WH1vYf6EH16");
+        };
+
+        static RequestId result;
+        Because of = () => result = identifier.GetRequestIdFor(call_context);
+
+        It should_return_a_non_empty_request_id = () => result.Value.Length.ShouldBeGreaterThan(0);
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_has_id_header/multiple_times.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_has_id_header/multiple_times.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.when_getting_request_id_for.and_request_has_id_header
+{
+    public class multiple_times : given.an_identifier_and_a_call_context
+    {
+        Establish context = () =>
+        {
+            call_context.RequestHeaders.Add("X-Request-ID", "LcDX3TNcXUObGuBe10fG");
+        };
+
+        static RequestId first_result;
+        static RequestId second_result;
+        static RequestId third_result;
+        Because of = () =>
+        {
+            first_result = identifier.GetRequestIdFor(call_context);
+            second_result = identifier.GetRequestIdFor(call_context);
+            third_result = identifier.GetRequestIdFor(call_context);
+        };
+
+        It should_return_the_value_of_the_header_the_first_time = () => first_result.Value.ShouldEqual("LcDX3TNcXUObGuBe10fG");
+        It should_return_the_value_of_the_header_the_second_time = () => second_result.Value.ShouldEqual("LcDX3TNcXUObGuBe10fG");
+        It should_return_the_value_of_the_header_the_third_time = () => third_result.Value.ShouldEqual("LcDX3TNcXUObGuBe10fG");
+    }
+}

--- a/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_has_id_header/once.cs
+++ b/Specifications/Services/for_HeaderRequestIdentifier/when_getting_request_id_for/and_request_has_id_header/once.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Machine.Specifications;
+
+namespace Dolittle.Runtime.Services.for_HeaderRequestIdentifier.when_getting_request_id_for.and_request_has_id_header
+{
+    public class once : given.an_identifier_and_a_call_context
+    {
+        Establish context = () =>
+        {
+            call_context.RequestHeaders.Add("X-Request-ID", "cv8a5w0dt8oHiW2q5NFb");
+            call_context.RequestHeaders.Add("X-Request-ID-", "BT0Nr1M2pbWYwIJqJU3");
+            call_context.RequestHeaders.Add("Other-Header", "LSJtEzVgVgxoXJHz8MHd");
+        };
+
+        static RequestId result;
+        Because of = () => result = identifier.GetRequestIdFor(call_context);
+
+        It should_return_the_value_of_the_header = () => result.Value.ShouldEqual("cv8a5w0dt8oHiW2q5NFb");
+    }
+}


### PR DESCRIPTION
Adds a little implementation that gets or generates a request id from the server call context. If it is present in X-Request-ID (case invariant matching) - that will be used, otherwise a random GUID is generated. We could use that header from the SDK in the future, and it is also the header that NGINX will set when used as a proxy.

This is to be used in the reverse call gRPC services.