### PR TITLE
Fix embedding execution context

### DIFF
--- a/Source/Embeddings.Processing/EmbeddingProcessorFactory.cs
+++ b/Source/Embeddings.Processing/EmbeddingProcessorFactory.cs
@@ -65,6 +65,8 @@ public class EmbeddingProcessorFactory : IEmbeddingProcessorFactory
             var projectManyEvents = CreateProjectManyEvents(embeddingId, embedding, initialState);
             return new EmbeddingProcessor(
                 embeddingId,
+                tenant,
+                _executionContextManager,
                 CreateEmbeddingStateUpdater(embeddingId, eventStore, embeddingStore, projectManyEvents),
                 _streamEventWatcherFactory(),
                 eventStore,

--- a/Source/Embeddings.Processing/EmbeddingRequestWorkScheduledForWrongTenant.cs
+++ b/Source/Embeddings.Processing/EmbeddingRequestWorkScheduledForWrongTenant.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.ApplicationModel;
+
+namespace Dolittle.Runtime.Embeddings.Processing;
+
+/// <summary>
+/// Exception that gets thrown when the processing of an embedding request is scheduled on the <see cref="EmbeddingProcessor"/> of the wrong tenant.
+/// </summary>
+public class EmbeddingRequestWorkScheduledForWrongTenant : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddingRequestWorkScheduledForWrongTenant"/> class.
+    /// </summary>
+    /// <param name="requestTenant">The tenant that the request was for.</param>
+    /// <param name="loopTenant">The tenant that the embedding processor is running for.</param>
+    public EmbeddingRequestWorkScheduledForWrongTenant(TenantId requestTenant, TenantId loopTenant)
+        : base($"The processing of an embedding request for tenant {requestTenant} was scheduled on the embedding processor for tenant {loopTenant}")
+    {
+    }
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/given/all_dependencies.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/given/all_dependencies.cs
@@ -1,16 +1,22 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.Embeddings.Store;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Execution;
 using Dolittle.Runtime.Rudimentary;
+using Dolittle.Runtime.Security;
+using Dolittle.Runtime.Versioning;
 using Machine.Specifications;
 using Microsoft.Extensions.Logging;
 using Moq;
+using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
 using It = Moq.It;
 
 namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.given;
@@ -18,6 +24,9 @@ namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.given;
 public class all_dependencies
 {
     protected static EmbeddingId embedding;
+    protected static TenantId tenant;
+    protected static ExecutionContext execution_context;
+    protected static Mock<IExecutionContextManager> execution_context_manager;
     protected static Mock<IUpdateEmbeddingStates> state_updater;
     protected static Mock<IStreamEventWatcher> event_waiter;
     protected static Mock<IEventStore> event_store;
@@ -26,9 +35,11 @@ public class all_dependencies
     protected static EmbeddingProcessor embedding_processor;
     protected static CancellationToken cancellation_token;
 
-    Establish context = () =>
+    private Establish context = () =>
     {
         embedding = "f46237c8-e144-4f29-bdcc-610ba075735b";
+        tenant = "769272fb-7e6c-4c3e-be40-9cd2fc6c7456";
+        execution_context_manager = new Mock<IExecutionContextManager>();
         state_updater = new Mock<IUpdateEmbeddingStates>();
         event_waiter = new Mock<IStreamEventWatcher>();
         event_store = new Mock<IEventStore>();
@@ -36,6 +47,8 @@ public class all_dependencies
         transition_calculator = new Mock<ICalculateStateTransitionEvents>();
         embedding_processor = new EmbeddingProcessor(
             embedding,
+            tenant,
+            execution_context_manager.Object,
             state_updater.Object,
             event_waiter.Object,
             event_store.Object,
@@ -43,6 +56,9 @@ public class all_dependencies
             transition_calculator.Object,
             Mock.Of<ILogger>());
         cancellation_token = CancellationToken.None;
+
+        execution_context = new ExecutionContext(MicroserviceId.NotSet, tenant, Version.NotSet, Environment.Undetermined, CorrelationId.Empty, Claims.Empty, CultureInfo.InvariantCulture);
+        execution_context_manager.SetupGet(_ => _.Current).Returns(execution_context);
 
         state_updater.Setup(_ => _.TryUpdateAll(It.IsAny<CancellationToken>())).Returns(Task.FromResult(Try.Succeeded()));
         event_waiter.Setup(_ => _.WaitForEvent(ScopeId.Default, StreamId.EventLog, It.IsAny<CancellationToken>())).Returns<ScopeId, StreamId, CancellationToken>((_scope, _stream, cancellationToken) => Task.Delay(Timeout.Infinite, cancellationToken));

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_deleting/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_deleting/and_everything_works.cs
@@ -7,6 +7,8 @@ using Dolittle.Runtime.Embeddings.Store;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
+using Moq;
+using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
 using It = Machine.Specifications.It;
 
 namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_deleting;
@@ -39,6 +41,7 @@ public class and_everything_works : given.all_dependencies_and_a_key
     Because of = () => result = embedding_processor.Delete(key, cancellation_token).GetAwaiter().GetResult();
 
     It should_still_be_running = () => task.Status.ShouldEqual(TaskStatus.WaitingForActivation);
+    It should_set_the_execution_context_twice = () => execution_context_manager.Verify(_ => _.CurrentFor(Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<string>(), Moq.It.IsAny<int>(), Moq.It.IsAny<string>()), Times.Exactly(2));
     It should_fetch_the_current_state = () => embedding_store.Verify(_ => _.TryGet(embedding, key, Moq.It.IsAny<CancellationToken>()));
     It should_calculate_the_transition_events = () => transition_calculator.Verify(_ => _.TryDelete(current_state, Moq.It.IsAny<CancellationToken>()));
     It should_commit_the_calculated_events = () => event_store.Verify(_ => _.CommitAggregateEvents(uncommitted_events, Moq.It.IsAny<CancellationToken>()));

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_deleting/and_request_is_sent_to_the_wrong_processor.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_deleting/and_request_is_sent_to_the_wrong_processor.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Execution;
+using Dolittle.Runtime.Security;
+using Machine.Specifications;
+using Environment = Dolittle.Runtime.Execution.Environment;
+using Version = Dolittle.Runtime.Versioning.Version;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_deleting;
+
+public class and_request_is_sent_to_the_wrong_processor : given.all_dependencies_and_a_key
+{
+    static Task task;
+
+    private Establish context = () =>
+    {
+        task = embedding_processor.Start(cancellation_token);
+        execution_context_manager
+            .SetupGet(_ => _.Current)
+            .Returns(new ExecutionContext(
+                MicroserviceId.NotSet,
+                "6cc0728e-efc2-4786-8029-e1a83c95f964",
+                Version.NotSet,
+                Environment.Undetermined,
+                CorrelationId.Empty,
+                Claims.Empty,
+                CultureInfo.InvariantCulture));
+    };
+    
+    static Exception result;
+
+    Because of = () => result = Catch.Exception(() => embedding_processor.Delete(key, cancellation_token).GetAwaiter().GetResult());
+    
+    It should_still_be_running = () => task.Status.ShouldEqual(TaskStatus.WaitingForActivation);
+    It should_fail = () => result.ShouldBeOfExactType<EmbeddingRequestWorkScheduledForWrongTenant>();
+}

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_updating/and_everything_works.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_updating/and_everything_works.cs
@@ -8,6 +8,8 @@ using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store.State;
 using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
+using Moq;
+using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
 using It = Machine.Specifications.It;
 
 namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_updating;
@@ -39,6 +41,7 @@ public class and_everything_works : given.all_dependencies_and_a_desired_state
     Because of = () => result = embedding_processor.Update(key, desired_state, cancellation_token).GetAwaiter().GetResult();
 
     It should_still_be_running = () => task.Status.ShouldEqual(TaskStatus.WaitingForActivation);
+    It should_set_the_execution_context_twice = () => execution_context_manager.Verify(_ => _.CurrentFor(Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<string>(), Moq.It.IsAny<int>(), Moq.It.IsAny<string>()), Times.Exactly(2));
     It should_fetch_the_current_state = () => embedding_store.Verify(_ => _.TryGet(embedding, key, Moq.It.IsAny<CancellationToken>()));
     It should_calculate_the_transition_events = () => transition_calculator.Verify(_ => _.TryConverge(current_state, desired_state, Moq.It.IsAny<CancellationToken>()));
     It should_commit_the_calculated_events = () => event_store.Verify(_ => _.CommitAggregateEvents(uncommitted_events, Moq.It.IsAny<CancellationToken>()));

--- a/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_updating/and_request_is_sent_to_the_wrong_processor.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingProcessor/when_updating/and_request_is_sent_to_the_wrong_processor.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Execution;
+using Dolittle.Runtime.Security;
+using Machine.Specifications;
+using Environment = Dolittle.Runtime.Execution.Environment;
+using Version = Dolittle.Runtime.Versioning.Version;
+
+namespace Dolittle.Runtime.Embeddings.Processing.for_EmbeddingProcessor.when_updating;
+
+public class and_request_is_sent_to_the_wrong_processor : given.all_dependencies_and_a_desired_state
+{
+    static Task task;
+
+    private Establish context = () =>
+    {
+        task = embedding_processor.Start(cancellation_token);
+        execution_context_manager
+            .SetupGet(_ => _.Current)
+            .Returns(new ExecutionContext(
+                MicroserviceId.NotSet,
+                "6cc0728e-efc2-4786-8029-e1a83c95f964",
+                Version.NotSet,
+                Environment.Undetermined,
+                CorrelationId.Empty,
+                Claims.Empty,
+                CultureInfo.InvariantCulture));
+    };
+    
+    static Exception result;
+
+    Because of = () => result = Catch.Exception(() => embedding_processor.Update(key, desired_state, cancellation_token).GetAwaiter().GetResult());
+    
+    It should_still_be_running = () => task.Status.ShouldEqual(TaskStatus.WaitingForActivation);
+    It should_fail = () => result.ShouldBeOfExactType<EmbeddingRequestWorkScheduledForWrongTenant>();
+}

--- a/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/concurrently.cs
+++ b/Specifications/Services/ReverseCall/for_WrappedAsyncStreamWriter/when_writing/concurrently.cs
@@ -62,20 +62,20 @@ public class concurrently : given.a_wrapped_stream_writer
         Task second_write_status = wrapped_writer.WriteAsync(second_message);
         Task third_write_status = wrapped_writer.WriteAsync(third_message);
 
-        Thread.Sleep(5);
+        Thread.Sleep(20);
         first_write_first_check = first_write_status.IsCompleted;
         second_write_first_check = second_write_status.IsCompleted;
         third_write_first_check = third_write_status.IsCompleted;
 
         first_message_write.SetResult();
         third_message_write.SetResult();
-        Thread.Sleep(5);
+        Thread.Sleep(20);
         first_write_second_check = first_write_status.IsCompleted;
         second_write_second_check = second_write_status.IsCompleted;
         third_write_second_check = third_write_status.IsCompleted;
 
         second_message_write.SetResult();
-        Thread.Sleep(5);
+        Thread.Sleep(20);
         first_write_third_check = first_write_status.IsCompleted;
         second_write_third_check = second_write_status.IsCompleted;
         third_write_third_check = third_write_status.IsCompleted;


### PR DESCRIPTION
## Summary

Fixes the problem of the ExecutionContext in the EmbeddingProcessor while processing requests by setting the TenantId of the ExecutionContext to the TenantId of the processor in the loop. The ExecutionContext is re-set in the DoWork tasks to also propagate the CorrelationId from the Client while processing requests. Also added a check that the TenantId of the ExecutionContext matches that of the processor to ensure we don't screw up somewhere else and end up with strange events committed.

### Fixed

- The ExecutionContext sent to the Client while processing an Embedding request was not set to the correct tenant.