### PR TITLE
Set correct event source

### DIFF
--- a/Source/Embeddings.Processing/Embedding.cs
+++ b/Source/Embeddings.Processing/Embedding.cs
@@ -141,11 +141,11 @@ namespace Dolittle.Runtime.Embeddings.Processing
         UncommittedEvents ToUncommittedEvents(IEnumerable<Events.Contracts.UncommittedEvent> events)
             => new(
                 new ReadOnlyCollection<UncommittedEvent>(events.Select(_ =>
-                    new UncommittedEvent
-                    (_.EventSourceId.ToGuid(),
-                    new Artifact(_.Artifact.Id.ToGuid(),
-                    _.Artifact.Generation),
-                    _.Public,
-                    _.Content)).ToList()));
+                    new UncommittedEvent(
+                        EventSourceId.NotSet,
+                        new Artifact(_.Artifact.Id.ToGuid(),
+                        _.Artifact.Generation),
+                        _.Public,
+                        _.Content)).ToList()));
     }
 }

--- a/Source/Embeddings.Processing/EmbeddingProcessorFactory.cs
+++ b/Source/Embeddings.Processing/EmbeddingProcessorFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.DependencyInversion;
 using Dolittle.Runtime.Embeddings.Store;
@@ -98,7 +97,13 @@ namespace Dolittle.Runtime.Embeddings.Processing
             EmbeddingId embeddingId,
             IEmbedding embedding,
             IProjectManyEvents projectManyEvents)
-            => new(embeddingId, embedding, projectManyEvents, _stateComparer, _embeddingLoopDetector);
+            => new(
+                embeddingId,
+                embedding,
+                projectManyEvents,
+                _stateComparer,
+                _embeddingLoopDetector,
+                _projectionKeysConverter);
 
         ProjectManyEvents CreateProjectManyEvents(
             EmbeddingId embeddingId,

--- a/Source/Embeddings.Processing/StateTransitionEventsCalculator.cs
+++ b/Source/Embeddings.Processing/StateTransitionEventsCalculator.cs
@@ -24,6 +24,7 @@ namespace Dolittle.Runtime.Embeddings.Processing
         readonly IProjectManyEvents _projector;
         readonly ICompareStates _stateComparer;
         readonly IDetectEmbeddingLoops _loopDetector;
+        readonly IConvertProjectionKeysToEventSourceIds _keyToEventSourceConverter;
 
         /// <summary>
         /// Initializes an instance of the <see cref="StateTransitionEventsCalculator" /> class.
@@ -33,19 +34,21 @@ namespace Dolittle.Runtime.Embeddings.Processing
         /// <param name="projector">The <see cref="IProjectManyEvents"/>.</param>
         /// <param name="stateComparer">The <see cref="ICompareStates"/>.</param>
         /// <param name="loopDetector">The <see cref="IDetectEmbeddingLoops"/>.</param>
+        /// <param name="keyToEventSourceConverter">The <see cref="IConvertProjectionKeysToEventSourceIds"/>.</param>
         public StateTransitionEventsCalculator(
             EmbeddingId identifier,
             IEmbedding embedding,
             IProjectManyEvents projector,
             ICompareStates stateComparer,
-            IDetectEmbeddingLoops loopDetector
-        )
+            IDetectEmbeddingLoops loopDetector,
+            IConvertProjectionKeysToEventSourceIds keyToEventSourceConverter)
         {
             _identifier = identifier;
             _embedding = embedding;
             _projector = projector;
             _stateComparer = stateComparer;
             _loopDetector = loopDetector;
+            _keyToEventSourceConverter = keyToEventSourceConverter;
         }
 
         /// <inheritdoc/>
@@ -137,6 +140,10 @@ namespace Dolittle.Runtime.Embeddings.Processing
         }
 
         UncommittedAggregateEvents CreateUncommittedAggregateEvents(UncommittedEvents events, EmbeddingCurrentState currentState)
-            => new(_identifier.Value, new Artifact(_identifier.Value, ArtifactGeneration.First), currentState.Version, events);
+            => new(
+                _keyToEventSourceConverter.GetEventSourceIdFor(currentState.Key),
+                new Artifact(_identifier.Value, ArtifactGeneration.First),
+                currentState.Version,
+                events);
     }
 }

--- a/Source/Embeddings.Processing/StateTransitionEventsCalculator.cs
+++ b/Source/Embeddings.Processing/StateTransitionEventsCalculator.cs
@@ -102,15 +102,15 @@ namespace Dolittle.Runtime.Embeddings.Processing
                         return CreateUncommittedAggregateEvents(new UncommittedEvents(events.ToArray()), current);
                     }
 
-                    var transitionEvents = await getTransitionEvents(current, cancellationToken).ConfigureAwait(false);
-                    if (!transitionEvents.Success)
+                    var newTransitionEvents = await getTransitionEvents(current, cancellationToken).ConfigureAwait(false);
+                    if (!newTransitionEvents.Success)
                     {
-                        return transitionEvents.Exception;
+                        return newTransitionEvents.Exception;
                     }
 
-                    allTransitionEvents.Add(transitionEvents.Result);
+                    allTransitionEvents.Add(newTransitionEvents.Result);
 
-                    var intermediateState = await _projector.TryProject(current, transitionEvents.Result, cancellationToken).ConfigureAwait(false);
+                    var intermediateState = await _projector.TryProject(current, newTransitionEvents.Result, cancellationToken).ConfigureAwait(false);
                     if (!intermediateState.Success)
                     {
                         return intermediateState.IsPartialResult

--- a/Specifications/Embeddings.Processing/for_Embedding/when_comparing/and_the_embedding_returns/an_embedding_compare_response.cs
+++ b/Specifications/Embeddings.Processing/for_Embedding/when_comparing/and_the_embedding_returns/an_embedding_compare_response.cs
@@ -60,7 +60,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_Embedding.when_comparing.an
             var events = result.Result;
             events.Count.ShouldEqual(1);
             events[0].Content.ShouldEqual(pb_uncommitted_event.Content);
-            events[0].EventSource.Value.ShouldEqual(pb_uncommitted_event.EventSourceId.ToGuid());
+            events[0].EventSource.ShouldEqual(EventSourceId.NotSet);
             events[0].Public.ShouldEqual(pb_uncommitted_event.Public);
             events[0].Type.Id.Value.ShouldEqual(pb_uncommitted_event.Artifact.Id.ToGuid());
             events[0].Type.Generation.Value.ShouldEqual(pb_uncommitted_event.Artifact.Generation);

--- a/Specifications/Embeddings.Processing/for_Embedding/when_deleting/and_the_embedding_returns/an_embedding_delete_response.cs
+++ b/Specifications/Embeddings.Processing/for_Embedding/when_deleting/and_the_embedding_returns/an_embedding_delete_response.cs
@@ -60,7 +60,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_Embedding.when_deleting.and
             var events = result.Result;
             events.Count.ShouldEqual(1);
             events[0].Content.ShouldEqual(pb_uncommitted_event.Content);
-            events[0].EventSource.Value.ShouldEqual(pb_uncommitted_event.EventSourceId.ToGuid());
+            events[0].EventSource.ShouldEqual(EventSourceId.NotSet);
             events[0].Public.ShouldEqual(pb_uncommitted_event.Public);
             events[0].Type.Id.Value.ShouldEqual(pb_uncommitted_event.Artifact.Id.ToGuid());
             events[0].Type.Generation.Value.ShouldEqual(pb_uncommitted_event.Artifact.Generation);

--- a/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/given/all_dependencies.cs
+++ b/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/given/all_dependencies.cs
@@ -16,6 +16,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
         protected static Mock<ICompareStates> state_comparer;
         protected static Mock<IDetectEmbeddingLoops> loop_detector;
         protected static StateTransitionEventsCalculator calculator;
+        protected static IConvertProjectionKeysToEventSourceIds key_to_event_source_converter;
         protected static CancellationToken cancellation;
 
         Establish context = () =>
@@ -25,8 +26,9 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
             project_many_events = new Mock<IProjectManyEvents>(MockBehavior.Strict);
             state_comparer = new Mock<ICompareStates>(MockBehavior.Strict);
             loop_detector = new Mock<IDetectEmbeddingLoops>(MockBehavior.Strict);
-            calculator = new StateTransitionEventsCalculator(identifier, embedding.Object, project_many_events.Object, state_comparer.Object, loop_detector.Object);
+            key_to_event_source_converter = new ProjectionKeyToEventSourceIdConverter();
             cancellation = CancellationToken.None;
+            calculator = new StateTransitionEventsCalculator(identifier, embedding.Object, project_many_events.Object, state_comparer.Object, loop_detector.Object);
         };
     }
 }

--- a/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/given/all_dependencies.cs
+++ b/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/given/all_dependencies.cs
@@ -28,7 +28,13 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
             loop_detector = new Mock<IDetectEmbeddingLoops>(MockBehavior.Strict);
             key_to_event_source_converter = new ProjectionKeyToEventSourceIdConverter();
             cancellation = CancellationToken.None;
-            calculator = new StateTransitionEventsCalculator(identifier, embedding.Object, project_many_events.Object, state_comparer.Object, loop_detector.Object);
+            calculator = new StateTransitionEventsCalculator(
+                identifier,
+                embedding.Object,
+                project_many_events.Object,
+                state_comparer.Object,
+                loop_detector.Object,
+                key_to_event_source_converter);
         };
     }
 }

--- a/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_converging/and_desired_state_is_reached_after_one_compare.cs
+++ b/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_converging/and_desired_state_is_reached_after_one_compare.cs
@@ -54,7 +54,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
         It should_not_project_anything_else = () => project_many_events.VerifyNoOtherCalls();
         It should_return_the_same_events = () => result.Result.ShouldContainOnly(events);
         It should_return_uncommitted_events_with_correct_aggregate_root_id = () => result.Result.AggregateRoot.Id.Value.ShouldEqual(identifier.Value);
-        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.Value.ShouldEqual(identifier.Value);
+        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.ShouldEqual(key_to_event_source_converter.GetEventSourceIdFor(current_state.Key));
         It should_return_uncommitted_events_with_correct_aggregate_root_version = () => result.Result.ExpectedAggregateRootVersion.Value.ShouldEqual<ulong>(1);
     }
 }

--- a/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_converging/and_desired_state_is_reached_after_second_compare.cs
+++ b/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_converging/and_desired_state_is_reached_after_second_compare.cs
@@ -76,7 +76,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
         It should_not_project_anything_else = () => project_many_events.VerifyNoOtherCalls();
         It should_return_all_the_same_events = () => result.Result.ShouldContainOnly(first_event_batch.Concat(second_event_batch));
         It should_return_uncommitted_events_with_correct_aggregate_root_id = () => result.Result.AggregateRoot.Id.Value.ShouldEqual(identifier.Value);
-        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.Value.ShouldEqual(identifier.Value);
+        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.ShouldEqual(key_to_event_source_converter.GetEventSourceIdFor(current_state.Key));
         It should_return_uncommitted_events_with_correct_aggregate_root_version = () => result.Result.ExpectedAggregateRootVersion.Value.ShouldEqual<ulong>(2);
     }
 }

--- a/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_deleting/and_state_is_deleted_after_one_delete.cs
+++ b/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_deleting/and_state_is_deleted_after_one_delete.cs
@@ -45,7 +45,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
         It should_not_project_anything_else = () => project_many_events.VerifyNoOtherCalls();
         It should_return_the_same_events = () => result.Result.ShouldContainOnly(events);
         It should_return_uncommitted_events_with_correct_aggregate_root_id = () => result.Result.AggregateRoot.Id.Value.ShouldEqual(identifier.Value);
-        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.Value.ShouldEqual(identifier.Value);
+        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.ShouldEqual(key_to_event_source_converter.GetEventSourceIdFor(current_state.Key));
         It should_return_uncommitted_events_with_correct_aggregate_root_version = () => result.Result.ExpectedAggregateRootVersion.Value.ShouldEqual<ulong>(1);
     }
 }

--- a/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_deleting/and_state_is_deleted_after_second_compare.cs
+++ b/Specifications/Embeddings.Processing/for_StateTransitionEventsCalculator/when_deleting/and_state_is_deleted_after_second_compare.cs
@@ -62,7 +62,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_StateTransitionEventsCalcul
         It should_not_project_anything_else = () => project_many_events.VerifyNoOtherCalls();
         It should_return_all_the_same_events = () => result.Result.ShouldContainOnly(first_event_batch.Concat(second_event_batch));
         It should_return_uncommitted_events_with_correct_aggregate_root_id = () => result.Result.AggregateRoot.Id.Value.ShouldEqual(identifier.Value);
-        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.Value.ShouldEqual(identifier.Value);
+        It should_return_uncommitted_events_with_correct_event_source_id = () => result.Result.EventSource.ShouldEqual(key_to_event_source_converter.GetEventSourceIdFor(current_state.Key));
         It should_return_uncommitted_events_with_correct_aggregate_root_version = () => result.Result.ExpectedAggregateRootVersion.Value.ShouldEqual<ulong>(2);
     }
 }


### PR DESCRIPTION
The wrong event source id for uncommitted events coming from embedding was being set. The event source id to use should be the one converted from the projection key.