### PR TITLE
Upgrade Contracts, make custom failures for Handshake.

### DIFF
--- a/Source/Platform/Handshake/ContractsCompatibility.cs
+++ b/Source/Platform/Handshake/ContractsCompatibility.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Defines the results of verifying compatibility of a Client SDK and a Runtime version.
+/// </summary>
+public enum ContractsCompatibility
+{
+    /// <summary>
+    /// The value returned when the versions are compatible.
+    /// </summary>
+    Compatible = 0,
+    
+    /// <summary>
+    /// The value returned when the Contracts version used by the Client SDK is older than required by the current Runtime version.
+    /// </summary>
+    ClientTooOld = 1,
+    
+    /// <summary>
+    /// The value returned when the Contracts version used by the Client SDK is newer than supported by the current Runtime version.
+    /// </summary>
+    RuntimeTooOld = 2,
+}

--- a/Source/Platform/Handshake/HandshakeAttempt.cs
+++ b/Source/Platform/Handshake/HandshakeAttempt.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Represents the number of handshake request attempts that have been made by a Client.
+/// </summary>
+/// <param name="Attempt">The attempt number.</param>
+public record HandshakeAttempt(uint Attempt) : ConceptAs<uint>(Attempt)
+{
+    /// <summary>
+    /// Implicitly convert from a <see cref="uint"/> to an <see cref="HandshakeAttempt"/>.
+    /// </summary>
+    /// <param name="attempt">HandshakeAttempt as a <see cref="uint"/>.</param>
+    /// <returns>The <see cref="HandshakeAttempt"/> concept value.</returns>
+    public static implicit operator HandshakeAttempt(uint attempt) => new(attempt);
+}

--- a/Source/Platform/Handshake/HandshakeFailures.cs
+++ b/Source/Platform/Handshake/HandshakeFailures.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Handshake.Contracts;
+using Dolittle.Runtime.Protobuf;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Holds the unique <see cref="FailureId">failure ids</see> used in handshakes.
+/// </summary>
+public static class HandshakeFailures
+{
+    /// <summary>
+    /// Gets the <see cref="FailureId"/> that is returned when a <see cref="HandshakeRequest"/> is missing required information.
+    /// </summary>
+    public static FailureId MissingHandshakeInformation => FailureId.Create("8f5ba2c2-6543-47ce-b2a8-d92a872e7280");
+    
+    /// <summary>
+    /// Gets the <see cref="FailureId"/> that is returned when the Contracts version of the Client SDK is too old to be used with the current Runtime.
+    /// </summary>
+    public static FailureId SDKMustBeUpdated => FailureId.Create("3e2d8368-4bca-4e0b-a9bf-8d1cccbcac21");
+    
+    /// <summary>
+    /// Gets the <see cref="FailureId"/> that is returned when the Contracts version of the Runtime is too old to be used with the Client SDK.
+    /// </summary>
+    public static FailureId RuntimeMustBeUpdated => FailureId.Create("b46fb8a0-4565-4f00-880c-022cbb3bbabb");
+}

--- a/Source/Platform/Handshake/HandshakeService.cs
+++ b/Source/Platform/Handshake/HandshakeService.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Threading.Tasks;
-using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Handshake.Contracts;
 using Dolittle.Runtime.Protobuf;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using static Dolittle.Runtime.Handshake.Contracts.Handshake;
-using Environment = Dolittle.Runtime.Execution.Environment;
 using Version = Dolittle.Runtime.Versioning.Version;
 using Failure = Dolittle.Protobuf.Contracts.Failure;
 
@@ -21,20 +19,33 @@ namespace Dolittle.Runtime.Platform.Handshake;
 public class HandshakeService : HandshakeBase
 {
     readonly IResolvePlatformEnvironment _platformEnvironment;
+    readonly IRequestConverter _requestConverter;
     readonly IVerifyContractsCompatibility _contractsCompatibility;
     readonly ILogger _logger;
+    
+    readonly Version _runtimeVersion;
+    readonly Version _runtimeContractsVersion;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HandshakeService"/> class.
     /// </summary>
-    /// <param name="platformEnvironment">The <see cref="IResolvePlatformEnvironment"/>.</param>
-    /// <param name="contractsCompatibility"></param>
-    /// <param name="logger">The <see cref="ILogger"/>.</param>
-    public HandshakeService(IResolvePlatformEnvironment platformEnvironment, IVerifyContractsCompatibility contractsCompatibility, ILogger logger)
+    /// <param name="platformEnvironment">The <see cref="IResolvePlatformEnvironment"/> to use for resolving the current Runtime environment.</param>
+    /// <param name="requestConverter">The <see cref="IRequestConverter"/> to use to parse incoming requests.</param>
+    /// <param name="contractsCompatibility">The <see cref="IVerifyContractsCompatibility"/> to use to compare Contracts versions.</param>
+    /// <param name="logger">The <see cref="ILogger"/> to use for logging.</param>
+    public HandshakeService(
+        IResolvePlatformEnvironment platformEnvironment,
+        IRequestConverter requestConverter,
+        IVerifyContractsCompatibility contractsCompatibility,
+        ILogger logger)
     {
         _platformEnvironment = platformEnvironment;
+        _requestConverter = requestConverter;
         _contractsCompatibility = contractsCompatibility;
         _logger = logger;
+
+        _runtimeVersion = VersionInfo.CurrentVersion;
+        _runtimeContractsVersion = Contracts.VersionInfo.CurrentVersion.ToVersion();
     }
 
     /// <inheritdoc />
@@ -42,60 +53,61 @@ public class HandshakeService : HandshakeBase
     {
         try
         {
-            var runtimeVersion = VersionInfo.CurrentVersion;
-            var runtimeContractsVersion = Contracts.VersionInfo.CurrentVersion.ToVersion();
-            var sdk = request.Sdk;
-            var sdkVersion = request.SdkVersion.ToVersion();
-            var headVersion = request.HeadVersion.ToVersion();
-            var headContractsVersion = request.ContractsVersion.ToVersion();
-            Log.HeadInitiatedHandshake(_logger, sdk, sdkVersion, headVersion, headContractsVersion);
-            if (VersionsAreIncompatible(runtimeVersion, runtimeContractsVersion, headContractsVersion, out var failedResponse))
+            if (!_requestConverter.TryConvert(request, out var parsedRequest, out var failure))
             {
-                Log.HeadAndRuntimeContractsIncompatible(_logger, headContractsVersion, runtimeContractsVersion);
-                return failedResponse;
+                Log.RequestParsingFailed(_logger, failure.Reason);
+                return FailedResponse(failure);
+            }
+
+            Log.HeadInitiatedHandshake(
+                _logger,
+                parsedRequest.Attempt,
+                parsedRequest.HeadVersion,
+                parsedRequest.SDK,
+                parsedRequest.SDKVersion,
+                parsedRequest.ContractsVersion);
+
+            switch (_contractsCompatibility.CheckCompatibility(_runtimeContractsVersion, parsedRequest.ContractsVersion))
+            {
+                case ContractsCompatibility.ClientTooOld:
+                    Log.ClientContractsVersionTooOld(_logger, parsedRequest.ContractsVersion, _runtimeContractsVersion);
+                    return FailedResponse(new SDKMustBeUpdated(_runtimeContractsVersion));
+                case ContractsCompatibility.RuntimeTooOld:
+                    Log.RuntimeContractsVersionTooOld(_logger, parsedRequest.ContractsVersion, _runtimeContractsVersion);
+                    return FailedResponse(new RuntimeMustBeUpdated(parsedRequest.ContractsVersion));
             }
             
             var platformEnvironment = await _platformEnvironment.Resolve().ConfigureAwait(false);
-            var microserviceId = platformEnvironment.MicroserviceId;
-            var environment = platformEnvironment.Environment;
-            Log.SuccessfulHandshake(_logger, runtimeVersion, microserviceId, runtimeContractsVersion, environment, headContractsVersion);
-            return CreateSuccessfulResponse(microserviceId, environment, runtimeVersion, runtimeContractsVersion);
+            Log.SuccessfulHandshake(
+                _logger,
+                parsedRequest.HeadVersion,
+                parsedRequest.SDK,
+                parsedRequest.SDKVersion,
+                platformEnvironment.MicroserviceId,
+                platformEnvironment.Environment,
+                parsedRequest.Attempt,
+                parsedRequest.TimeSpent);
+
+            return new HandshakeResponse
+            {
+                RuntimeVersion = _runtimeVersion.ToProtobuf(),
+                ContractsVersion = _runtimeContractsVersion.ToProtobuf(),
+                CustomerId = platformEnvironment.CustomerId.ToProtobuf(),
+                CustomerName = platformEnvironment.CustomerName.Value,
+                ApplicationId = platformEnvironment.ApplicationId.ToProtobuf(),
+                ApplicationName = platformEnvironment.ApplicationName.Value,
+                MicroserviceId = platformEnvironment.MicroserviceId.ToProtobuf(),
+                MicroserviceName = platformEnvironment.MicroserviceName.Value,
+                EnvironmentName = platformEnvironment.Environment.Value,
+            };
         }
         catch (Exception ex)
         {
             Log.ErrorWhilePerformingHandshake(_logger, ex);
-            return CreateFailedResponse(ex.Message);
+            return FailedResponse(new Failure{Id = FailureId.Other.ToProtobuf(), Reason = ex.Message});
         }
     }
 
-    static HandshakeResponse CreateSuccessfulResponse(MicroserviceId microserviceId, Environment environment, Version runtimeVersion, Version runtimeContractsVersion)
-        => new()
-        {
-            Environment = environment,
-            MicroserviceId = microserviceId.ToProtobuf(),
-            RuntimeVersion = runtimeVersion.ToProtobuf(),
-            ContractsVersion = runtimeContractsVersion.ToProtobuf()
-        };
-
-    static HandshakeResponse CreateFailedResponse(FailureReason reason)
-        => new()
-        {
-            Failure = new Failure
-            {
-                Id = FailureId.Other.ToProtobuf(),
-                Reason = reason
-            }
-        };
-
-    bool VersionsAreIncompatible(Version runtimeVersion, Version runtimeContractsVersion, Version headContractsVersion, out HandshakeResponse failedResponse)
-    {
-        failedResponse = null;
-        if (_contractsCompatibility.IsCompatible(runtimeContractsVersion, headContractsVersion))
-        {
-            return false;
-        }
-        
-        failedResponse = CreateFailedResponse($"Runtime version {runtimeVersion} uses contracts version {runtimeContractsVersion} which is not compatible with the Head's version {headContractsVersion} of contracts");
-        return true;
-    }
+    static HandshakeResponse FailedResponse(Failure failure)
+        => new() {Failure = failure};
 }

--- a/Source/Platform/Handshake/HandshakeTimeSpent.cs
+++ b/Source/Platform/Handshake/HandshakeTimeSpent.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Represents the time spent by a Client attempting to perform a handshake with a Runtime.
+/// </summary>
+/// <param name="Duration">The time since the first handshake request.</param>
+public record HandshakeTimeSpent(TimeSpan Duration) : ConceptAs<TimeSpan>(Duration)
+{
+    /// <summary>
+    /// Implicitly convert from a <see cref="TimeSpan"/> to an <see cref="HandshakeTimeSpent"/>.
+    /// </summary>
+    /// <param name="duration">HandshakeTimeSpent as a <see cref="TimeSpan"/>.</param>
+    /// <returns>The <see cref="HandshakeTimeSpent"/> concept value.</returns>
+    public static implicit operator HandshakeTimeSpent(TimeSpan duration) => new(duration);
+}

--- a/Source/Platform/Handshake/IRequestConverter.cs
+++ b/Source/Platform/Handshake/IRequestConverter.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Handshake.Contracts;
+using Dolittle.Runtime.Protobuf;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Defines a system that can parse handshake requests.
+/// </summary>
+public interface IRequestConverter
+{
+    /// <summary>
+    /// Attempts to convert a received handshake request to the Runtime representation.
+    /// </summary>
+    /// <param name="request">The received handshake request.</param>
+    /// <param name="parsed">The parsed handshake request, if parsing succeeded.</param>
+    /// <param name="failure">The failure, if the parsing failed.</param>
+    /// <returns>True if the parsing succeeded, false if not.</returns>
+    bool TryConvert(HandshakeRequest request, out Request parsed, out Failure failure);
+}

--- a/Source/Platform/Handshake/IVerifyContractsCompatability.cs
+++ b/Source/Platform/Handshake/IVerifyContractsCompatability.cs
@@ -15,6 +15,6 @@ public interface IVerifyContractsCompatibility
     /// </summary>
     /// <param name="runtimeContractsVersion">The <see cref="Version"/> of the contracts for the Runtime.</param>
     /// <param name="headContractsVersion">The <see cref="Version"/> of the contracts for the Head.</param>
-    /// <returns></returns>
-    bool IsCompatible(Version runtimeContractsVersion, Version headContractsVersion);
+    /// <returns>A <see cref="ContractsCompatibility"/> result indicating whether or not the versions are compatible.</returns>
+    ContractsCompatibility CheckCompatibility(Version runtimeContractsVersion, Version headContractsVersion);
 }

--- a/Source/Platform/Handshake/Log.cs
+++ b/Source/Platform/Handshake/Log.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Protobuf;
 using Microsoft.Extensions.Logging;
 using Environment = Dolittle.Runtime.Execution.Environment;
 using Version = Dolittle.Runtime.Versioning.Version;
@@ -11,15 +12,21 @@ namespace Dolittle.Runtime.Platform.Handshake;
 
 static partial class Log
 {
-    [LoggerMessage(0, LogLevel.Debug, "Handshake initiated by a Head v{HeadVersion} using the {SDK} SDK using version {HeadContractsVersion} Contracts")]
-    internal static partial void HeadInitiatedHandshake(ILogger logger, string sdk, Version sdkVersion, Version headVersion, Version headContractsVersion);
-    
-    [LoggerMessage(0, LogLevel.Warning, "Cannot perform handshake between Head and Runtime because the Head's version of contracts ({HeadContractsVersion}) is incompatible with the Runtime version of contracts ({RuntimeContractsVersion})")]
-    internal static partial void HeadAndRuntimeContractsIncompatible(ILogger logger, Version headContractsVersion, Version runtimeContractsVersion);
+    [LoggerMessage(0, LogLevel.Error, "Failed to parse handshake request because {Reason}")]
+    internal static partial void RequestParsingFailed(ILogger logger, FailureReason reason);
 
-    [LoggerMessage(0, LogLevel.Information, "Runtime v{RuntimeVersion} with Microservice ID {MicroserviceId} using version {RuntimeContractsVersion} Contracts running in environment {Environment} successfully performed handshake with Head using version {HeadContractsVersion} Contracts")]
-    internal static partial void SuccessfulHandshake(ILogger logger, Version runtimeVersion, MicroserviceId microserviceId, Version runtimeContractsVersion, Environment environment, Version headContractsVersion);
+    [LoggerMessage(0, LogLevel.Debug, "Handshake attempt {Attempt} initiated by a Head version {HeadVersion} using the {SDKIdentifier} SDK {SDKVersion} with Contracts {HeadContractsVersion}")]
+    internal static partial void HeadInitiatedHandshake(ILogger logger, HandshakeAttempt attempt, Version headVersion, SDKIdentifier sdkIdentifier, Version sdkVersion, Version headContractsVersion);
     
-    [LoggerMessage(0, LogLevel.Warning, "An error occurred while performing handshake")]
+    [LoggerMessage(0, LogLevel.Warning, "The Client that initiated the handshake is using a Contracts version {HeadContractsVersion} that is older than the Contracts version {RuntimeContractsVersion} of this Runtime")]
+    internal static partial void ClientContractsVersionTooOld(ILogger logger, Version headContractsVersion, Version runtimeContractsVersion);
+    
+    [LoggerMessage(0, LogLevel.Warning, "The Client that initiated the handshake is using a Contracts version {HeadContractsVersion} that is newer than the Contracts version {RuntimeContractsVersion} of this Runtime")]
+    internal static partial void RuntimeContractsVersionTooOld(ILogger logger, Version headContractsVersion, Version runtimeContractsVersion);
+
+    [LoggerMessage(0, LogLevel.Information, "Handshake successful with Head version {HeadVersion} using {SDKIdentifier} SDK version {SDKVersion} for microservice {Microservice} in environment {Environment} at attempt {Attempt} after {TimeSpent}")]
+    internal static partial void SuccessfulHandshake(ILogger logger, Version headVersion, SDKIdentifier sdkIdentifier, Version sdkVersion, MicroserviceId microservice, Environment environment, HandshakeAttempt attempt, HandshakeTimeSpent timeSpent);
+    
+    [LoggerMessage(0, LogLevel.Error, "An error occurred while performing handshake")]
     internal static partial void ErrorWhilePerformingHandshake(ILogger logger, Exception ex);
 }

--- a/Source/Platform/Handshake/MissingHandshakeInformation.cs
+++ b/Source/Platform/Handshake/MissingHandshakeInformation.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Handshake.Contracts;
+using Dolittle.Runtime.Protobuf;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// The failure that is returned when a <see cref="HandshakeRequest"/> is missing information.
+/// </summary>
+/// <param name="Field">The field that is missing.</param>
+public record MissingHandshakeInformation(string Field) : Failure(
+    HandshakeFailures.MissingHandshakeInformation, 
+    $"The received handshake is missing the field {Field}");

--- a/Source/Platform/Handshake/Request.cs
+++ b/Source/Platform/Handshake/Request.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Versioning;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Represents a handshake request received from a Client.
+/// </summary>
+/// <param name="SDK">The SDK identifier.</param>
+/// <param name="SDKVersion">The SDK version.</param>
+/// <param name="HeadVersion">The Head version.</param>
+/// <param name="ContractsVersion">The version of the Contracts used by the Client SDK.</param>
+/// <param name="Attempt">The handshake attempt number.</param>
+/// <param name="TimeSpent">Time since the first handshake attempt.</param>
+public record Request(
+    SDKIdentifier SDK,
+    Version SDKVersion,
+    Version HeadVersion,
+    Version ContractsVersion,
+    HandshakeAttempt Attempt,
+    HandshakeTimeSpent TimeSpent);

--- a/Source/Platform/Handshake/RequestConverter.cs
+++ b/Source/Platform/Handshake/RequestConverter.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Handshake.Contracts;
+using Dolittle.Runtime.Protobuf;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Represents an implementation of <see cref="IRequestConverter"/>.
+/// </summary>
+public class RequestConverter : IRequestConverter
+{
+    /// <inheritdoc />
+    public bool TryConvert(HandshakeRequest request, out Request parsed, out Failure failure)
+    {
+        parsed = null;
+        if (string.IsNullOrWhiteSpace(request.SdkIdentifier))
+        {
+            failure = new MissingHandshakeInformation(nameof(request.SdkIdentifier));
+            return false;
+        }
+        if (request.HeadVersion == null)
+        {
+            failure = new MissingHandshakeInformation(nameof(request.HeadVersion));
+            return false;
+        }
+        if (request.SdkVersion == null)
+        {
+            failure = new MissingHandshakeInformation(nameof(request.SdkVersion));
+            return false;
+        }
+        if (request.ContractsVersion == null)
+        {
+            failure = new MissingHandshakeInformation(nameof(request.ContractsVersion));
+            return false;
+        }
+        if (request.TimeSpent == null)
+        {
+            failure = new MissingHandshakeInformation(nameof(request.TimeSpent));
+            return false;
+        }
+
+        failure = null;
+        parsed = new Request(
+            request.SdkIdentifier,
+            request.SdkVersion.ToVersion(),
+            request.HeadVersion.ToVersion(),
+            request.ContractsVersion.ToVersion(),
+            request.Attempt,
+            request.TimeSpent.ToTimeSpan());
+        return true;
+    }
+}

--- a/Source/Platform/Handshake/RuntimeMustBeUpdated.cs
+++ b/Source/Platform/Handshake/RuntimeMustBeUpdated.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Protobuf;
+using Dolittle.Runtime.Versioning;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// The <see cref="Failure"/> that is returned when the Contracts version of the Client SDK is too old to be used with the current Runtime.
+/// </summary>
+public record RuntimeMustBeUpdated(Version MinimumContractsVersion) : Failure(
+    HandshakeFailures.RuntimeMustBeUpdated,
+    $"This version of the Runtime is too old to be used with the SDK you are currently using. Please upgrade your SDK to a version that supports Contracts {MinimumContractsVersion}.");

--- a/Source/Platform/Handshake/RuntimeMustBeUpdated.cs
+++ b/Source/Platform/Handshake/RuntimeMustBeUpdated.cs
@@ -11,4 +11,4 @@ namespace Dolittle.Runtime.Platform.Handshake;
 /// </summary>
 public record RuntimeMustBeUpdated(Version MinimumContractsVersion) : Failure(
     HandshakeFailures.RuntimeMustBeUpdated,
-    $"This version of the Runtime is too old to be used with the SDK you are currently using. Please upgrade your SDK to a version that supports Contracts {MinimumContractsVersion}.");
+    $"This version of the Runtime is too old to be used with the SDK you are currently using. Please upgrade your Runtime to a version that supports Contracts {MinimumContractsVersion}.");

--- a/Source/Platform/Handshake/SDKIdentifier.cs
+++ b/Source/Platform/Handshake/SDKIdentifier.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// Represents the identifier of a Dolittle client SDK.
+/// </summary>
+/// <param name="Identifier">The SDK identifier.</param>
+public record SDKIdentifier(string Identifier) : ConceptAs<string>(Identifier)
+{
+    /// <summary>
+    /// Implicitly convert a <see cref="string"/> to an <see cref="SDKIdentifier"/>.
+    /// </summary>
+    /// <param name="identifier">SDK identifier as <see cref="string"/>.</param>
+    /// <returns>The <see cref="SDKIdentifier"/> concept value.</returns>
+    public static implicit operator SDKIdentifier(string identifier) => new(identifier);
+}

--- a/Source/Platform/Handshake/SDKMustBeUpdated.cs
+++ b/Source/Platform/Handshake/SDKMustBeUpdated.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Protobuf;
+using Dolittle.Runtime.Versioning;
+
+namespace Dolittle.Runtime.Platform.Handshake;
+
+/// <summary>
+/// The <see cref="Failure"/> that is returned when the Contracts version of the Client SDK is too old to be used with the current Runtime.
+/// </summary>
+public record SDKMustBeUpdated(Version MinimumContractsVersion) : Failure(
+    HandshakeFailures.SDKMustBeUpdated,
+    $"The version of your currently used SDK is too old to be used with this version of the Runtime. Please upgrade your Runtime to a version that supports Contracts {MinimumContractsVersion}.");

--- a/Source/Platform/Handshake/VerifyContractsCompatibility.cs
+++ b/Source/Platform/Handshake/VerifyContractsCompatibility.cs
@@ -11,13 +11,18 @@ namespace Dolittle.Runtime.Platform.Handshake;
 public class VerifyContractsCompatibility : IVerifyContractsCompatibility
 {
     /// <inheritdoc />
-    public bool IsCompatible(Version runtimeContractsVersion, Version headContractsVersion)
-        => HasSameMajor(runtimeContractsVersion, headContractsVersion)
-            && HasCompatibleMinor(runtimeContractsVersion, headContractsVersion);
+    public ContractsCompatibility CheckCompatibility(Version runtimeContractsVersion, Version headContractsVersion)
+    {
+        if (headContractsVersion.Major > runtimeContractsVersion.Major)
+        {
+            return ContractsCompatibility.RuntimeTooOld;
+        }
+        
+        if (headContractsVersion.Major < runtimeContractsVersion.Major || headContractsVersion.Minor < runtimeContractsVersion.Minor)
+        {
+            return ContractsCompatibility.ClientTooOld;
+        }
 
-    static bool HasSameMajor(Version version, Version otherVersion)
-        => version.Major == otherVersion.Major;
-    
-    static bool HasCompatibleMinor(Version runtimeContractsVersion, Version headContractsVersion)
-        => runtimeContractsVersion.Minor >= headContractsVersion.Minor;
+        return ContractsCompatibility.Compatible;
+    }
 }

--- a/Source/Server/appsettings.json
+++ b/Source/Server/appsettings.json
@@ -10,7 +10,7 @@
             "FormatterName": "Simple",
             "FormatterOptions": {
                 "IncludeScopes": true,
-                "TimestampFormat": "HH:mm:ss",
+                "TimestampFormat": "HH:mm:ss ",
                 "UseUtcTimestamp": true
             }
         }

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>5.0.0</AutofacVersion>
         <AutofacExtensionsVersion>6.0.0</AutofacExtensionsVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>6.4.0-gimli.2</ContractsVersion>
+        <ContractsVersion>6.4.0-gimli.3</ContractsVersion>
         <CoverletVersion>2.9.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary

Update Contracts to get new Handshake structure. Check that `HandshakeRequest` contains all valid information. Return new custom failures for the different situations of Handshake and version incompatibilities.

### Added

- New custom `FailureId` and `Failure`s for describing what to do when handshake fails.

### Changed

- Updated Contracts

### Fixed

- Added a space in the log formatting config in `appsettings.json` to make it look a little nicer.