### PR TITLE
Clean up unregistering and cancelling of stream processors

### DIFF
--- a/Source/EventHorizon/Consumer/EventHorizonConnection.cs
+++ b/Source/EventHorizon/Consumer/EventHorizonConnection.cs
@@ -30,7 +30,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
         readonly CancellationTokenSource _cancellationTokenSource = new();
         readonly TaskCompletionSource<SubscriptionResponse> _firstSubscriptionResponse = new(TaskCreationOptions.RunContinuationsAsynchronously);
         bool _is_first_connection = true;
-        bool disposed;
+        bool _disposed;
 
         public EventHorizonConnection(
             SubscriptionId subscription,
@@ -101,7 +101,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposed)
+            if (_disposed)
             {
                 return;
             }
@@ -113,7 +113,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
                 _firstSubscriptionResponse.TrySetCanceled();
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         IEventHorizonProcessor SetupEventHorizon(CancellationToken cancellationToken)

--- a/Source/EventHorizon/Consumer/Processing/StreamProcessor.cs
+++ b/Source/EventHorizon/Consumer/Processing/StreamProcessor.cs
@@ -65,7 +65,6 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Processing
         /// </summary>
         public ConsentId ConsentId { get; }
 
-
         /// <inheritdoc/>
         public async Task<Try<bool>> TryStartAndWait(CancellationToken cancellationToken)
         {

--- a/Source/Events.Processing/Streams/StreamProcessor.cs
+++ b/Source/Events.Processing/Streams/StreamProcessor.cs
@@ -29,9 +29,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         readonly FactoryFor<ICreateScopedStreamProcessors> _getScopedStreamProcessorsCreator;
         readonly IExecutionContextManager _executionContextManager;
         readonly ILogger<StreamProcessor> _logger;
-        readonly CancellationToken _externalCancellationToken;
-        readonly CancellationTokenSource _internalCancellationTokenSource;
-        readonly CancellationTokenRegistration _unregisterTokenRegistration;
+        readonly CancellationTokenSource _stopAllScopedStreamProcessorsTokenSource;
         bool _initialized;
         bool _started;
         bool _disposed;
@@ -67,9 +65,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
             _getScopedStreamProcessorsCreator = getScopedStreamProcessorsCreator;
             _executionContextManager = executionContextManager;
             _logger = logger;
-            _internalCancellationTokenSource = new CancellationTokenSource();
-            _externalCancellationToken = cancellationToken;
-            _unregisterTokenRegistration = _externalCancellationToken.Register(_unregister);
+            _stopAllScopedStreamProcessorsTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         }
 
         /// <summary>
@@ -79,8 +75,14 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         public async Task Initialize()
         {
             _logger.InitializingStreamProcessor(_identifier);
-            _externalCancellationToken.ThrowIfCancellationRequested();
-            if (_initialized) throw new StreamProcessorAlreadyInitialized(_identifier);
+
+            _stopAllScopedStreamProcessorsTokenSource.Token.ThrowIfCancellationRequested();
+            if (_initialized)
+            {
+                throw new StreamProcessorAlreadyInitialized(_identifier);
+            }
+            _initialized = true;
+
             await _onAllTenants.PerformAsync(async tenant =>
                 {
                     var scopedStreamProcessorsCreators = _getScopedStreamProcessorsCreator();
@@ -88,10 +90,9 @@ namespace Dolittle.Runtime.Events.Processing.Streams
                         _streamDefinition,
                         _identifier,
                         _getEventProcessor(),
-                        _externalCancellationToken).ConfigureAwait(false);
+                        _stopAllScopedStreamProcessorsTokenSource.Token).ConfigureAwait(false);
                     _streamProcessors.Add(tenant, scopedStreamProcessor);
                 }).ConfigureAwait(false);
-            _initialized = true;
         }
 
         /// <summary>
@@ -101,21 +102,28 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         public async Task Start()
         {
             _logger.StartingStreamProcessor(_identifier);
-            if (!_initialized) throw new StreamProcessorNotInitialized(_identifier);
-            if (_started) throw new StreamProcessorAlreadyProcessingStream(_identifier);
+
+            if (!_initialized)
+            {
+                throw new StreamProcessorNotInitialized(_identifier);
+            }
+
+            if (_started)
+            {
+                throw new StreamProcessorAlreadyProcessingStream(_identifier);
+            }
+
             _started = true;
-            _unregisterTokenRegistration.Dispose();
             try
             {
-                using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_internalCancellationTokenSource.Token, _externalCancellationToken);
-                var tasks = StartScopedStreamProcessors(linkedTokenSource.Token);
+                var tasks = StartScopedStreamProcessors(_stopAllScopedStreamProcessorsTokenSource.Token);
                 await Task.WhenAny(tasks).ConfigureAwait(false);
                 if (TryGetException(tasks, out var ex))
                 {
                     _logger.ScopedStreamProcessorFailed(ex, _identifier);
                 }
 
-                _internalCancellationTokenSource.Cancel();
+                _stopAllScopedStreamProcessorsTokenSource.Cancel();
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             finally
@@ -138,12 +146,16 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         protected virtual void Dispose(bool disposing)
         {
             if (_disposed) return;
-            if (!_internalCancellationTokenSource.IsCancellationRequested) _internalCancellationTokenSource.Cancel();
-            if (!_started && !_externalCancellationToken.IsCancellationRequested) _unregister();
+
             if (disposing)
             {
-                _internalCancellationTokenSource.Dispose();
-                _unregisterTokenRegistration.Dispose();
+                _stopAllScopedStreamProcessorsTokenSource.Cancel();
+                _stopAllScopedStreamProcessorsTokenSource.Dispose();
+
+                if (!_started)
+                {
+                    _unregister();
+                }
             }
 
             _disposed = true;
@@ -155,7 +167,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
                     (var tenant, var streamProcessor) = _;
                     _executionContextManager.CurrentFor(tenant);
                     await streamProcessor.Start(cancellationToken).ConfigureAwait(false);
-                })).ToList();
+                }, cancellationToken)).ToList();
 
         static bool TryGetException(IEnumerable<Task> tasks, out Exception exception)
         {

--- a/Source/Events.Processing/Streams/StreamProcessors.cs
+++ b/Source/Events.Processing/Streams/StreamProcessors.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using Dolittle.Runtime.DependencyInversion;
@@ -9,8 +8,8 @@ using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Execution;
 using Dolittle.Runtime.Lifecycle;
-using Microsoft.Extensions.Logging;
 using Dolittle.Runtime.Tenancy;
+using Microsoft.Extensions.Logging;
 
 namespace Dolittle.Runtime.Events.Processing.Streams
 {
@@ -88,8 +87,13 @@ namespace Dolittle.Runtime.Events.Processing.Streams
 
         void Unregister(StreamProcessorId id)
         {
+            StreamProcessor existing;
+            do
+            {
+                _streamProcessors.TryRemove(id, out existing);
+            }
+            while (existing != default);
             _logger.StreamProcessorUnregistered(id);
-            _streamProcessors.TryRemove(id, out var _);
         }
     }
 }


### PR DESCRIPTION
We have issues with stream processors not being unregistered. This is an attempt to make the code more robust and correct.