### PR TITLE
Add CLI binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       should-publish: ${{ steps.context.outputs.should-publish }}
       release-type: ${{ steps.context.outputs.release-type }}
       next-version: ${{ steps.increment-version.outputs.next-version }}
+      release-output-url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v2
       - name: Establish context
@@ -40,6 +41,7 @@ jobs:
           user-email: build@dolittle.com
           user-name: dolittle-build
       - name: Create GitHub Release
+        id: create-release
         uses: dolittle/github-release-action@v2
         if: ${{ steps.context.outputs.should-publish == 'true' }}
         with:
@@ -194,3 +196,122 @@ jobs:
           file: ./Docker/ARM64Development/Dockerfile
           tags: dolittle/runtime:latest-arm64-development
           platforms: linux/arm64
+
+  release-cli-tool:
+    name: Release Dolittle CLI tool
+    needs: setup
+    runs-on: ubuntu-latest
+    if: needs.setup.outputs.should-publish == 'true'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
+      - name: Publish for macOS x64
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=osx-x64
+      - name: Upload macOS x64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/osx-x64/publish/dolittle
+          asset_name: dolittle-macos-x64
+          asset_content_type: application/octet-stream
+#      - name: Publish for macOS arm64
+#        working-directory: ./Source/CLI
+#        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=osx.11.0-arm64
+#      - name: Upload macOS arm64
+#        uses: actions/upload-release-asset@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+#          asset_path: ./Source/CLI/bin/Release/net5.0/osx.11.0-arm64/publish/dolittle
+#          asset_name: dolittle-macos-arm64
+#          asset_content_type: application/octet-stream
+      - name: Publish for Windows x64
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=win-x64
+      - name: Upload Windows x64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/win-x64/publish/dolittle
+          asset_name: dolittle-win-x64
+          asset_content_type: application/octet-stream
+      - name: Publish for Windows x86
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=win-x86
+      - name: Upload Windows x86
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/win-x86/publish/dolittle
+          asset_name: dolittle-win-x86
+          asset_content_type: application/octet-stream
+      - name: Publish for Windows arm64
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=win-arm64
+      - name: Upload Windows arm64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/win-arm64/publish/dolittle
+          asset_name: dolittle-win-arm64
+          asset_content_type: application/octet-stream
+      - name: Publish for Windows arm
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=win-arm
+      - name: Upload Windows arm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/win-arm/publish/dolittle
+          asset_name: dolittle-win-arm
+          asset_content_type: application/octet-stream
+      - name: Publish for Linux x64
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=linux-x64
+      - name: Upload Linux x64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/linux-x64/publish/dolittle
+          asset_name: dolittle-linux-x64
+          asset_content_type: application/octet-stream
+      - name: Publish for Linux arm64
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=linux-arm64
+      - name: Upload Linux arm64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/linux-arm64/publish/dolittle
+          asset_name: dolittle-linux-arm64
+          asset_content_type: application/octet-stream
+      - name: Publish for Linux arm
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=linux-arm
+      - name: Upload Linux arm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net5.0/linux-arm/publish/dolittle
+          asset_name: dolittle-linux-arm
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Adds workflow steps for building and releasing the `dolittle` cli as binaries on the Release page on GitHub. The macOS arm build didn't work on my machine - but that might just be an old .NET sdk. We can fix later.