### PR TITLE
Use default values in endpoints configuration

### DIFF
--- a/Specifications/Services/Services.csproj
+++ b/Specifications/Services/Services.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../specs.props"/>
+  <Import Project="../../specs.props" />
 
   <PropertyGroup>
     <AssemblyName>Dolittle.Runtime.Services.Specs</AssemblyName>

--- a/Specifications/Services/for_Endpoints/given/default_configuration_providers.cs
+++ b/Specifications/Services/for_Endpoints/given/default_configuration_providers.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.Configuration;
+using Dolittle.Runtime.Types;
+using Machine.Specifications;
+using Moq;
+
+namespace Dolittle.Runtime.Services.for_Endpoints.given
+{
+    public class default_configuration_providers
+    {
+        protected static IInstancesOf<ICanProvideDefaultConfigurationFor<EndpointsConfiguration>> default_providers;
+
+        private Establish context = () =>
+        {
+            var mock = new Mock<IInstancesOf<ICanProvideDefaultConfigurationFor<EndpointsConfiguration>>>();
+            var list = new List<ICanProvideDefaultConfigurationFor<EndpointsConfiguration>>();
+
+            mock.Setup(_ => _.GetEnumerator())
+                .Returns(list.GetEnumerator());
+
+            default_providers = mock.Object;
+        };
+    }
+}

--- a/Specifications/Services/for_Endpoints/given/one_service_type_with_binder.cs
+++ b/Specifications/Services/for_Endpoints/given/one_service_type_with_binder.cs
@@ -13,7 +13,7 @@ using Moq;
 
 namespace Dolittle.Runtime.Services.for_Endpoints.given
 {
-    public class one_service_type_with_binder
+    public class one_service_type_with_binder : default_configuration_providers
     {
         protected const string service_type_identifier = "My Service Type";
 

--- a/Specifications/Services/for_Endpoints/given/one_service_type_with_two_binders.cs
+++ b/Specifications/Services/for_Endpoints/given/one_service_type_with_two_binders.cs
@@ -12,7 +12,7 @@ using Moq;
 
 namespace Dolittle.Runtime.Services.for_Endpoints.given
 {
-    public class one_service_type_with_two_binders
+    public class one_service_type_with_two_binders : default_configuration_providers
     {
         protected const string service_type_identifier = "My Service Type";
 

--- a/Specifications/Services/for_Endpoints/given/two_service_types_with_different_visibility_and_two_binders_each.cs
+++ b/Specifications/Services/for_Endpoints/given/two_service_types_with_different_visibility_and_two_binders_each.cs
@@ -13,7 +13,7 @@ using Moq;
 
 namespace Dolittle.Runtime.Services.for_Endpoints.given
 {
-    public class two_service_types_with_different_visibility_and_two_binders_each
+    public class two_service_types_with_different_visibility_and_two_binders_each : default_configuration_providers
     {
         protected const string first_service_type_identifier = "My First Service Type";
         protected const string second_service_type_identifier = "My Second Service Type";

--- a/Specifications/Services/for_Endpoints/when_starting/with_one_endpoint_enabled.cs
+++ b/Specifications/Services/for_Endpoints/when_starting/with_one_endpoint_enabled.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Services.for_Endpoints.when_starting
         {
             configuration = configuration with { Enabled = true };
             var endpoints_configuration = CreateEndpointsConfiguration(configuration);
-            endpoints = new Endpoints(service_types, endpoints_configuration, type_finder.Object, container.Object, bound_services.Object, logger);
+            endpoints = new Endpoints(service_types, endpoints_configuration, default_providers, type_finder.Object, container.Object, bound_services.Object, logger);
         };
 
         Because of = () => endpoints.Start();

--- a/Specifications/Services/for_Endpoints/when_starting/with_one_endpoint_not_enabled.cs
+++ b/Specifications/Services/for_Endpoints/when_starting/with_one_endpoint_not_enabled.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Services.for_Endpoints.when_starting
         {
             configuration = configuration with { Enabled = false };
             var endpoints_configuration = CreateEndpointsConfiguration(configuration);
-            endpoints = new Endpoints(service_types, endpoints_configuration, type_finder.Object, container.Object, bound_services.Object, logger);
+            endpoints = new Endpoints(service_types, endpoints_configuration, default_providers, type_finder.Object, container.Object, bound_services.Object, logger);
         };
 
         Because of = () => endpoints.Start();

--- a/Specifications/Services/for_Endpoints/when_starting/with_one_service_type_and_two_binders.cs
+++ b/Specifications/Services/for_Endpoints/when_starting/with_one_service_type_and_two_binders.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Services.for_Endpoints.when_starting
         {
             configuration = configuration with { Enabled = true };
             var endpoints_configuration = CreateEndpointsConfiguration(configuration);
-            endpoints = new Endpoints(service_types, endpoints_configuration, type_finder.Object, container.Object, bound_services.Object, logger);
+            endpoints = new Endpoints(service_types, endpoints_configuration, default_providers, type_finder.Object, container.Object, bound_services.Object, logger);
         };
 
         Because of = () => endpoints.Start();

--- a/Specifications/Services/for_Endpoints/when_starting/with_two_service_types_with_different_visibility_two_binders_each.cs
+++ b/Specifications/Services/for_Endpoints/when_starting/with_two_service_types_with_different_visibility_two_binders_each.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Services.for_Endpoints.when_starting
         {
             public_configuration = public_configuration with { Enabled = true };
             var endpoints_configuration = CreateEndpointsConfiguration(public_configuration, private_configuration);
-            endpoints = new Endpoints(service_types, endpoints_configuration, type_finder.Object, container.Object, bound_services.Object, logger);
+            endpoints = new Endpoints(service_types, endpoints_configuration, default_providers, type_finder.Object, container.Object, bound_services.Object, logger);
         };
 
         Because of = () => endpoints.Start();


### PR DESCRIPTION
## Summary

Fixes the behaviour of default configuration for gRPC Endpoints. The previous implementation used default values for all endpoints together (the whole contents of the `endpoints.json` file). Meaning that if you partially specified this configuration for some endpoints, it would not use default values for the rest. This fixes that by using the default values per endpoint visibility if not provided in the config Gile.

### Changed

- Use default values for each `EndpointConfiguration` per `EndpointVisibility`, instead of defaulting for the whole `EndpointsConfiguration` only when nothing was provided.

