### PR TITLE
Event source string

### DIFF
--- a/Source/Embeddings.Processing/EmbeddingRequestFactory.cs
+++ b/Source/Embeddings.Processing/EmbeddingRequestFactory.cs
@@ -28,7 +28,7 @@ namespace Dolittle.Runtime.Embeddings.Processing
                     {
                         Artifact = @event.Type.ToProtobuf(),
                         Content = @event.Content,
-                        EventSourceId = @event.EventSource.ToProtobuf(),
+                        EventSourceId = @event.EventSource.Value,
                         Public = @event.Public,
                     }
                 }

--- a/Source/Embeddings.Store/ProjectionKeyToEventSourceIdConverter.cs
+++ b/Source/Embeddings.Store/ProjectionKeyToEventSourceIdConverter.cs
@@ -15,37 +15,10 @@ namespace Dolittle.Runtime.Embeddings.Store
     /// </summary>
     public class ProjectionKeyToEventSourceIdConverter : IConvertProjectionKeysToEventSourceIds
     {
-        const int _eventSourceIdBitLength = 128;
-
-        readonly Encoding _encoding;
-        readonly ICityHash _hasher;
-
-        /// <summary>
-        /// Initializes an instance of the <see cref="ProjectionKeyToEventSourceIdConverter" /> class.
-        /// </summary>
-        public ProjectionKeyToEventSourceIdConverter()
-        {
-            _encoding = Encoding.Unicode;
-            _hasher = CityHashFactory.Instance.Create(new CityHashConfig { HashSizeInBits = _eventSourceIdBitLength });
-        }
-
         /// <inheritdoc/>
         public EventSourceId GetEventSourceIdFor(ProjectionKey key)
         {
-            var bytes = _encoding.GetBytes(key.Value);
-            var hash = _hasher.ComputeHash(bytes);
-
-            ThrowIfComputedHashIsNotCorrectLength(hash);
-
-            return new Guid(hash.Hash);
-        }
-
-        void ThrowIfComputedHashIsNotCorrectLength(IHashValue hash)
-        {
-            if (hash.BitLength != _eventSourceIdBitLength)
-            {
-                throw new ComputedHashIsNotOfCorrectLength(hash.BitLength, _eventSourceIdBitLength);
-            }
+            return key.Value;
         }
     }
 }

--- a/Source/EventHorizon/Consumer/Connections/EventHorizonConnection.cs
+++ b/Source/EventHorizon/Consumer/Connections/EventHorizonConnection.cs
@@ -113,7 +113,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Connections
                         @event.Event.ToCommittedEvent(),
                         @event.StreamSequenceNumber,
                         StreamId.EventLog,
-                        Guid.Empty,
+                        PartitionId.None,
                         false);
 
                 await connectionToStreamProcessorQueue.EnqueueAsync(streamEvent, cancellationToken).ConfigureAwait(false);
@@ -132,7 +132,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Connections
         ConsumerSubscriptionRequest CreateRequest(SubscriptionId subscription, StreamPosition publicEventsPosition)
             => new()
             {
-                PartitionId = subscription.PartitionId.ToProtobuf(),
+                PartitionId = subscription.PartitionId.Value,
                 StreamId = subscription.StreamId.ToProtobuf(),
                 StreamPosition = publicEventsPosition.Value,
                 TenantId = subscription.ProducerTenantId.ToProtobuf()

--- a/Source/EventHorizon/Consumer/SubscriptionsService.cs
+++ b/Source/EventHorizon/Consumer/SubscriptionsService.cs
@@ -53,7 +53,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
                 subscriptionRequest.TenantId.ToGuid(),
                 subscriptionRequest.ScopeId.ToGuid(),
                 subscriptionRequest.StreamId.ToGuid(),
-                subscriptionRequest.PartitionId.ToGuid());
+                subscriptionRequest.PartitionId);
             try
             {
                 _metrics.IncrementTotalSubscriptionsInitiatedFromHead();

--- a/Source/EventHorizon/EventHorizonConsent.cs
+++ b/Source/EventHorizon/EventHorizonConsent.cs
@@ -41,7 +41,7 @@ namespace Dolittle.Runtime.EventHorizon
     /// <summary>
     /// Represents the consent configuration for an event horizon.
     /// </summary>
-    public record EventHorizonConsentConfiguration(Guid Microservice, Guid Tenant, Guid Stream, Guid Partition, Guid Consent)
+    public record EventHorizonConsentConfiguration(Guid Microservice, Guid Tenant, Guid Stream, string Partition, Guid Consent)
     {
         public static implicit operator EventHorizonConsent(EventHorizonConsentConfiguration config)
             => new()

--- a/Source/EventHorizon/Producer/ConsumerProtocol.cs
+++ b/Source/EventHorizon/Producer/ConsumerProtocol.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.EventHorizon.Producer
                 executionContext.Tenant,
                 arguments.TenantId.ToGuid(),
                 arguments.StreamId.ToGuid(),
-                arguments.PartitionId.ToGuid(),
+                arguments.PartitionId,
                 arguments.StreamPosition);
         }
 

--- a/Source/EventHorizon/Producer/LoggerExtensions.cs
+++ b/Source/EventHorizon/Producer/LoggerExtensions.cs
@@ -10,32 +10,32 @@ namespace Dolittle.Runtime.EventHorizon.Producer
 {
     internal static class LoggerExtensions
     {
-        static readonly Action<ILogger, Guid, Guid, Guid, ulong, Guid, Guid, Exception> _incomingEventHorizonSubscription = LoggerMessage
-            .Define<Guid, Guid, Guid, ulong, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, ulong, string, Guid, Exception> _incomingEventHorizonSubscription = LoggerMessage
+            .Define<Guid, Guid, Guid, ulong, string, Guid>(
                 LogLevel.Debug,
                 new EventId(1404825474, nameof(IncomingEventHorizonSubscription)),
                 "Incoming event horizon subscription from microservice: {ConsumerMicroservice} and tenant: {ConsumerTenant} to tenant: {ProducerTenant} starting at position: {StreamPosition} in partition: {Partition} in stream: {PublicStream}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, ulong, Guid, Guid, Exception> _successfullySubscribed = LoggerMessage
-            .Define<Guid, Guid, Guid, ulong, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, ulong, string, Guid, Exception> _successfullySubscribed = LoggerMessage
+            .Define<Guid, Guid, Guid, ulong, string, Guid>(
                 LogLevel.Information,
                 new EventId(399974883, nameof(SuccessfullySubscribed)),
                 "Microservice: {ConsumerMicroservice} and tenant: {ConsumerTenant} successfully subscribed to tenant: {ProducerTenant} starting at position: {StreamPosition} in partition: {Partition} in stream: {PublicStream}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, Guid, Exception> _errorOccurredInEventHorizon = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, Guid, Exception> _errorOccurredInEventHorizon = LoggerMessage
+            .Define<Guid, Guid, Guid, string, Guid>(
                 LogLevel.Warning,
                 new EventId(255540672, nameof(ErrorOccurredInEventHorizon)),
                 "An error occurred in event horizon for microservice: {ConsumerMicroservice} and tenant: {ConsumerTenant} with producer tenant: {ProducerTenant} in partition: {Partition} in stream: {PublicStream}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, Guid, Exception> _eventHorizonStopped = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, Guid, Exception> _eventHorizonStopped = LoggerMessage
+            .Define<Guid, Guid, Guid, string, Guid>(
                 LogLevel.Warning,
                 new EventId(271973941, nameof(EventHorizonStopped)),
                 "Event horizon for microservice: {ConsumerMicroservice} and tenant: {ConsumerTenant} with producer tenant: {ProducerTenant} in partition: {Partition} in stream: {PublicStream} stopped");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, Guid, Exception> _eventHorizonDisconnecting = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, Guid, Exception> _eventHorizonDisconnecting = LoggerMessage
+            .Define<Guid, Guid, Guid, string, Guid>(
                 LogLevel.Warning,
                 new EventId(271973941, nameof(EventHorizonDisconnecting)),
                 "Disconnecting Event Horizon for microservice: {ConsumerMicroservice} and tenant: {ConsumerTenant} with producer tenant: {ProducerTenant} in partition: {Partition} in stream: {PublicStream}");

--- a/Source/Events.Processing/EventHandlers/EventProcessor.cs
+++ b/Source/Events.Processing/EventHandlers/EventProcessor.cs
@@ -52,7 +52,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
 
             var request = new HandleEventRequest
             {
-                Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.ToProtobuf(), ScopeId = Scope.ToProtobuf() },
+                Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.Value, ScopeId = Scope.ToProtobuf() },
             };
             return Process(request, cancellationToken);
         }
@@ -63,7 +63,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
             _logger.EventProcessorIsProcessingAgain(Identifier, @event.Type.Id, partitionId, retryCount, failureReason);
             var request = new HandleEventRequest
             {
-                Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.ToProtobuf(), ScopeId = Scope.ToProtobuf() },
+                Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.Value, ScopeId = Scope.ToProtobuf() },
                 RetryProcessingState = new RetryProcessingState { FailureReason = failureReason, RetryCount = retryCount }
             };
             return Process(request, cancellationToken);

--- a/Source/Events.Processing/EventHandlers/LoggerExtensions.cs
+++ b/Source/Events.Processing/EventHandlers/LoggerExtensions.cs
@@ -106,14 +106,14 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
                 new EventId(381357522, nameof(ErrorWhileRegisteringStreamProcessorForEventProcessor)),
                 "Error occurred while trying to register stream processor for Event Processor: {EventProcessor}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Exception> _eventProcessorIsProcessing = LoggerMessage
-            .Define<Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, string, Exception> _eventProcessorIsProcessing = LoggerMessage
+            .Define<Guid, Guid, string>(
                 LogLevel.Debug,
                 new EventId(265113086, nameof(EventProcessorIsProcessing)),
                 "Event processor: {EventProcessor} is processing event type: {EventTypeId} for partition: {PartitionId}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, uint, string, Exception> _eventProcessorIsProcessingAgain = LoggerMessage
-            .Define<Guid, Guid, Guid, uint, string>(
+        static readonly Action<ILogger, Guid, Guid, string, uint, string, Exception> _eventProcessorIsProcessingAgain = LoggerMessage
+            .Define<Guid, Guid, string, uint, string>(
                 LogLevel.Debug,
                 new EventId(250914604, nameof(EventProcessorIsProcessingAgain)),
                 "Event processor: {EventProcessor} is processing event type: {EventTypeId} for partition: {PartitionId} again for the {RetryCount} time, because of: {FailureReason}");

--- a/Source/Events.Processing/Filters/EventHorizon/PublicFilterProcessor.cs
+++ b/Source/Events.Processing/Filters/EventHorizon/PublicFilterProcessor.cs
@@ -41,7 +41,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, CancellationToken cancellationToken)
         {
-            if (!@event.Public) return Task.FromResult<IFilterResult>(new SuccessfulFiltering(false, Guid.Empty));
+            if (!@event.Public) return Task.FromResult<IFilterResult>(new SuccessfulFiltering(false, PartitionId.None));
             var request = new FilterEventRequest
             {
                 Event = @event.ToProtobuf(),
@@ -54,7 +54,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon
         /// <inheritdoc/>
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, string failureReason, uint retryCount, CancellationToken cancellationToken)
         {
-            if (!@event.Public) return Task.FromResult<IFilterResult>(new SuccessfulFiltering(false, Guid.Empty));
+            if (!@event.Public) return Task.FromResult<IFilterResult>(new SuccessfulFiltering(false, PartitionId.None));
             var request = new FilterEventRequest
             {
                 Event = @event.ToProtobuf(),
@@ -71,7 +71,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon
 
             return response switch
             {
-                { Failure: null } => new SuccessfulFiltering(response.IsIncluded, response.PartitionId.ToGuid()),
+                { Failure: null } => new SuccessfulFiltering(response.IsIncluded, response.PartitionId),
                 _ => new FailedFiltering(response.Failure.Reason, response.Failure.Retry, response.Failure.RetryTimeout.ToTimeSpan())
             };
         }

--- a/Source/Events.Processing/Filters/FailedFiltering.cs
+++ b/Source/Events.Processing/Filters/FailedFiltering.cs
@@ -35,7 +35,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         public bool IsIncluded => false;
 
         /// <inheritdoc/>
-        public PartitionId Partition => Guid.Empty;
+        public PartitionId Partition => PartitionId.None;
 
         /// <inheritdoc/>
         public bool IsPartitioned { get; }

--- a/Source/Events.Processing/Filters/LoggerExtensions.cs
+++ b/Source/Events.Processing/Filters/LoggerExtensions.cs
@@ -18,26 +18,26 @@ namespace Dolittle.Runtime.Events.Processing.Filters
     /// </summary>
     internal static class LoggerExtensions
     {
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, Exception> _filteringEvent = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, Exception> _filteringEvent = LoggerMessage
+            .Define<Guid, Guid, Guid, string>(
                 LogLevel.Debug,
                 new EventId(568531282, nameof(FilteringEvent)),
                 "Filter: {Filter} in scope: {Scope} is filtering event type: {EventTypeId} for partition: {PartitionId}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, uint, string, Exception> _filteringEventAgain = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid, uint, string>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, uint, string, Exception> _filteringEventAgain = LoggerMessage
+            .Define<Guid, Guid, Guid, string, uint, string>(
                 LogLevel.Debug,
                 new EventId(391135754, nameof(FilteringEventAgain)),
                 "Filter: {Filter} in scope: {Scope} is filtering event type: {EventTypeId} for partition: {PartitionId} again for the {RetryCount}. time because: \"{FailureReason}\"");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, Exception> _handleFilterResult = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, Exception> _handleFilterResult = LoggerMessage
+            .Define<Guid, Guid, Guid, string>(
                 LogLevel.Debug,
                 new EventId(1502330189, nameof(HandleFilterResult)),
                 "Filter: {Filter} in scope: {Scope} is handling filtering result for event type: {EventTypeId} in partition: {PartitionId}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Guid, Guid, Exception> _filteredEventIsIncluded = LoggerMessage
-            .Define<Guid, Guid, Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, Guid, string, Guid, Exception> _filteredEventIsIncluded = LoggerMessage
+            .Define<Guid, Guid, Guid, string, Guid>(
                 LogLevel.Debug,
                 new EventId(1603417156, nameof(FilteredEventIsIncluded)),
                 "Filter: {Filter} in scope: {Scope} is writing event type: {EventTypeId} to partition: {PartitionId} in stream: {Stream}");

--- a/Source/Events.Processing/Filters/Partitioned/FilterProcessor.cs
+++ b/Source/Events.Processing/Filters/Partitioned/FilterProcessor.cs
@@ -69,7 +69,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.Partitioned
             var response = await _dispatcher.Call(request, cancellationToken).ConfigureAwait(false);
             return response switch
             {
-                { Failure: null } => new SuccessfulFiltering(response.IsIncluded, response.PartitionId.ToGuid()),
+                { Failure: null } => new SuccessfulFiltering(response.IsIncluded, response.PartitionId),
                 _ => new FailedFiltering(response.Failure.Reason, response.Failure.Retry, response.Failure.RetryTimeout.ToTimeSpan())
             };
         }

--- a/Source/Events.Processing/Filters/SuccessfulFiltering.cs
+++ b/Source/Events.Processing/Filters/SuccessfulFiltering.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Dolittle.Runtime.Events.Store.Streams;
 
 namespace Dolittle.Runtime.Events.Processing.Filters
@@ -18,7 +17,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         public SuccessfulFiltering(bool isIncluded)
         {
             IsIncluded = isIncluded;
-            Partition = Guid.Empty;
+            Partition = PartitionId.None;
             IsPartitioned = false;
         }
 

--- a/Source/Events.Processing/Filters/TypeFilterWithEventSourcePartition.cs
+++ b/Source/Events.Processing/Filters/TypeFilterWithEventSourcePartition.cs
@@ -38,7 +38,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         public override Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, CancellationToken cancellationToken)
         {
             var included = Definition.Types.Contains(@event.Type.Id);
-            var outPartitionId = Guid.Empty;
+            var outPartitionId = PartitionId.None;
             if (Definition.Partitioned)
             {
                 outPartitionId = @event.EventSource.Value;

--- a/Source/Events.Processing/Filters/ValidateFilterByComparingStreams.cs
+++ b/Source/Events.Processing/Filters/ValidateFilterByComparingStreams.cs
@@ -54,7 +54,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                 var streamPosition = 0;
                 foreach (var @event in sourceStreamEvents.Select(_ => _.Event))
                 {
-                    var processingResult = await filter.Filter(@event, Guid.Empty, filter.Identifier, cancellationToken).ConfigureAwait(false);
+                    var processingResult = await filter.Filter(@event, PartitionId.None, filter.Identifier, cancellationToken).ConfigureAwait(false);
                     if (processingResult is FailedFiltering failedResult)
                     {
                         return FilterValidationResult.Failed(failedResult.FailureReason);

--- a/Source/Events.Processing/Projections/LoggerExtensions.cs
+++ b/Source/Events.Processing/Projections/LoggerExtensions.cs
@@ -87,14 +87,14 @@ namespace Dolittle.Runtime.Events.Processing.Projections
                 new EventId(397656028, nameof(ProjectionDisconnected)),
                 "Projection {Projection} in scope {Scope} disconnected");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, Exception> _eventProcessorIsProcessing = LoggerMessage
-            .Define<Guid, Guid, Guid>(
+        static readonly Action<ILogger, Guid, Guid, string, Exception> _eventProcessorIsProcessing = LoggerMessage
+            .Define<Guid, Guid, string>(
                 LogLevel.Trace,
                 new EventId(176851418, nameof(EventProcessorIsProcessing)),
                 "Projection Event processor {EventProcessor} is processing event type {EventTypeId} for partition {PartitionId}");
 
-        static readonly Action<ILogger, Guid, Guid, Guid, uint, string, Exception> _eventProcessorIsProcessingAgain = LoggerMessage
-            .Define<Guid, Guid, Guid, uint, string>(
+        static readonly Action<ILogger, Guid, Guid, string, uint, string, Exception> _eventProcessorIsProcessingAgain = LoggerMessage
+            .Define<Guid, Guid, string, uint, string>(
                 LogLevel.Debug,
                 new EventId(828753281, nameof(EventProcessorIsProcessingAgain)),
                 "Projection Event processor {EventProcessor} is processing event type {EventTypeId} for partition {PartitionId} again for the {RetryCount} time, because of {FailureReason}");

--- a/Source/Events.Processing/Projections/Projection.cs
+++ b/Source/Events.Processing/Projections/Projection.cs
@@ -50,7 +50,7 @@ namespace Dolittle.Runtime.Events.Processing.Projections
             request.Event = new Contracts.StreamEvent
             {
                 Event = @event.ToProtobuf(),
-                PartitionId = partitionId.ToProtobuf(),
+                PartitionId = partitionId.Value,
                 ScopeId = _projectionDefinition.Scope.ToProtobuf(),
             };
             request.CurrentState = state.ToProtobuf();

--- a/Source/Events.Store.MongoDB/Aggregates/AggregateRoot.cs
+++ b/Source/Events.Store.MongoDB/Aggregates/AggregateRoot.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
         /// <param name="eventSource">The event source id.</param>
         /// <param name="aggregateType">The type of the aggregate root.</param>
         /// <param name="version">The version of the aggregate root.</param>
-        public AggregateRoot(Guid eventSource, Guid aggregateType, ulong version)
+        public AggregateRoot(string eventSource, Guid aggregateType, ulong version)
         {
             EventSource = eventSource;
             AggregateType = aggregateType;
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
         /// <summary>
         /// Gets or sets the id of the Event Source.
         /// </summary>
-        public Guid EventSource { get; set; }
+        public string EventSource { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the Aggregate Root.

--- a/Source/Events.Store.MongoDB/Aggregates/LoggerExtensions.cs
+++ b/Source/Events.Store.MongoDB/Aggregates/LoggerExtensions.cs
@@ -9,14 +9,14 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
 {
     internal static class LoggerExtensions
     {
-        static readonly Action<ILogger, Guid, Guid, Exception> _incrementingVersionForAggregate = LoggerMessage
-            .Define<Guid, Guid>(
+        static readonly Action<ILogger, Guid, string, Exception> _incrementingVersionForAggregate = LoggerMessage
+            .Define<Guid, string>(
                 LogLevel.Trace,
                 new EventId(422590197, nameof(IncrementingVersionForAggregate)),
                 "Incrementing version for aggregate root: {AggregateRoot} and event source: {EventSource}");
 
-        static readonly Action<ILogger, Guid, Guid, Exception> _fetchingVersionFor = LoggerMessage
-            .Define<Guid, Guid>(
+        static readonly Action<ILogger, Guid, string, Exception> _fetchingVersionFor = LoggerMessage
+            .Define<Guid, string>(
                 LogLevel.Trace,
                 new EventId(422590197, nameof(FetchingVersionFor)),
                 "Fetching version for aggregate root: {AggregateRoot} and event source: {EventSource}");

--- a/Source/Events.Store.MongoDB/Events/EventConverter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventConverter.cs
@@ -52,7 +52,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
                 ToRuntimeCommittedEvent(@event),
                 @event.EventLogSequenceNumber,
                 StreamId.EventLog,
-                Guid.Empty,
+                PartitionId.None,
                 false);
 
         /// <inheritdoc/>

--- a/Source/Events.Store.MongoDB/Events/EventMetadata.cs
+++ b/Source/Events.Store.MongoDB/Events/EventMetadata.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// <param name="isPublic">Whether the Event is public.</param>
         public EventMetadata(
             DateTime occurred,
-            Guid eventSource,
+            string eventSource,
             Guid typeId,
             uint typeGeneration,
             bool isPublic)
@@ -44,7 +44,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// <summary>
         /// Gets or sets the event source id.
         /// </summary>
-        public Guid EventSource { get; set; }
+        public string EventSource { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="ArtifactId"/> of the <see cref="Artifact"/> identitying the type of the event.

--- a/Source/Events.Store.MongoDB/Events/StreamEvent.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEvent.cs
@@ -51,7 +51,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// <summary>
         /// Gets or sets the partition id.
         /// </summary>
-        public Guid Partition { get; set; }
+        public string Partition { get; set; }
 
         /// <summary>
         /// Gets or sets the execution context.

--- a/Source/Events.Store.MongoDB/Events/StreamEventMetadata.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEventMetadata.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         public StreamEventMetadata(
             ulong eventLogSequenceNumber,
             DateTime occurred,
-            Guid eventSource,
+            string eventSource,
             Guid typeId,
             uint typeGeneration,
             bool isPublic)

--- a/Source/Events.Store.MongoDB/Processing/Streams/EventHorizon/SubscriptionState.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/EventHorizon/SubscriptionState.cs
@@ -31,7 +31,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams.EventHorizon
             Guid producerMicroserviceId,
             Guid producerTenantId,
             Guid streamId,
-            Guid partitionId,
+            string partitionId,
             ulong position,
             DateTime retryTime,
             string failureReason,
@@ -67,9 +67,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams.EventHorizon
         public Guid Stream { get; set; }
 
         /// <summary>
-        /// Gets or setsthe <see cref="Store.Streams.PartitionId" /> in the public stream.
+        /// Gets or sets the <see cref="Store.Streams.PartitionId" /> in the public stream.
         /// </summary>
-        public Guid Partition { get; set; }
+        public string Partition { get; set; }
 
         /// <summary>
         /// Gets or sets the position.

--- a/Source/Events.Store.MongoDB/Processing/Streams/Partitioned/PartitionedStreamProcessorState.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/Partitioned/PartitionedStreamProcessorState.cs
@@ -42,7 +42,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams.Partitioned
         public override IStreamProcessorState ToRuntimeRepresentation() =>
             new runtime.Partitioned.StreamProcessorState(
                 Position,
-                FailingPartitions.ToDictionary(_ => new PartitionId(Guid.Parse(_.Key)), _ => _.Value.ToRuntimeRepresentation()),
+                FailingPartitions.ToDictionary(_ => new PartitionId(_.Key), _ => _.Value.ToRuntimeRepresentation()),
                 LastSuccessfullyProcessed);
     }
 }

--- a/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         readonly Expression<Func<TEvent, StreamEvent>> _eventToStreamEvent;
         readonly Expression<Func<TEvent, Guid>> _eventToArtifactId;
         readonly Expression<Func<TEvent, uint>> _eventToArtifactGeneration;
-        readonly Expression<Func<TEvent, Guid>> _partitionIdExpression = default;
+        readonly Expression<Func<TEvent, string>> _partitionIdExpression = default;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamFetcher{T}"/> class.
@@ -82,7 +82,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
             Expression<Func<TEvent, StreamEvent>> eventToStreamEvent,
             Expression<Func<TEvent, Guid>> eventToArtifactId,
             Expression<Func<TEvent, uint>> eventToArtifactGeneration,
-            Expression<Func<TEvent, Guid>> partitionIdExpression)
+            Expression<Func<TEvent, string>> partitionIdExpression)
             : this(stream, scope, collection, filter, sequenceNumberExpression, eventToStreamEvent, eventToArtifactId, eventToArtifactGeneration)
         {
             _partitionIdExpression = partitionIdExpression;

--- a/Source/Events.Store.Services.Grpc/EventStoreGrpcService.cs
+++ b/Source/Events.Store.Services.Grpc/EventStoreGrpcService.cs
@@ -32,7 +32,7 @@ namespace Dolittle.Runtime.Events.Store.Services.Grpc
         public override async Task<Contracts.CommitEventsResponse> Commit(Contracts.CommitEventsRequest request, ServerCallContext context)
         {
             var response = new Contracts.CommitEventsResponse();
-            var events = request.Events.Select(_ => new UncommittedEvent(_.EventSourceId.ToGuid(), new Artifact(_.Artifact.Id.ToGuid(), _.Artifact.Generation), _.Public, _.Content));
+            var events = request.Events.Select(_ => new UncommittedEvent(_.EventSourceId, new Artifact(_.Artifact.Id.ToGuid(), _.Artifact.Generation), _.Public, _.Content));
             var commitResult = await _eventStoreService.TryCommit(
                 new UncommittedEvents(new ReadOnlyCollection<UncommittedEvent>(events.ToList())),
                 request.CallContext.ExecutionContext.ToExecutionContext(),
@@ -50,7 +50,7 @@ namespace Dolittle.Runtime.Events.Store.Services.Grpc
         public override async Task<Contracts.CommitAggregateEventsResponse> CommitForAggregate(Contracts.CommitAggregateEventsRequest request, ServerCallContext context)
         {
             var response = new Contracts.CommitAggregateEventsResponse();
-            EventSourceId eventSourceId = request.Events.EventSourceId.ToGuid();
+            EventSourceId eventSourceId = request.Events.EventSourceId;
             var events = request.Events.Events.Select(_ => new UncommittedEvent(eventSourceId, new Artifact(_.Artifact.Id.ToGuid(), _.Artifact.Generation), _.Public, _.Content));
 
             var commitResult = await _eventStoreService.TryCommitForAggregate(
@@ -75,7 +75,7 @@ namespace Dolittle.Runtime.Events.Store.Services.Grpc
             var response = new Contracts.FetchForAggregateResponse();
             var fetchResult = await _eventStoreService.TryFetchForAggregate(
                 request.Aggregate.AggregateRootId.ToGuid(),
-                request.Aggregate.EventSourceId.ToGuid(),
+                request.Aggregate.EventSourceId,
                 request.CallContext.ExecutionContext.ToExecutionContext(),
                 context.CancellationToken).ConfigureAwait(false);
             if (fetchResult.Success)

--- a/Source/Events.Store.Services.WebAPI/Requests.cs
+++ b/Source/Events.Store.Services.WebAPI/Requests.cs
@@ -51,7 +51,7 @@ namespace Dolittle.Runtime.Events.Store.Services.WebAPI
             => new(artifact.Id, artifact.Generation);
     }
 
-    public record JsonRequestUncommittedEvent(Guid EventSource, Artifact Type, bool Public, string Content)
+    public record JsonRequestUncommittedEvent(string EventSource, Artifact Type, bool Public, string Content)
     {
         public UncommittedEvent ToUncommittedEvent()
             => new(EventSource, Type.ToArtifact(), Public, Content);
@@ -64,7 +64,7 @@ namespace Dolittle.Runtime.Events.Store.Services.WebAPI
     }
 
     public record JsonRequestUncommittedAggregateEvents(
-        Guid EventSource,
+        string EventSource,
         Guid AggregateRoot,
         ulong AggregateRootVersion,
         JsonRequestUncommittedAggregateEvent[] Events)
@@ -79,5 +79,5 @@ namespace Dolittle.Runtime.Events.Store.Services.WebAPI
 
     public record CommitRequest(JsonRequestUncommittedEvent[] Events, CallRequestContext CallContext);
     public record CommitForAggregateRequest(JsonRequestUncommittedAggregateEvents AggregateEvents, CallRequestContext CallContext);
-    public record FetchForAggregateRequest(Guid AggregateRoot, Guid EventSource, CallRequestContext CallContext);
+    public record FetchForAggregateRequest(Guid AggregateRoot, string EventSource, CallRequestContext CallContext);
 }

--- a/Source/Events.Store.Services.WebAPI/Responses.cs
+++ b/Source/Events.Store.Services.WebAPI/Responses.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Events.Store.Services.WebAPI
     public record JsonResponseCommittedEvent(
         ulong EventLogSequenceNumber,
         DateTimeOffset Occurred,
-        Guid EventSource,
+        string EventSource,
         ExecutionContext ExecutionContext,
         Artifact Type,
         bool Public,
@@ -52,7 +52,7 @@ namespace Dolittle.Runtime.Events.Store.Services.WebAPI
                 @event.Content);
     }
 
-    public record JsonResponseCommittedAggregateEvents(Guid EventSourceId, Guid AggregateRoot, ulong AggregateRootVersion, JsonResponseCommittedAggregateEvent[] Events)
+    public record JsonResponseCommittedAggregateEvents(string EventSourceId, Guid AggregateRoot, ulong AggregateRootVersion, JsonResponseCommittedAggregateEvent[] Events)
     {
         public static JsonResponseCommittedAggregateEvents From(CommittedAggregateEvents events)
             => new(

--- a/Source/Events.Store/CommittedAggregateEventsExtensions.cs
+++ b/Source/Events.Store/CommittedAggregateEventsExtensions.cs
@@ -22,7 +22,7 @@ namespace Dolittle.Runtime.Events.Store
             var protobuf = new Contracts.CommittedAggregateEvents
             {
                 AggregateRootId = committedAggregateEvents.AggregateRoot.ToProtobuf(),
-                EventSourceId = committedAggregateEvents.EventSource.ToProtobuf(),
+                EventSourceId = committedAggregateEvents.EventSource.Value,
                 AggregateRootVersion = aggregateRootVersion
             };
             protobuf.Events.AddRange(committedAggregateEvents.Select(_ => _.ToProtobuf()));

--- a/Source/Events.Store/CommittedEventExtensions.cs
+++ b/Source/Events.Store/CommittedEventExtensions.cs
@@ -26,7 +26,7 @@ namespace Dolittle.Runtime.Events.Store
                 {
                     EventLogSequenceNumber = @event.EventLogSequenceNumber,
                     Occurred = Timestamp.FromDateTimeOffset(@event.Occurred),
-                    EventSourceId = @event.EventSource.ToProtobuf(),
+                    EventSourceId = @event.EventSource.Value,
                     ExecutionContext = @event.ExecutionContext.ToProtobuf(),
                     Type = new ArtifactsContracts.Artifact
                     {
@@ -46,7 +46,7 @@ namespace Dolittle.Runtime.Events.Store
             new(
                 @event.EventLogSequenceNumber,
                 @event.Occurred.ToDateTimeOffset(),
-                @event.EventSourceId.ToGuid(),
+                @event.EventSourceId,
                 @event.ExecutionContext.ToExecutionContext(),
                 new Artifact(@event.Type.Id.ToGuid(), @event.Type.Generation),
                 @event.Public,

--- a/Source/Events.Store/CommittedExternalEventExtensions.cs
+++ b/Source/Events.Store/CommittedExternalEventExtensions.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Events.Store
             {
                 EventLogSequenceNumber = @event.EventLogSequenceNumber,
                 Occurred = Timestamp.FromDateTimeOffset(@event.Occurred),
-                EventSourceId = @event.EventSource.ToProtobuf(),
+                EventSourceId = @event.EventSource.Value,
                 ExecutionContext = @event.ExecutionContext.ToProtobuf(),
                 Type = new ArtifactsContracts.Artifact
                 {

--- a/Source/Events.Store/EventSourceId.cs
+++ b/Source/Events.Store/EventSourceId.cs
@@ -9,29 +9,17 @@ namespace Dolittle.Runtime.Events.Store
     /// <summary>
     /// Represents the identification of an event source.
     /// </summary>
-    public record EventSourceId(Guid Value) : ConceptAs<Guid>(Value)
+    public record EventSourceId(string Value) : ConceptAs<string>(Value)
     {
         /// <summary>
         /// A static singleton instance to represent a "NotSet" <see cref="EventSourceId" />.
         /// </summary>
-        public static readonly EventSourceId NotSet = Guid.Empty;
-
-        /// <summary>
-        /// Implicitly convert from a <see cref="Guid"/> to an <see cref="EventSourceId"/>.
-        /// </summary>
-        /// <param name="eventSourceId">EventSourceId as <see cref="Guid"/>.</param>
-        public static implicit operator EventSourceId(Guid eventSourceId) => new(eventSourceId);
+        public static readonly EventSourceId NotSet = Guid.Empty.ToString();
 
         /// <summary>
         /// Implicitly convert from a <see cref="string"/> to an <see cref="EventSourceId"/>.
         /// </summary>
         /// <param name="eventSourceId">EventSourceId as <see cref="string"/>.</param>
-        public static implicit operator EventSourceId(string eventSourceId) => new(Guid.Parse(eventSourceId));
-
-        /// <summary>
-        /// Creates a new instance of <see cref="EventSourceId"/> with a unique id.
-        /// </summary>
-        /// <returns>A new <see cref="EventSourceId"/>.</returns>
-        public static EventSourceId New() => Guid.NewGuid();
+        public static implicit operator EventSourceId(string eventSourceId) => new(eventSourceId);
     }
 }

--- a/Source/Events.Store/Streams/PartitionId.cs
+++ b/Source/Events.Store/Streams/PartitionId.cs
@@ -9,24 +9,17 @@ namespace Dolittle.Runtime.Events.Store.Streams
     /// <summary>
     /// Represents a unique identifier for a partition.
     /// </summary>
-    public record PartitionId(Guid Value) : ConceptAs<Guid>(Value)
+    public record PartitionId(string Value) : ConceptAs<string>(Value)
     {
         /// <summary>
         /// Gets the <see cref="PartitionId"/> when no partition is specified.
         /// </summary>
-        public static PartitionId None => Guid.Empty;
-
-        /// <summary>
-        /// Implicitly convert from <see cref="Guid"/> to <see cref="PartitionId"/>.
-        /// </summary>
-        /// <param name="identifier"><see cref="Guid"/> representation.</param>
-        public static implicit operator PartitionId(Guid identifier) => new(identifier);
+        public static PartitionId None => Guid.Empty.ToString();
 
         /// <summary>
         /// Implicitly convert from <see cref="string"/> to <see cref="PartitionId"/>.
         /// </summary>
-        /// <param name="identifier"><see cref="string"/> representation.</param>
-        public static implicit operator PartitionId(string identifier) => Guid.Parse(identifier);
-
+        /// <param name="partition"><see cref="string"/> representation.</param>
+        public static implicit operator PartitionId(string partition) => new(partition);
     }
 }

--- a/Specifications/Embeddings.Processing/for_Embedding/when_comparing/and_the_embedding_returns/an_embedding_compare_response.cs
+++ b/Specifications/Embeddings.Processing/for_Embedding/when_comparing/and_the_embedding_returns/an_embedding_compare_response.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_Embedding.when_comparing.an
             pb_uncommitted_event = new Events.Contracts.UncommittedEvent
             {
                 Content = "{}",
-                EventSourceId = Guid.Parse("302c7c8f-b773-44e7-947d-75747ed1a976").ToProtobuf(),
+                EventSourceId = "302c7c8f-b773-44e7-947d-75747ed1a976",
                 Public = true,
                 Artifact = new Dolittle.Artifacts.Contracts.Artifact()
                 {

--- a/Specifications/Embeddings.Processing/for_Embedding/when_comparing/and_the_embedding_returns/an_embedding_delete_response.cs
+++ b/Specifications/Embeddings.Processing/for_Embedding/when_comparing/and_the_embedding_returns/an_embedding_delete_response.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_Embedding.when_comparing.an
             pb_uncommitted_event = new Events.Contracts.UncommittedEvent
             {
                 Content = "{}",
-                EventSourceId = Guid.Parse("302c7c8f-b773-44e7-947d-75747ed1a976").ToProtobuf(),
+                EventSourceId = "302c7c8f-b773-44e7-947d-75747ed1a976",
                 Public = true,
                 Artifact = new Dolittle.Artifacts.Contracts.Artifact()
                 {

--- a/Specifications/Embeddings.Processing/for_Embedding/when_deleting/and_the_embedding_returns/an_embedding_delete_response.cs
+++ b/Specifications/Embeddings.Processing/for_Embedding/when_deleting/and_the_embedding_returns/an_embedding_delete_response.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_Embedding.when_deleting.and
             pb_uncommitted_event = new Events.Contracts.UncommittedEvent
             {
                 Content = "{}",
-                EventSourceId = Guid.Parse("302c7c8f-b773-44e7-947d-75747ed1a976").ToProtobuf(),
+                EventSourceId = "302c7c8f-b773-44e7-947d-75747ed1a976",
                 Public = true,
                 Artifact = new Dolittle.Artifacts.Contracts.Artifact()
                 {

--- a/Specifications/Embeddings.Processing/for_Embedding/when_projecting/given/all_dependencies.cs
+++ b/Specifications/Embeddings.Processing/for_Embedding/when_projecting/given/all_dependencies.cs
@@ -17,7 +17,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_Embedding.when_projecting.g
         Establish context = () =>
         {
             @event = new UncommittedEvent(
-                Guid.Parse("1a477367-3404-45e6-a2af-6cbf19693b56"),
+                "1a477367-3404-45e6-a2af-6cbf19693b56",
                 new Artifact(Guid.Parse("fe570d85-2619-49e4-bc72-9a8b2b2f149d"), ArtifactGeneration.First),
                 true,
                 "beautiful 😍 event to 🙅 be tested 🤓🤓");

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_deleting/given/all_dependencies_and_a_key.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_deleting/given/all_dependencies_and_a_key.cs
@@ -35,7 +35,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_del
                 0,
                 0,
                 DateTimeOffset.Now,
-                Guid.Parse("1d137f3a-b8d0-43a5-a08a-f8eb35b5e932"),
+                "1d137f3a-b8d0-43a5-a08a-f8eb35b5e932",
                 new ExecutionContext(
                     Guid.Parse("4e93a0f0-ddf1-48a3-ab6e-508ed9950ed4"),
                     "63560704-69dd-47bd-a4de-41af2634a190",
@@ -48,13 +48,13 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_del
                 false,
                 "event-content");
             committed_events = new CommittedAggregateEvents(
-                Guid.Parse("1d137f3a-b8d0-43a5-a08a-f8eb35b5e932"),
+                "1d137f3a-b8d0-43a5-a08a-f8eb35b5e932",
                 "5512cda5-5e38-4654-ba86-3a7d917f3eb0",
                 new[] { committed_event });
         };
         protected static UncommittedAggregateEvents CreateUncommittedEvents(params UncommittedEvent[] events)
             => new(
-                Guid.Parse("1d137f3a-b8d0-43a5-a08a-f8eb35b5e932"),
+                "1d137f3a-b8d0-43a5-a08a-f8eb35b5e932",
                 new Artifact("5512cda5-5e38-4654-ba86-3a7d917f3eb0", ArtifactGeneration.First),
                 1,
                 events);

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_started/and_aggregate_events_are_committed/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_started/and_aggregate_events_are_committed/and_everything_works.cs
@@ -32,7 +32,11 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_sta
             state_updater.Setup(_ => _.TryUpdateAll(Moq.It.IsAny<CancellationToken>())).Returns(Task.FromResult(Try.Succeeded()));
         };
 
-        Because of = () => result = embedding_processor.Start(cancellation_token);
+        Because of = () =>
+        {
+            result = embedding_processor.Start(cancellation_token);
+            Thread.Sleep(100);
+        };
 
         It should_be_running = () => result.Status.ShouldEqual(TaskStatus.WaitingForActivation);
         It should_update_embedding_states = () => state_updater.Verify(_ => _.TryUpdateAll(Moq.It.IsAny<CancellationToken>()), Times.Exactly(2));

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_updating/given/all_dependencies_and_a_desired_state.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_updating/given/all_dependencies_and_a_desired_state.cs
@@ -36,7 +36,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_upd
                 0,
                 0,
                 DateTimeOffset.Now,
-                Guid.Parse("1d137f3a-b8d0-43a5-a08a-f8eb35b5e932"),
+                "1d137f3a-b8d0-43a5-a08a-f8eb35b5e932",
                 new ExecutionContext(
                     Guid.Parse("4e93a0f0-ddf1-48a3-ab6e-508ed9950ed4"),
                     "63560704-69dd-47bd-a4de-41af2634a190",
@@ -49,7 +49,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_upd
                 false,
                 "event-content");
             committed_events = new CommittedAggregateEvents(
-                Guid.Parse("1d137f3a-b8d0-43a5-a08a-f8eb35b5e932"),
+                "1d137f3a-b8d0-43a5-a08a-f8eb35b5e932",
                 "5512cda5-5e38-4654-ba86-3a7d917f3eb0",
                 new[] { committed_event });
             desired_state = "{}";
@@ -57,7 +57,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_upd
 
         protected static UncommittedAggregateEvents CreateUncommittedEvents(params UncommittedEvent[] events)
             => new(
-                Guid.Parse("1d137f3a-b8d0-43a5-a08a-f8eb35b5e932"),
+                "1d137f3a-b8d0-43a5-a08a-f8eb35b5e932",
                 new Artifact("5512cda5-5e38-4654-ba86-3a7d917f3eb0", ArtifactGeneration.First),
                 1,
                 events);

--- a/Specifications/Embeddings.Processing/for_EmbeddingRequestFactory/when_creating/a_project_request/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingRequestFactory/when_creating/a_project_request/and_everything_works.cs
@@ -16,7 +16,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingRequestFactory.whe
         Establish context = () =>
         {
             @event = new UncommittedEvent(
-                Guid.Parse("2b70d917-46e8-485f-8a3e-f12bd6392e8f"),
+                "2b70d917-46e8-485f-8a3e-f12bd6392e8f",
                 new Artifacts.Artifact(
                     "97dae10c-6986-46c4-be68-2b763ae565bf",
                     Artifacts.ArtifactGeneration.First
@@ -33,7 +33,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingRequestFactory.whe
         It should_have_the_correct_type = () => result.Projection.CurrentState.Type.ShouldEqual(current_state.Type.ToProtobuf());
         It should_have_the_correct_state = () => result.Projection.CurrentState.State.ShouldEqual(current_state.State.Value);
         It should_have_the_correct_key = () => result.Projection.CurrentState.Key.ShouldEqual(current_state.Key.Value);
-        It should_have_the_correct_event_source_id = () => result.Projection.Event.EventSourceId.ShouldEqual(@event.EventSource.Value.ToProtobuf());
+        It should_have_the_correct_event_source_id = () => result.Projection.Event.EventSourceId.ShouldEqual(@event.EventSource.Value);
         It should_have_the_correct_event_artifact_id = () => result.Projection.Event.Artifact.Id.ShouldEqual(@event.Type.Id.Value.ToProtobuf());
         It should_have_the_correct_event_artifact_generation = () => result.Projection.Event.Artifact.Generation.ShouldEqual(@event.Type.Generation.Value);
         It should_have_the_correct_event_content = () => result.Projection.Event.Content.ShouldEqual(@event.Content);

--- a/Specifications/Embeddings.Processing/for_EmbeddingRequestFactory/when_trying_to_create/a_project_request/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingRequestFactory/when_trying_to_create/a_project_request/and_everything_works.cs
@@ -17,7 +17,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingRequestFactory.whe
         Establish context = () =>
         {
             @event = new UncommittedEvent(
-                Guid.Parse("2b70d917-46e8-485f-8a3e-f12bd6392e8f"),
+                "2b70d917-46e8-485f-8a3e-f12bd6392e8f",
                 new Artifacts.Artifact(
                     "97dae10c-6986-46c4-be68-2b763ae565bf",
                     Artifacts.ArtifactGeneration.First
@@ -35,7 +35,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingRequestFactory.whe
         It should_have_the_correct_type = () => result.Result.Projection.CurrentState.Type.ShouldEqual(current_state.Type.ToProtobuf());
         It should_have_the_correct_state = () => result.Result.Projection.CurrentState.State.ShouldEqual(current_state.State.Value);
         It should_have_the_correct_key = () => result.Result.Projection.CurrentState.Key.ShouldEqual(current_state.Key.Value);
-        It should_have_the_correct_event_source_id = () => result.Result.Projection.Event.EventSourceId.ShouldEqual(@event.EventSource.Value.ToProtobuf());
+        It should_have_the_correct_event_source_id = () => result.Result.Projection.Event.EventSourceId.ShouldEqual(@event.EventSource.Value);
         It should_have_the_correct_event_artifact_id = () => result.Result.Projection.Event.Artifact.Id.ShouldEqual(@event.Type.Id.Value.ToProtobuf());
         It should_have_the_correct_event_artifact_generation = () => result.Result.Projection.Event.Artifact.Generation.ShouldEqual(@event.Type.Generation.Value);
         It should_have_the_correct_event_content = () => result.Result.Projection.Event.Content.ShouldEqual(@event.Content);

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_getting_current_state_fails.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_getting_current_state_fails.cs
@@ -22,7 +22,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("f05923c2-561d-4603-97bb-7fc17d808a8a");
+            event_source = "f05923c2-561d-4603-97bb-7fc17d808a8a";
             exception = new Exception();
 
             embedding_store.Setup(_ => _.TryGetKeys(embedding, cancellation_token)).Returns(Task.FromResult<Try<IEnumerable<ProjectionKey>>>(new[] { projection_key }));

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_getting_unprocessed_events_fails.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_getting_unprocessed_events_fails.cs
@@ -26,7 +26,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             aggregate_root_type = new Artifact(embedding.Value, ArtifactGeneration.First);
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             exception = new Exception();

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_one_of_two_keys_fails.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_one_of_two_keys_fails.cs
@@ -37,14 +37,14 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
             exception = new Exception();
 
             projection_key_a = "key-a";
-            event_source_a = Guid.Parse("f0cbe001-65a4-49d2-adcb-ff4d42e92223");
+            event_source_a = "f0cbe001-65a4-49d2-adcb-ff4d42e92223";
             current_state_a = new EmbeddingCurrentState(1, EmbeddingCurrentStateType.Persisted, "state-current-a", projection_key_a);
             unprocessed_event_a = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 1, 10, DateTimeOffset.Now, event_source_a, execution_context, event_type, false, "event-one-content");
             unprocessed_events_a = new CommittedAggregateEvents(event_source_a, embedding.Value, new[] { unprocessed_event_a });
             projection_result_a = new EmbeddingCurrentState(current_state_a.Version.Value + 1, EmbeddingCurrentStateType.Deleted, current_state_a.State, current_state_a.Key);
 
             projection_key_b = "key-b";
-            event_source_b = Guid.Parse("760a14d6-639d-4eba-9e7e-48675631bdd2");
+            event_source_b = "760a14d6-639d-4eba-9e7e-48675631bdd2";
             current_state_b = new EmbeddingCurrentState(0, EmbeddingCurrentStateType.CreatedFromInitialState, "state-initial-b", projection_key_b);
             unprocessed_event_b = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 1, 10, DateTimeOffset.Now, event_source_b, execution_context, event_type, false, "event-one-content");
             unprocessed_events_b = new CommittedAggregateEvents(event_source_b, embedding.Value, new[] { unprocessed_event_b });

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_projecting_fails.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_projecting_fails.cs
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             unprocessed_event = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");
             unprocessed_events = new CommittedAggregateEvents(event_source, embedding.Value, new[] { unprocessed_event });

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_projecting_partially_succeeds.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_projecting_partially_succeeds.cs
@@ -30,7 +30,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             unprocessed_event = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");
             unprocessed_events = new CommittedAggregateEvents(event_source, embedding.Value, new[] { unprocessed_event });

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_storing_the_result_fails.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_storing_the_result_fails.cs
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             committed_event = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");
             unprocessed_events = new CommittedAggregateEvents(event_source, embedding.Value, new[] { committed_event });

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_two_of_three_keys_fails.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/and_two_of_three_keys_fails.cs
@@ -41,17 +41,17 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
             exception_b = new Exception();
 
             projection_key_a = "key-a";
-            event_source_a = Guid.Parse("f0cbe001-65a4-49d2-adcb-ff4d42e92223");
+            event_source_a = "f0cbe001-65a4-49d2-adcb-ff4d42e92223";
             current_state_a = new EmbeddingCurrentState(1, EmbeddingCurrentStateType.Persisted, "state-current-a", projection_key_a);
             committed_event_a = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 3, 10, DateTimeOffset.Now, event_source_a, execution_context, event_type, false, "event-one-content");
             unprocessed_events_a = new CommittedAggregateEvents(event_source_a, embedding.Value, new[] { committed_event_a });
             projection_result_a = new EmbeddingCurrentState(current_state_a.Version + 1, EmbeddingCurrentStateType.Deleted, current_state_a.State, current_state_a.Key);
 
             projection_key_b = "key-b";
-            event_source_b = Guid.Parse("760a14d6-639d-4eba-9e7e-48675631bdd2");
+            event_source_b = "760a14d6-639d-4eba-9e7e-48675631bdd2";
 
             projection_key_c = "key-c";
-            event_source_c = Guid.Parse("313ef6a7-62da-4761-b054-fd33d89d5ebd");
+            event_source_c = "313ef6a7-62da-4761-b054-fd33d89d5ebd";
             current_state_c = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.CreatedFromInitialState, "state-initial-c", projection_key_c);
             committed_event_c = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 3, 10, DateTimeOffset.Now, event_source_c, execution_context, event_type, false, "event-one-content");
             unprocessed_events_c = new CommittedAggregateEvents(event_source_c, embedding.Value, new[] { committed_event_c });

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/from_many_events.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/from_many_events.cs
@@ -30,7 +30,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             unprocessed_event = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");
             unprocessed_events = new CommittedAggregateEvents(event_source, embedding.Value, new[] { unprocessed_event });

--- a/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/two_keys.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingStateUpdater/when_updating/two_keys.cs
@@ -33,14 +33,14 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingStateUpdater.when_
         Establish context = () =>
         {
             projection_key_a = "key-a";
-            event_source_a = Guid.Parse("f0cbe001-65a4-49d2-adcb-ff4d42e92223");
+            event_source_a = "f0cbe001-65a4-49d2-adcb-ff4d42e92223";
             current_state_a = new EmbeddingCurrentState(1, EmbeddingCurrentStateType.Persisted, "state-current-a", projection_key_a);
             unprocessed_event_a = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 1, 10, DateTimeOffset.Now, event_source_a, execution_context, event_type, false, "event-one-content");
             unprocessed_events_a = new CommittedAggregateEvents(event_source_a, embedding.Value, new[] { unprocessed_event_a });
             projection_result_a = new EmbeddingCurrentState(current_state_a.Version + 1, EmbeddingCurrentStateType.Deleted, current_state_a.State, current_state_a.Key);
 
             projection_key_b = "key-b";
-            event_source_b = Guid.Parse("760a14d6-639d-4eba-9e7e-48675631bdd2");
+            event_source_b = "760a14d6-639d-4eba-9e7e-48675631bdd2";
             current_state_b = new EmbeddingCurrentState(0, EmbeddingCurrentStateType.CreatedFromInitialState, "state-initial-b", projection_key_b);
             unprocessed_event_b = new CommittedAggregateEvent(new Artifact(embedding.Value, ArtifactGeneration.First), 0, 12, DateTimeOffset.Now, event_source_b, execution_context, event_type, false, "event-two-content");
             unprocessed_events_b = new CommittedAggregateEvents(event_source_b, embedding.Value, new[] { unprocessed_event_b });

--- a/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/committed_events/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/committed_events/and_everything_works.cs
@@ -33,7 +33,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_ProjectManyEvents.when_proj
         Establish context = () =>
         {
             projection_key = "projection-key-ZSF";
-            event_source = Guid.Parse("ed882f2f-9974-4334-ad43-e662d6db3396");
+            event_source = "ed882f2f-9974-4334-ad43-e662d6db3396";
             aggregate_root_type = new Artifact(identifier.Value, ArtifactGeneration.First);
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             event_one = new CommittedAggregateEvent(aggregate_root_type, 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");

--- a/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/committed_events/and_it_fails_on_first_event.cs
+++ b/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/committed_events/and_it_fails_on_first_event.cs
@@ -31,7 +31,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_ProjectManyEvents.when_proj
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             aggregate_root_type = new Artifact(identifier.Value, ArtifactGeneration.First);
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             event_one = new CommittedAggregateEvent(aggregate_root_type, 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");

--- a/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/committed_events/and_it_fails_on_third_event.cs
+++ b/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/committed_events/and_it_fails_on_third_event.cs
@@ -34,7 +34,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_ProjectManyEvents.when_proj
         Establish context = () =>
         {
             projection_key = "projection-key-ZSF";
-            event_source = Guid.Parse("ed882f2f-9974-4334-ad43-e662d6db3396");
+            event_source = "ed882f2f-9974-4334-ad43-e662d6db3396";
             aggregate_root_type = new Artifact(identifier.Value, ArtifactGeneration.First);
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             event_one = new CommittedAggregateEvent(aggregate_root_type, 3, 10, DateTimeOffset.Now, event_source, execution_context, event_type, false, "event-one-content");

--- a/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/uncommitted_events/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/uncommitted_events/and_everything_works.cs
@@ -32,7 +32,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_ProjectManyEvents.when_proj
         Establish context = () =>
         {
             projection_key = "projection-key-ZSF";
-            event_source = Guid.Parse("ed882f2f-9974-4334-ad43-e662d6db3396");
+            event_source = "ed882f2f-9974-4334-ad43-e662d6db3396";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             event_one = new UncommittedEvent(event_source, event_type, false, "event-one-content");
             event_two = new UncommittedEvent(event_source, event_type, true, "event-two-content");

--- a/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/uncommitted_events/and_it_fails_on_first_event.cs
+++ b/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/uncommitted_events/and_it_fails_on_first_event.cs
@@ -30,7 +30,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_ProjectManyEvents.when_proj
         Establish context = () =>
         {
             projection_key = "projection-key";
-            event_source = Guid.Parse("642ca1f2-c8e1-4e5c-a213-246ce95a8376");
+            event_source = "642ca1f2-c8e1-4e5c-a213-246ce95a8376";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             event_one = new UncommittedEvent(event_source, event_type, false, "event-one-content");
             event_two = new UncommittedEvent(event_source, event_type, true, "event-two-content");

--- a/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/uncommitted_events/and_it_fails_on_third_event.cs
+++ b/Specifications/Embeddings.Processing/for_ProjectManyEvents/when_projecting/uncommitted_events/and_it_fails_on_third_event.cs
@@ -33,7 +33,7 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_ProjectManyEvents.when_proj
         Establish context = () =>
         {
             projection_key = "projection-key-ZSF";
-            event_source = Guid.Parse("ed882f2f-9974-4334-ad43-e662d6db3396");
+            event_source = "ed882f2f-9974-4334-ad43-e662d6db3396";
             current_state = new EmbeddingCurrentState(3, EmbeddingCurrentStateType.Persisted, "state-current", projection_key);
             event_one = new UncommittedEvent(event_source, event_type, false, "event-one-content");
             event_two = new UncommittedEvent(event_source, event_type, true, "event-two-content");

--- a/Specifications/Embeddings.Store/for_ProjectionKeyToEventSourceIdConverter/when_getting_event_source_id_for/a_special_value.cs
+++ b/Specifications/Embeddings.Store/for_ProjectionKeyToEventSourceIdConverter/when_getting_event_source_id_for/a_special_value.cs
@@ -18,6 +18,6 @@ namespace Dolittle.Runtime.Embeddings.Store.for_ProjectionKeyToEventSourceIdConv
 
         Because of = () => event_source_id = converter.GetEventSourceIdFor(projection_key);
 
-        It should_return_a_special_event_source = () => event_source_id.Value.ShouldEqual(Guid.Parse("f5fffaff-66b4-f316-4b4d-54a435b50d2a"));
+        It should_return_a_special_event_source = () => event_source_id.Value.ShouldEqual(projection_key.Value);
     }
 }

--- a/Specifications/Embeddings.Store/for_ProjectionKeyToEventSourceIdConverter/when_getting_event_source_id_for/a_value_with_complex_contents.cs
+++ b/Specifications/Embeddings.Store/for_ProjectionKeyToEventSourceIdConverter/when_getting_event_source_id_for/a_value_with_complex_contents.cs
@@ -24,6 +24,6 @@ namespace Dolittle.Runtime.Embeddings.Store.for_ProjectionKeyToEventSourceIdConv
 
         Because of = () => event_source_id = converter.GetEventSourceIdFor(projection_key);
 
-        It should_return_a_special_event_source = () => event_source_id.Value.ShouldEqual(Guid.Parse("e02d01ac-8e39-1a33-7106-b6390b0159e2"));
+        It should_return_a_special_event_source = () => event_source_id.Value.ShouldEqual(projection_key.Value);
     }
 }

--- a/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/given/all_dependencies.cs
+++ b/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/given/all_dependencies.cs
@@ -63,7 +63,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Connections.for_EventHorizonCon
                     {
                         Content = "content",
                         EventLogSequenceNumber = 4,
-                        EventSourceId = Guid.Parse("0d2b2e6a-10ec-4be6-a745-09de09b9809c").ToProtobuf(),
+                        EventSourceId = Guid.Parse("0d2b2e6a-10ec-4be6-a745-09de09b9809c").ToString(),
                         External = true,
                         ExecutionContext = execution_context,
                         ExternalEventLogSequenceNumber = 6,

--- a/Specifications/EventHorizon/Consumer/Processing/for_EventProcessor/given/all_dependencies.cs
+++ b/Specifications/EventHorizon/Consumer/Processing/for_EventProcessor/given/all_dependencies.cs
@@ -36,9 +36,9 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Processing.for_EventProcessor.g
                 Guid.NewGuid(),
                 Guid.NewGuid(),
                 Guid.NewGuid(),
-                Guid.NewGuid());
+                "partition id");
 
-            partition = Guid.NewGuid();
+            partition = "another partition id";
 
             event_horizon_events_writer = new Mock<IWriteEventHorizonEvents>();
 
@@ -48,7 +48,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Processing.for_EventProcessor.g
             @event = new CommittedEvent(
                 0,
                 DateTimeOffset.Now,
-                Guid.NewGuid(),
+                "event source id",
                 execution_contexts.create(),
                 new Artifacts.Artifact(Guid.NewGuid(), 0),
                 true,

--- a/Specifications/EventHorizon/Producer/for_EventExtensions/when_converting_to_committed_event_horizon_event/and_there_are_claims.cs
+++ b/Specifications/EventHorizon/Producer/for_EventExtensions/when_converting_to_committed_event_horizon_event/and_there_are_claims.cs
@@ -18,7 +18,7 @@ namespace Dolittle.Runtime.EventHorizon.Producer.for_EventExtensions.when_conver
         Establish context = () => committed_event = new CommittedEvent(
             0,
             DateTimeOffset.UtcNow,
-            Guid.NewGuid(),
+            "an event source id",
             execution_contexts.create_with_claims(new Claims(new[] { new Claim("name", "value", "valueType") })),
             artifacts.create(),
             false,
@@ -28,7 +28,7 @@ namespace Dolittle.Runtime.EventHorizon.Producer.for_EventExtensions.when_conver
 
         It should_have_the_correct_event_log_sequence_number = () => result.EventLogSequenceNumber.ShouldEqual(committed_event.EventLogSequenceNumber.Value);
         It should_have_the_correct_content = () => result.Content.ShouldEqual(committed_event.Content);
-        It should_have_the_correct_event_source = () => result.EventSourceId.ToGuid().ShouldEqual(committed_event.EventSource.Value);
+        It should_have_the_correct_event_source = () => result.EventSourceId.ShouldEqual(committed_event.EventSource.Value);
         It should_not_be_an_external_event = () => result.External.ShouldBeFalse();
         It should_have_the_default_external_event_log_sequence_number = () => result.ExternalEventLogSequenceNumber.ShouldEqual(default);
         It should_not_have_external_event_received = () => result.ExternalEventReceived.ShouldBeNull();

--- a/Specifications/EventHorizon/for_EventHorizonConsentsConfiguration/when_creating_a_configuration.cs
+++ b/Specifications/EventHorizon/for_EventHorizonConsentsConfiguration/when_creating_a_configuration.cs
@@ -31,7 +31,7 @@ namespace Dolittle.Runtime.EventHorizon.for_EventHorizonConsentsConfiguration
             consumer_microservice = Guid.Parse("07b697ed-44e4-4167-805f-ff5a9851cf98");
             consumer_tenant = Guid.Parse("8e18214b-287f-41a1-9fef-dd67ef0cf86f");
             stream = Guid.Parse("82695d13-f7a2-4755-ba24-a473154ab7a3");
-            partition = Guid.Parse("1221f439-7b6c-4f34-b084-856e52974f67");
+            partition = "1221f439-7b6c-4f34-b084-856e52974f67";
             consent = Guid.Parse("b2c2f59c-8172-4134-a9d1-a6288d3baed3");
         };
 

--- a/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_processing/an_event.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_processing/an_event.cs
@@ -31,12 +31,12 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers.for_EventProcessor.wh
             @event = new CommittedEvent(
                 0,
                 DateTimeOffset.Now,
-                Guid.NewGuid(),
+                "some event source",
                 execution_contexts.create(),
                 new Artifact(Guid.NewGuid(), 0),
                 true,
                 "");
-            partition = Guid.NewGuid();
+            partition = "some partition";
         };
 
         Because of = () => event_processor.Process(@event, partition, default).GetAwaiter().GetResult();

--- a/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_retrying_processing/an_event.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_retrying_processing/an_event.cs
@@ -30,12 +30,12 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers.for_EventProcessor.wh
             @event = new CommittedEvent(
                 0,
                 DateTimeOffset.Now,
-                Guid.NewGuid(),
+                "some event source",
                 execution_contexts.create(),
                 new Artifact(Guid.NewGuid(), 0),
                 true,
                 "");
-            partition = Guid.NewGuid();
+            partition = "a partition";
         };
 
         Because of = () => event_processor.Process(@event, partition, default).GetAwaiter().GetResult();

--- a/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/given/a_public_event_filter.cs
+++ b/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/given/a_public_event_filter.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon.for_PublicFilt
             new CommittedEvent(
                 EventLogSequenceNumber.Initial,
                 DateTimeOffset.Now,
-                Guid.NewGuid(),
+                "(/event source  ",
                 execution_contexts.create(),
                 new Artifact(Guid.NewGuid(), 0),
                 true,
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon.for_PublicFilt
             new CommittedEvent(
                 EventLogSequenceNumber.Initial,
                 DateTimeOffset.Now,
-                Guid.NewGuid(),
+                "__event_source__",
                 execution_contexts.create(),
                 new Artifact(Guid.NewGuid(), 0),
                 false,

--- a/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/when_filtering_non_public_event.cs
+++ b/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/when_filtering_non_public_event.cs
@@ -12,7 +12,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon.for_PublicFilt
     {
         static IFilterResult result;
 
-        Because of = () => result = filter.Filter(a_non_public_event, Guid.NewGuid(), Guid.NewGuid(), default).GetAwaiter().GetResult();
+        Because of = () => result = filter.Filter(a_non_public_event, "the partition id", Guid.NewGuid(), default).GetAwaiter().GetResult();
 
         It should_not_call_the_remote_filter = () => dispatcher.Verify(_ => _.Call(Moq.It.IsAny<FilterEventRequest>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
         It should_filter_successfully = () => result.Succeeded.ShouldBeTrue();

--- a/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/when_filtering_public_event/and_filtered_successfully.cs
+++ b/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/when_filtering_public_event/and_filtered_successfully.cs
@@ -21,12 +21,12 @@ namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon.for_PublicFilt
         Establish context = () =>
         {
             is_included = true;
-            partition_id = Guid.NewGuid();
-            filter_response = new PartitionedFilterResponse { IsIncluded = is_included, PartitionId = partition_id.ToProtobuf() };
+            partition_id = "partition";
+            filter_response = new PartitionedFilterResponse { IsIncluded = is_included, PartitionId = partition_id.Value };
             dispatcher.Setup(_ => _.Call(Moq.It.IsAny<FilterEventRequest>(), Moq.It.IsAny<CancellationToken>())).Returns(Task.FromResult(filter_response));
         };
 
-        Because of = () => result = filter.Filter(a_public_event, Guid.NewGuid(), Guid.NewGuid(), default).GetAwaiter().GetResult();
+        Because of = () => result = filter.Filter(a_public_event, "a partition", Guid.NewGuid(), default).GetAwaiter().GetResult();
 
         It should_call_the_remote_filter = () => dispatcher.Verify(_ => _.Call(Moq.It.IsAny<FilterEventRequest>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
         It should_filter_successfully = () => result.Succeeded.ShouldBeTrue();

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_included.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_included.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_AbstractFilterProcessor
 
         Establish context = () =>
         {
-            partition = Guid.NewGuid();
+            partition = "partition";
             filter_processor
                 .Setup(_ => _.Filter(
                     Moq.It.IsAny<CommittedEvent>(),

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_not_included.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_not_included.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_AbstractFilterProcessor
 
         Establish context = () =>
         {
-            partition = Guid.NewGuid();
+            partition = "   weird partition   ";
             filter_processor
                 .Setup(_ => _.Filter(
                     Moq.It.IsAny<CommittedEvent>(),

--- a/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_non_partitioned_filter/and_event_type_is_included_in_definition.cs
+++ b/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_non_partitioned_filter/and_event_type_is_included_in_definition.cs
@@ -7,6 +7,7 @@ using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.Events.Store.Streams.Filters;
 using Microsoft.Extensions.Logging;
 using Machine.Specifications;
+using Dolittle.Runtime.Events.Store.Streams;
 
 namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSourcePartition.when_filtering.with_non_partitioned_filter
 {
@@ -26,9 +27,9 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSour
                 Moq.Mock.Of<ILogger<TypeFilterWithEventSourcePartition>>());
         };
 
-        Because of = () => result = filter.Filter(given.committed_events.single_with_artifact(Guid.NewGuid(), artifact), Guid.NewGuid(), Guid.NewGuid(), default).GetAwaiter().GetResult();
+        Because of = () => result = filter.Filter(given.committed_events.single_with_artifact("event source", artifact), "a partition", Guid.NewGuid(), default).GetAwaiter().GetResult();
 
-        It should_have_the_correct_partition = () => result.Partition.Value.ShouldEqual(Guid.Empty);
+        It should_have_none_partition = () => result.Partition.Value.ShouldEqual(PartitionId.None.Value);
         It should_be_successful = () => result.Succeeded.ShouldBeTrue();
         It should_not_retry = () => result.Retry.ShouldBeFalse();
         It should_be_included = () => result.IsIncluded.ShouldBeTrue();

--- a/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_non_partitioned_filter/and_event_type_is_not_included_in_definition.cs
+++ b/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_non_partitioned_filter/and_event_type_is_not_included_in_definition.cs
@@ -7,6 +7,7 @@ using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.Events.Store.Streams.Filters;
 using Microsoft.Extensions.Logging;
 using Machine.Specifications;
+using Dolittle.Runtime.Events.Store.Streams;
 
 namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSourcePartition.when_filtering.with_non_partitioned_filter
 {
@@ -24,9 +25,9 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSour
                 Moq.Mock.Of<ILogger<TypeFilterWithEventSourcePartition>>());
         };
 
-        Because of = () => result = filter.Filter(given.committed_events.single(Guid.NewGuid()), Guid.NewGuid(), Guid.NewGuid(), default).GetAwaiter().GetResult();
+        Because of = () => result = filter.Filter(given.committed_events.single("event source"), "a partition", Guid.NewGuid(), default).GetAwaiter().GetResult();
 
-        It should_have_the_correct_partition = () => result.Partition.Value.ShouldEqual(Guid.Empty);
+        It should_have_none_partition = () => result.Partition.Value.ShouldEqual(PartitionId.None.Value);
         It should_be_successful = () => result.Succeeded.ShouldBeTrue();
         It should_not_retry = () => result.Retry.ShouldBeFalse();
         It should_not_be_included = () => result.IsIncluded.ShouldBeFalse();

--- a/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_partitioned_filter/and_event_type_is_included_in_definition.cs
+++ b/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_partitioned_filter/and_event_type_is_included_in_definition.cs
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSour
         Establish context = () =>
         {
             artifact = given.artifacts.single();
-            partition = Guid.NewGuid();
+            partition = "another partition";
             filter = new TypeFilterWithEventSourcePartition(
                 scope,
                 new TypeFilterWithEventSourcePartitionDefinition(Guid.NewGuid(), Guid.NewGuid(), new ArtifactId[] { artifact.Id }.AsEnumerable(), true),
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSour
                 Moq.Mock.Of<ILogger<TypeFilterWithEventSourcePartition>>());
         };
 
-        Because of = () => result = filter.Filter(given.committed_events.single_with_artifact(partition.Value, artifact), Guid.NewGuid(), Guid.NewGuid(), default).GetAwaiter().GetResult();
+        Because of = () => result = filter.Filter(given.committed_events.single_with_artifact(partition.Value, artifact), "some partition", Guid.NewGuid(), default).GetAwaiter().GetResult();
 
         It should_have_the_correct_partition = () => result.Partition.ShouldEqual(partition);
         It should_be_successful = () => result.Succeeded.ShouldBeTrue();

--- a/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_partitioned_filter/and_event_type_is_not_included_in_definition.cs
+++ b/Specifications/Events.Processing/Filters/for_TypeFilterWithEventSourcePartition/when_filtering/with_partitioned_filter/and_event_type_is_not_included_in_definition.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSour
 
         Establish context = () =>
         {
-            partition = Guid.NewGuid();
+            partition = "the partition";
             filter = new TypeFilterWithEventSourcePartition(
                 scope,
                 new TypeFilterWithEventSourcePartitionDefinition(Guid.NewGuid(), Guid.NewGuid(), new ArtifactId[] { given.artifacts.single().Id }.AsEnumerable(), true),
@@ -27,7 +27,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_TypeFilterWithEventSour
                 Moq.Mock.Of<ILogger<TypeFilterWithEventSourcePartition>>());
         };
 
-        Because of = () => result = filter.Filter(given.committed_events.single(partition.Value), Guid.NewGuid(), Guid.NewGuid(), default).GetAwaiter().GetResult();
+        Because of = () => result = filter.Filter(given.committed_events.single(partition.Value), "some partition id", Guid.NewGuid(), default).GetAwaiter().GetResult();
 
         It should_have_the_correct_partition = () => result.Partition.ShouldEqual(partition);
         It should_be_successful = () => result.Succeeded.ShouldBeTrue();

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/given/all_dependencies.cs
@@ -75,7 +75,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_ValidateFilterByCompari
             var end = events_in_event_log.Count + num_events_to_create;
             for (int i = events_in_event_log.Count; i < end; i++)
             {
-                events_in_event_log.Add(new StreamEvent(committed_events.single((uint)i), (uint)i, StreamId.EventLog, Guid.Empty, true));
+                events_in_event_log.Add(new StreamEvent(committed_events.single((uint)i), (uint)i, StreamId.EventLog, PartitionId.None, true));
             }
         }
 
@@ -84,7 +84,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_ValidateFilterByCompari
             var end = events_in_filtered_stream.Count + num_events_to_create;
             for (int i = events_in_filtered_stream.Count; i < end; i++)
             {
-                events_in_filtered_stream.Add(new StreamEvent(committed_events.single((uint)i), (uint)i, target_stream, partition == default ? new PartitionId(Guid.Empty) : partition, true));
+                events_in_filtered_stream.Add(new StreamEvent(committed_events.single((uint)i), (uint)i, target_stream, partition == default ? PartitionId.None : partition, true));
             }
         }
 
@@ -93,7 +93,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_ValidateFilterByCompari
             var end = events_in_event_log.Count + 1;
             for (int i = events_in_event_log.Count; i < end; i++)
             {
-                events_in_event_log.Add(new StreamEvent(@event, (uint)i, StreamId.EventLog, Guid.Empty, true));
+                events_in_event_log.Add(new StreamEvent(@event, (uint)i, StreamId.EventLog, PartitionId.None, true));
             }
         }
 
@@ -102,7 +102,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_ValidateFilterByCompari
             var end = events_in_filtered_stream.Count + 1;
             for (int i = events_in_filtered_stream.Count; i < end; i++)
             {
-                events_in_filtered_stream.Add(new StreamEvent(@event, (uint)i, target_stream, partition == default ? new PartitionId(Guid.Empty) : partition, true));
+                events_in_filtered_stream.Add(new StreamEvent(@event, (uint)i, target_stream, partition == default ? PartitionId.None : partition, true));
             }
         }
     }

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_old_and_new_filter_includes_the_same_events_in_different_partitions.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_old_and_new_filter_includes_the_same_events_in_different_partitions.cs
@@ -15,10 +15,10 @@ namespace Dolittle.Runtime.Events.Processing.Filters.for_ValidateFilterByCompari
         {
             var @event = committed_events.single(0);
             add_event_to_event_log(1);
-            add_event_to_filtered_stream(1, Guid.NewGuid());
+            add_event_to_filtered_stream(1, "partition");
             filter_processor
                 .Setup(_ => _.Filter(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), event_processor_id, cancellation_token))
-                .Returns(Task.FromResult<IFilterResult>(new SuccessfulFiltering(true, Guid.NewGuid())));
+                .Returns(Task.FromResult<IFilterResult>(new SuccessfulFiltering(true, "a partition")));
         };
 
         static FilterValidationResult result;

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_event_source.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_event_source.cs
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Processing.Projections.for_ProjectionKeys
         Establish context = () =>
         {
             committed_event = committed_events.single();
-            partition = Guid.Parse("8fe25727-b922-4907-aeaa-06497b0ba80e");
+            partition = "the partition";
             definition = given.projection_definition_builder.create()
                             .with_selector(ProjectionEventSelector.EventSourceId(committed_event.Type.Id))
                             .Build();

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_partition.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_partition.cs
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Processing.Projections.for_ProjectionKeys
         Establish context = () =>
         {
             committed_event = committed_events.single();
-            partition = Guid.Parse("8fe25727-b922-4907-aeaa-06497b0ba80e");
+            partition = "___partition__";
             definition = given.projection_definition_builder.create()
                             .with_selector(ProjectionEventSelector.PartitionId(committed_event.Type.Id))
                             .Build();

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_property.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_property.cs
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Processing.Projections.for_ProjectionKeys
         Establish context = () =>
         {
             committed_event = committed_events.single("{\"property\": \"value\"}");
-            partition = Guid.Parse("8fe25727-b922-4907-aeaa-06497b0ba80e");
+            partition = "/(partition!";
             definition = given.projection_definition_builder.create()
                             .with_selector(new ProjectionEventSelector(committed_event.Type.Id, ProjectEventKeySelectorType.Property, "property"))
                             .Build();

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_adding_failing_partition.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_adding_failing_partition.cs
@@ -22,7 +22,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_FailingPart
         Establish context = () =>
         {
             stream_processor_id = new StreamProcessorId(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
-            partition = Guid.NewGuid();
+            partition = "a partition";
             stream_position = 0;
             retry_time = DateTimeOffset.Now;
             old_state = new StreamProcessorState(stream_position, new Dictionary<PartitionId, FailingPartitionState>(), DateTimeOffset.UtcNow);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/given/all_dependencies.cs
@@ -22,8 +22,8 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_FailingPart
 
         Establish context = () =>
         {
-            first_failing_partition_id = Guid.NewGuid();
-            second_failing_partition_id = Guid.NewGuid();
+            first_failing_partition_id = "first failing partition";
+            second_failing_partition_id = "the second failing partiton";
             first_initial_failing_partition_position = second_initial_failing_partition_position = 0;
             first_initial_failing_partition_reason = second_initial_failing_partition_reason = "some reason";
             first_initial_failing_partition_retry_time = second_initial_failing_partition_retry_time = DateTimeOffset.UtcNow;

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/given/all_dependencies.cs
@@ -17,7 +17,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_FailingPart
 
         Establish context = () =>
         {
-            failing_partition_id = Guid.NewGuid();
+            failing_partition_id = "failing partition";
             initial_failing_partition_position = 0;
             initial_failing_partition_reason = "some reason";
             initial_failing_partition_retry_time = DateTimeOffset.UtcNow;

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_at_second_event_in_both_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_at_second_event_in_both_partitions.cs
@@ -23,8 +23,8 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
 
         Establish context = () =>
         {
-            first_partition_id = Guid.NewGuid();
-            second_partition_id = Guid.NewGuid();
+            first_partition_id = "first partition";
+            second_partition_id = "second partition";
             first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
             second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
             third_event = new StreamEvent(committed_events.single(), 2u, Guid.NewGuid(), first_partition_id, true);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_both_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_both_partitions.cs
@@ -21,8 +21,8 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
 
         Establish context = () =>
         {
-            first_partition_id = Guid.NewGuid();
-            second_partition_id = Guid.NewGuid();
+            first_partition_id = "first partition";
+            second_partition_id = "second partition";
             first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
             second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
             event_processor

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_one_partition.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_one_partition.cs
@@ -23,8 +23,8 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
 
         Establish context = () =>
         {
-            first_partition_id = Guid.NewGuid();
-            second_partition_id = Guid.NewGuid();
+            first_partition_id = "first partition";
+            second_partition_id = "second partition";
             first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
             second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
             third_event = new StreamEvent(committed_events.single(), 2u, Guid.NewGuid(), second_partition_id, true);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_must_retry_in_both_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_must_retry_in_both_partitions.cs
@@ -21,8 +21,8 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
 
         Establish context = () =>
         {
-            first_partition_id = Guid.NewGuid();
-            second_partition_id = Guid.NewGuid();
+            first_partition_id = "first partition";
+            second_partition_id = "second partition";
             first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
             second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
             event_processor

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_first_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_first_event.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
     public class and_event_processing_failed_at_first_event : given.all_dependencies
     {
         const string reason = "some reason";
-        static readonly PartitionId partition_id = Guid.NewGuid();
+        static readonly PartitionId partition_id = "partition";
         static readonly CommittedEvent first_event = committed_events.single();
 
         Establish context = () =>

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
     public class and_event_processing_failed_at_second_event : given.all_dependencies
     {
         const string reason = "some reason";
-        static readonly PartitionId partition_id = Guid.NewGuid();
+        static readonly PartitionId partition_id = "a partition";
         static readonly CommittedEvent first_event = committed_events.single();
         static readonly CommittedEvent second_event = committed_events.single();
 

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_stream_processor_must_retry_processing_an_event_three_times.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_stream_processor_must_retry_processing_an_event_three_times.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStrea
     {
         const string failure_reason = "some reason";
         const string retry_reason = "retry reason";
-        static readonly PartitionId partition_id = Guid.NewGuid();
+        static readonly PartitionId partition_id = "cool partition";
         static readonly CommittedEvent first_event = committed_events.single();
 
         Establish context = () =>

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_first_event.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_first_event.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.w
     public class and_event_processing_failed_at_first_event : given.all_dependencies
     {
         const string reason = "some reason";
-        static readonly PartitionId partition_id = Guid.NewGuid();
+        static readonly PartitionId partition_id = "a partition id";
         static readonly CommittedEvent first_event = committed_events.single();
         static CancellationTokenSource cancellation_token_source;
 

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_second_event.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.w
     public class and_event_processing_failed_at_second_event : given.all_dependencies
     {
         const string reason = "some reason";
-        static readonly PartitionId partition_id = Guid.NewGuid();
+        static readonly PartitionId partition_id = "partition id";
         static readonly CommittedEvent first_event = committed_events.single();
         static readonly CommittedEvent second_event = committed_events.single();
         static CancellationTokenSource cancellation_token_source;

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_stream_processor_must_retry_processing_an_event_three_times.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_stream_processor_must_retry_processing_an_event_three_times.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.w
     {
         const string failure_reason = "some reason";
         const string retry_reason = "retry reason";
-        static readonly PartitionId partition_id = Guid.NewGuid();
+        static readonly PartitionId partition_id = "<12partition>";
         static readonly CommittedEvent first_event = committed_events.single();
         static CancellationTokenSource cancellation_token_source;
 

--- a/Specifications/Events.Processing/committed_events.cs
+++ b/Specifications/Events.Processing/committed_events.cs
@@ -16,7 +16,7 @@ namespace Dolittle.Runtime.Events.Processing
         public static CommittedEvent single(EventLogSequenceNumber event_log_sequence_number, string content) => new(
                 event_log_sequence_number,
                 DateTimeOffset.UtcNow,
-                EventSourceId.New(),
+                "event source///",
                 execution_contexts.create(),
                 new Artifact(ArtifactId.New(), ArtifactGeneration.First),
                 false,

--- a/Specifications/Events.Store.MongoDB/Aggregates/for_AggregateRoot/when_creating_aggregate_root.cs
+++ b/Specifications/Events.Store.MongoDB/Aggregates/for_AggregateRoot/when_creating_aggregate_root.cs
@@ -16,7 +16,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates.for_AggregateRoot
 
         Establish context = () =>
         {
-            event_source = Guid.Parse("a970569d-497e-463d-8174-b608d25d38cb");
+            event_source = "a970569d-event-source-b608d25d38cb";
             aggregate_type = Guid.Parse("4c95bbef-ce78-4ffe-b1aa-36e7ad7fa6c5");
             version = random.aggregate_root_version;
         };

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/a_non_aggregate/partitioned_stream_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/a_non_aggregate/partitioned_stream_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
         Establish context = () =>
         {
             stream_position = random.stream_position;
-            partition = Guid.Parse("82e94df4-75d8-45e1-9595-bb17552975e8");
+            partition = "82e94df4-75d8-45e1-9595-bb17552975e8 partition";
             stream = Guid.Parse("f61ca65f-29e2-47a8-b51a-2ca35e489860");
             stored_event = events.a_stream_event_not_from_aggregate(stream_position, partition);
             event_converter = new EventConverter(event_content_converter.Object);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/a_non_aggregate/unpartitioned_stream_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/a_non_aggregate/unpartitioned_stream_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
         {
             stream_position = random.stream_position;
             stream = Guid.Parse("206efb44-95e5-4db9-82d5-79d5690e8f81");
-            stored_event = events.a_stream_event_not_from_aggregate(stream_position, Guid.Parse("06402523-e6bb-4821-b468-55fe3956e922"));
+            stored_event = events.a_stream_event_not_from_aggregate(stream_position, "partition 06402523-e6bb-4821-b468-55fe3956e922");
             event_converter = new EventConverter(event_content_converter.Object);
         };
 

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_aggregate/partitioned_stream_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_aggregate/partitioned_stream_event.cs
@@ -22,7 +22,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
         {
             stream_position = random.stream_position;
             aggregate_root_version = random.aggregate_root_version;
-            partition = Guid.Parse("76fe52e0-9b3f-4484-9581-7bf014a4de4a");
+            partition = "random partition";
             stream = Guid.Parse("6d3bf849-dfbf-4526-8ef0-c01d7620be94");
             stored_event = events.an_aggregate_stream_event(stream_position, partition, aggregate_root_version);
             event_converter = new EventConverter(event_content_converter.Object);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_aggregate/unpartitioned_stream_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_aggregate/unpartitioned_stream_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
         {
             stream_position = random.stream_position;
             stream = Guid.Parse("6793bb6f-b36f-4fc0-966b-9e66e499b1f4");
-            stored_event = events.an_aggregate_stream_event(stream_position, Guid.Parse("5e8b7530-5e63-4efd-bfa3-c88c14a0e853"), random.aggregate_root_version);
+            stored_event = events.an_aggregate_stream_event(stream_position, "5e8b7530-5e63-partition", random.aggregate_root_version);
             event_converter = new EventConverter(event_content_converter.Object);
         };
 

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_external/partitioned_stream_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_external/partitioned_stream_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
         Establish context = () =>
         {
             stream_position = random.stream_position;
-            partition = Guid.Parse("f33a900b-9f24-429d-abe8-3bb44f63f074");
+            partition = "   partition    f33a900b-9f24-429d-abe8-3bb44f63f074";
             stream = Guid.Parse("3fcc88d1-1866-428e-80b4-0e9bd89dbf27");
             stored_event = events.an_external_stream_event(stream_position, partition);
             event_converter = new EventConverter(event_content_converter.Object);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_external/unpartitioned_stream_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_runtime_stream_event/an_external/unpartitioned_stream_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
         {
             stream_position = random.stream_position;
             stream = Guid.Parse("48ab3ce1-b7bd-486a-a21f-54b1ce5c42fa");
-            stored_event = events.an_external_stream_event(stream_position, Guid.Empty);
+            stored_event = events.an_external_stream_event(stream_position, PartitionId.None);
             event_converter = new EventConverter(event_content_converter.Object);
         };
 

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/a_non_aggregate_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/a_non_aggregate_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
             committed_event = committed_events.a_committed_event(random.event_log_sequence_number);
             event_converter = new EventConverter(event_content_converter.Object);
             stream_position = random.stream_position;
-            partition = Guid.Parse("9b63adc5-e09b-4fec-9a30-29c220b0dd79");
+            partition = "9b63adc5-e09b-4fec-9a30-29c220b0dd79 partition";
         };
 
         Because of = () => result = event_converter.ToStoreStreamEvent(committed_event, stream_position, partition);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_aggregate_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_aggregate_event.cs
@@ -17,10 +17,10 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
 
         Establish context = () =>
         {
-            committed_event = committed_events.a_committed_aggregate_event(random.event_log_sequence_number, Guid.Parse("ad52a09c-6a25-4cb8-a38a-1a5ee30615d7"), Guid.Parse("77663b1c-79a0-46f7-8d87-fc7cd53dacf6"), random.aggregate_root_version);
+            committed_event = committed_events.a_committed_aggregate_event(random.event_log_sequence_number, Guid.Parse("ad52a09c-6a25-4cb8-a38a-1a5ee30615d7"), "event source 77663b1c-79a0-46f7-8d87-fc7cd53dacf6", random.aggregate_root_version);
             event_converter = new EventConverter(event_content_converter.Object);
             stream_position = random.stream_position;
-            partition = Guid.Parse("479770cd-edef-4ca2-bf37-5735d8ad484d");
+            partition = "479770cd-edef-4ca2-bf37-5735d8ad484d";
         };
 
         Because of = () => result = event_converter.ToStoreStreamEvent(committed_event, stream_position, partition);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_external_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_external_event.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventConverter.when_c
             committed_event = committed_events.a_committed_external_event(random.event_log_sequence_number, random.event_log_sequence_number);
             event_converter = new EventConverter(event_content_converter.Object);
             stream_position = random.stream_position;
-            partition = Guid.Parse("5170e7b5-6a98-4d99-99ef-83b0bbe2796a");
+            partition = "5170e7b5-6a98-4d99-99ef-83b0bbe2796a";
         };
 
         Because of = () => result = event_converter.ToStoreStreamEvent(committed_event, stream_position, partition);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventMetadata/when_creating.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventMetadata/when_creating.cs
@@ -9,7 +9,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventMetadata
     public class when_creating
     {
         static DateTime occurred;
-        static Guid event_source;
+        static string event_source;
         static Guid type_id;
         static uint type_generation;
         static bool is_public;
@@ -18,7 +18,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_EventMetadata
         Establish context = () =>
         {
             occurred = new DateTime(2852152428, DateTimeKind.Utc);
-            event_source = Guid.Parse("bfbfb1aa-b6c1-4bc3-9269-23d5e4205231");
+            event_source = "event source";
             type_id = Guid.Parse("5b92f887-a986-4cde-a375-cb868c50eee2");
             type_generation = 678275961;
             is_public = true;

--- a/Specifications/Events.Store.MongoDB/Events/for_StreamEvent/when_creating.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_StreamEvent/when_creating.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_StreamEvent
     public class when_creating
     {
         static ulong stream_position;
-        static Guid partition;
+        static string partition;
         static ExecutionContext execution_context;
         static StreamEventMetadata stream_event_metadata;
         static AggregateMetadata aggregate_metadata;
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_StreamEvent
         Establish context = () =>
         {
             stream_position = random.stream_position;
-            partition = Guid.Parse("c485009f-397f-48b1-bf8c-6040f0efe523");
+            partition = "   partition   ˝";
             execution_context = execution_contexts.create_store();
             stream_event_metadata = metadata.random_stream_event_metadata;
             aggregate_metadata = metadata.aggregate_metadata_from_non_aggregate_event;

--- a/Specifications/Events.Store.MongoDB/Events/for_StreamEventMetadata/when_creating.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_StreamEventMetadata/when_creating.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_StreamEventMetadata
     {
         static ulong event_log_sequence_number;
         static DateTime occurred;
-        static Guid event_source;
+        static string event_source;
         static Guid type_id;
         static uint type_generation;
         static bool is_public;
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events.for_StreamEventMetadata
         {
             event_log_sequence_number = random.event_log_sequence_number;
             occurred = new DateTime(137599714, DateTimeKind.Utc);
-            event_source = Guid.Parse("adc4819f-5d9b-44fc-aef3-1520fc7c1713");
+            event_source = "  the event source";
             type_id = Guid.Parse("24352369-fd47-4950-8e62-963f2c402970");
             type_generation = 1227724615;
             is_public = true;

--- a/Specifications/Events.Store.MongoDB/committed_events.cs
+++ b/Specifications/Events.Store.MongoDB/committed_events.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
             new CommittedEvent(
                 event_log_sequence_number,
                 new DateTimeOffset(2232571935, TimeSpan.Zero),
-                Guid.Parse("914990bd-9c3b-4909-a448-989a2df7951b"),
+                "event source",
                 execution_contexts.create(),
                 new Artifact(Guid.Parse("e61f3f6e-fc31-4e76-9274-c37cacbb74eb"), 2405803362),
                 false,
@@ -34,7 +34,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
             new CommittedExternalEvent(
                 event_log_sequence_number,
                 new DateTimeOffset(1242521935, TimeSpan.Zero),
-                Guid.Parse("5538a71c-fc8d-4f93-8e18-a2aadf070175"),
+                "event source 4f93-8e18-a2aadf070175",
                 execution_contexts.create(),
                 new Artifact(Guid.Parse("9e2f39c6-4824-4054-b714-8ccf63921cd9"), 2575047027),
                 false,

--- a/Specifications/Events.Store.MongoDB/event_metadata_builder.cs
+++ b/Specifications/Events.Store.MongoDB/event_metadata_builder.cs
@@ -13,14 +13,14 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         public event_metadata_builder() =>
             _instance = new EventMetadata(
                 new DateTime(214800287, DateTimeKind.Utc),
-                Guid.Parse("0bc15693-6141-449b-b66d-11a610ec7c82"),
+                "0bc15693-6141-eventsource-11a610ec7c82",
                 Guid.Parse("17398e13-539e-4628-b419-ee081b631c57"),
                 1990762078,
                 false);
 
         public EventMetadata build() => _instance;
 
-        public event_metadata_builder with_event_source(Guid event_source)
+        public event_metadata_builder with_event_source(string event_source)
         {
             _instance.EventSource = event_source;
             return this;

--- a/Specifications/Events.Store.MongoDB/stream_event_metadata_builder.cs
+++ b/Specifications/Events.Store.MongoDB/stream_event_metadata_builder.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
             _instance = new StreamEventMetadata(
                 59077,
                 new DateTime(2943653239, DateTimeKind.Utc),
-                Guid.Parse("a61e645e-70e8-4249-ad48-33536a57a139"),
+                "the event sourec",
                 Guid.Parse("a4ca4bbd-21d3-4caf-9e5e-b46ce26b0b2e"),
                 62012,
                 false);
@@ -27,7 +27,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
             return this;
         }
 
-        public stream_event_metadata_builder with_event_source(Guid event_source)
+        public stream_event_metadata_builder with_event_source(string event_source)
         {
             _instance.EventSource = event_source;
             return this;

--- a/Specifications/Events.Store/Streams/for_StreamEvent/when_creating_stream_event.cs
+++ b/Specifications/Events.Store/Streams/for_StreamEvent/when_creating_stream_event.cs
@@ -20,12 +20,12 @@ namespace Dolittle.Runtime.Events.Store.Streams.for_StreamEvent
         {
             stream = Guid.NewGuid();
             stream_position = 0;
-            partition = Guid.NewGuid();
+            partition = "]≈[partitionﬁß";
             execution_context = execution_contexts.create();
             committed_event = new CommittedEvent(
                 0,
                 DateTimeOffset.Now,
-                Guid.NewGuid(),
+                "event source∞§",
                 execution_context,
                 new Artifacts.Artifact(Guid.NewGuid(), 0),
                 false,

--- a/Specifications/Events.Store/for_CommittedAggregateEvent/when_creating_event.cs
+++ b/Specifications/Events.Store/for_CommittedAggregateEvent/when_creating_event.cs
@@ -30,7 +30,7 @@ namespace Dolittle.Runtime.Events.Store.for_CommittedAggregateEvent
             aggregate_root_version = 1;
             event_log_sequence_number = 2;
             occurred = DateTimeOffset.Now;
-            event_source = Guid.NewGuid();
+            event_source = "    event     source    ";
             execution_context = execution_contexts.create();
             artifact_id = Guid.NewGuid();
             artifact_generation = 4;

--- a/Specifications/Events.Store/for_CommittedAggregateEvents/given/events_and_an_artifact.cs
+++ b/Specifications/Events.Store/for_CommittedAggregateEvents/given/events_and_an_artifact.cs
@@ -11,7 +11,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.for_CommittedAggregateEvents.given
     public abstract class events_and_an_artifact
     {
         public const bool is_public = false;
-        public static EventSourceId event_source_id = Guid.Parse("a96d181c-cf8b-4bc9-a576-20be48166101");
+        public static EventSourceId event_source_id = Guid.Parse("a96d181c-cf8b-4bc9-a576-20be48166101").ToString();
         public static Artifact aggregate_artifact = new Artifact(Guid.Parse("28238ebc-6454-4229-8891-5798ecb1875f"), ArtifactGeneration.First);
         public static AggregateRootVersion aggregate_version_before = 0;
         public static AggregateRootVersion aggregate_version_after = 3;

--- a/Specifications/Events.Store/for_CommittedAggregateEvents/when_creating_with_a_wrong_event_source.cs
+++ b/Specifications/Events.Store/for_CommittedAggregateEvents/when_creating_with_a_wrong_event_source.cs
@@ -8,7 +8,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.for_CommittedAggregateEvents
 {
     public class when_creating_with_a_wrong_event_source : given.events_and_an_artifact
     {
-        static EventSourceId wrong_event_source_id = Guid.Parse("d695855e-9702-44f6-90bf-64cbc68cf5e1");
+        static EventSourceId wrong_event_source_id = Guid.Parse("d695855e-9702-44f6-90bf-64cbc68cf5e1").ToString();
         static CommittedAggregateEvent wrong_event_source_event;
         static CommittedAggregateEvents events;
         static Exception exception;

--- a/Specifications/Events.Store/for_CommittedEvent/when_creating_event.cs
+++ b/Specifications/Events.Store/for_CommittedEvent/when_creating_event.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.Events.Store.for_CommittedEvent
         {
             event_log_sequence_number = 0;
             occurred = DateTimeOffset.Now;
-            event_source = Guid.NewGuid();
+            event_source = "a random event source";
             execution_context = execution_contexts.create();
             artifact_id = Guid.NewGuid();
             artifact_generation = 2;

--- a/Specifications/Events.Store/for_UncommittedAggregateEvents/given/events_and_an_aggregate.cs
+++ b/Specifications/Events.Store/for_UncommittedAggregateEvents/given/events_and_an_aggregate.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.for_UncommittedAggregateEvents.giv
     public abstract class events_and_an_aggregate
     {
         public const bool is_public = false;
-        public static EventSourceId event_source_id = Guid.Parse("a96d181c-cf8b-4bc9-a576-20be48166101");
+        public static EventSourceId event_source_id = "a96d181c-cf8b-4bc9-a576-20be48166101";
         public static Artifact aggregate_artifact = new Artifact(Guid.Parse("28238ebc-6454-4229-8891-5798ecb1875f"), ArtifactGeneration.First);
         public static AggregateRootVersion aggregate_version = AggregateRootVersion.Initial;
 

--- a/Specifications/Events.Store/for_UncommittedEvent/when_creating_uncommitted_event.cs
+++ b/Specifications/Events.Store/for_UncommittedEvent/when_creating_uncommitted_event.cs
@@ -18,7 +18,7 @@ namespace Dolittle.Runtime.Events.Store.for_UncommittedEvent
 
         Establish context = () =>
         {
-            event_source_id = Guid.NewGuid();
+            event_source_id = "the event source™";
             artifact_id = Guid.NewGuid();
             artifact_generation = 0;
             is_public = false;

--- a/Specifications/Events.Store/for_UncommittedEvents/given/events.cs
+++ b/Specifications/Events.Store/for_UncommittedEvents/given/events.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.for_UncommittedEvents.given
     public abstract class events
     {
         public const bool is_public = false;
-        public static EventSourceId event_source_id = Guid.NewGuid();
+        public static EventSourceId event_source_id = "eventßª√source[]";
         public static Artifact event_a_artifact = new Artifact(Guid.Parse("d26cc060-9153-4988-8f07-3cf67f58bf47"), ArtifactGeneration.First);
         public static Artifact event_b_artifact = new Artifact(Guid.Parse("cc657c0a-2c81-4338-85a8-507f05d4fc0e"), ArtifactGeneration.First);
 

--- a/versions.props
+++ b/versions.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <AutofacVersion>5.0.0</AutofacVersion>
         <AutofacExtensionsVersion>6.0.0</AutofacExtensionsVersion>
-        <ContractsVersion>5.4.0</ContractsVersion>
+        <ContractsVersion>6.0.0-eventsource.0</ContractsVersion>
         <CoverletVersion>2.9.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <GrpcVersion>2.38.1</GrpcVersion>


### PR DESCRIPTION
## Summary

Change event source id and partition id to be strings and deal with all the compilation and tests errors that causes.