### PR TITLE
Hook up pinged connection

### DIFF
--- a/Source/Services/ReverseCalls/Bindings.cs
+++ b/Source/Services/ReverseCalls/Bindings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.DependencyInversion;
+
+namespace Dolittle.Runtime.Services.ReverseCalls
+{
+    /// <summary>
+    /// Represents a <see cref="ICanProvideBindings">binding provider</see> for services.
+    /// </summary>
+    public class Bindings : ICanProvideBindings
+    {
+        /// <inheritdoc/>
+        public void Provide(IBindingProviderBuilder builder)
+        {
+            builder.Bind<IKeepConnectionsAlive>().To<PingedConnectionFactory>();
+        }
+    }
+}

--- a/Source/Services/ReverseCalls/IMetricsCollector.cs
+++ b/Source/Services/ReverseCalls/IMetricsCollector.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace Dolittle.Runtime.Services.ReverseCalls
 {
+    /// <summary>
+    /// Defines a system for collecting metrics about reverse calls.
+    /// </summary>
     public interface IMetricsCollector
     {
         void IncrementPendingStreamWrites();

--- a/Source/Services/ReverseCalls/MetricsCollector.cs
+++ b/Source/Services/ReverseCalls/MetricsCollector.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.Runtime.Services.ReverseCalls
+{
+    /// <summary>
+    /// Represents an implementatino of <see cref="IMetricsCollector"/>.
+    /// </summary>
+    public class MetricsCollector : IMetricsCollector
+    {
+        /// <inheritdoc/>
+        public void AddToTotalStreamWriteTime(TimeSpan writeTime)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void AddToTotalStreamWriteWaitTime(TimeSpan waitTime)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void AddToTotalWaitForFirstMessageTime(TimeSpan waitTime)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void AddToTotalWaitForPingStarterToCompleteTime(TimeSpan waitTime)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void DecrementPendingStreamWrites()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementPendingStreamWrites()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalKeepaliveTimeouts()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalKeepaliveTokenResets()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalPingsSent()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalPongsReceived()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalStreamReadBytes(int writtenBytes)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalStreamReads()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalStreamWriteBytes(int writtenBytes)
+        {
+        }
+
+        /// <inheritdoc/>
+        public void IncrementTotalStreamWrites()
+        {
+        }
+    }
+}

--- a/Source/Services/ReverseCalls/PingedConnectionFactory.cs
+++ b/Source/Services/ReverseCalls/PingedConnectionFactory.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Google.Protobuf;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.Runtime.Services.ReverseCalls
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="IKeepConnectionsAlive"/>.
+    /// </summary>
+    public class PingedConnectionFactory : IKeepConnectionsAlive
+    {
+        readonly ICallbackScheduler _callbackScheduler;
+        readonly IMetricsCollector _metricsCollector;
+        readonly ILoggerFactory _loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PingedConnectionFactory"/> class.
+        /// </summary>
+        /// <param name="callbackScheduler">The callback scheduler to use for scheduling pings.</param>
+        /// <param name="metricsCollector">The metrics collector to use for metrics about pinged reverse call connections.</param>
+        /// <param name="loggerFactory">The logger factory to use to create loggers.</param>
+        public PingedConnectionFactory(ICallbackScheduler callbackScheduler, IMetricsCollector metricsCollector, ILoggerFactory loggerFactory)
+        {
+            _callbackScheduler = callbackScheduler;
+            _metricsCollector = metricsCollector;
+            _loggerFactory = loggerFactory;
+        }
+
+        /// <inheritdoc/>
+        public IPingedConnection<TClientMessage, TServerMessage> CreatePingedReverseCallConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+                RequestId requestId,
+                IAsyncStreamReader<TClientMessage> runtimeStream,
+                IAsyncStreamWriter<TServerMessage> clientStream,
+                ServerCallContext context,
+                IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> messageConverter)
+            where TClientMessage : IMessage, new()
+            where TServerMessage : IMessage, new()
+            where TConnectArguments : class
+            where TConnectResponse : class
+            where TRequest : class
+            where TResponse : class
+            => new PingedConnection<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>(
+                requestId,
+                runtimeStream,
+                clientStream,
+                context,
+                messageConverter,
+                new TokenSourceDeadline(),
+                _callbackScheduler,
+                _metricsCollector,
+                _loggerFactory);
+    }
+}

--- a/Specifications/Services/ReverseCall/for_PingedConnection/given/Scenario.cs
+++ b/Specifications/Services/ReverseCall/for_PingedConnection/given/Scenario.cs
@@ -133,6 +133,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given
             _readMessageException = new(-1, null);
 
             var fakeKeepaliveDeadline = new SimulatedKeepaliveDeadline(this);
+            var fakeCallbackScheduler = new SimulatedCallbackScheduler(this);
 
             var connection = new PingedConnection<a_message, a_message, object, object, object, object>(
                 requestId,
@@ -141,6 +142,7 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given
                 context,
                 messageConverter,
                 fakeKeepaliveDeadline,
+                fakeCallbackScheduler,
                 metrics,
                 loggerFactory);
 
@@ -215,6 +217,17 @@ namespace Dolittle.Runtime.Services.ReverseCalls.for_PingedConnection.given
             public void RefreshDeadline(TimeSpan nextRefreshBefore)
             {
                 // TODO: Implement with fake time
+            }
+        }
+
+        class SimulatedCallbackScheduler : ICallbackScheduler
+        {
+            readonly Scenario _scenario;
+            public SimulatedCallbackScheduler(Scenario scenario) => _scenario = scenario;
+            public IDisposable ScheduleCallback(Action callback, TimeSpan interval)
+            {
+                // TODO: Implement with fake time
+                return null;
             }
         }
 


### PR DESCRIPTION
- Used ICallbackScheduler for scheduling pings in the PingedConnection
- Created a binding for IMetricsCollector that doesn't do anything for now (we need to figure out a good metric naming strategy)
- Implemented and bound up the IKeepConnectionsAlive

There is still a lot of specs missing for PingedConnection, but we may need to get back to that...