### PR TITLE
Return failure instead of throwing exception when EventHandler is registered multiple times.

### DIFF
--- a/Source/Events.Processing/EventHandlers/EventHandlerAlreadyRegistered.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlerAlreadyRegistered.cs
@@ -1,19 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+
+using Dolittle.Runtime.Protobuf;
+
 namespace Dolittle.Runtime.Events.Processing.EventHandlers;
 
 /// <summary>
-/// Exception that gets thrown when an <see cref="EventHandler{TEventArgs}"/> has already been registered.
+/// The <see cref="Failure"/> that is returned when attempting to register an <see cref="EventHandler"/> that has already been registered.
 /// </summary>
-public class EventHandlerAlreadyRegistered : Exception
-{
-    /// <summary>
-    /// Initializes an instance of the <see cref="EventHandlerAlreadyRegistered"/> class.
-    /// </summary>
-    /// <param name="eventHandler">The <see cref="EventHandlerId"/>.</param>
-    public EventHandlerAlreadyRegistered(EventHandlerId eventHandler)
-        : base($"Event handler {eventHandler} is already registered")
-    {
-    }
-}
+/// <param name="EventHandlerId">The event handler identifier.</param>
+public record EventHandlerAlreadyRegistered(EventHandlerId EventHandlerId) : Failure(
+    EventHandlersFailures.EventHandlerAlreadyRegistered,
+    $"The event handler {EventHandlerId.EventHandler} in scope {EventHandlerId.Scope} is already registered"
+);

--- a/Source/Events.Processing/EventHandlers/EventHandlersFailures.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlersFailures.cs
@@ -14,6 +14,11 @@ public static class EventHandlersFailures
     /// Gets the <see cref="FailureId" /> that represents the 'NoEventHandlerRegistrationReceived' failure type.
     /// </summary>
     public static FailureId NoEventHandlerRegistrationReceived => FailureId.Create("209a79c7-824c-4988-928b-0dd517746ca0");
+    
+    /// <summary>
+    /// Gets the <see cref="FailureId" /> that represents the 'EventHandlerAlreadyRegistered' failure type.
+    /// </summary>
+    public static FailureId EventHandlerAlreadyRegistered => FailureId.Create("19dc6254-1732-4625-90af-444732bce795");
 
     /// <summary>
     /// Gets the <see cref="FailureId" /> that represents the 'CannotRegisterEventHandlerOnNonWriteableStream' failure type.

--- a/Source/Events.Processing/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlersService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Processing.Contracts;
@@ -70,6 +71,7 @@ public class EventHandlersService : EventHandlersBase
             {
                 return;
             }
+
             var (dispatcher, arguments) = connectResult.Result;
             _logger.SettingExecutionContext(arguments.ExecutionContext);
             _executionContextManager.CurrentFor(arguments.ExecutionContext);

--- a/Source/Events.Processing/EventHandlers/Log.cs
+++ b/Source/Events.Processing/EventHandlers/Log.cs
@@ -15,5 +15,7 @@ static partial class Log
     
     [LoggerMessage(0, LogLevel.Debug, "Connecting Event Handler")]
     internal static partial void ConnectingEventHandler(ILogger logger);
-    
+
+    [LoggerMessage(0, LogLevel.Warning, "Event Handler {EventHandler} already registered")]
+    internal static partial void EventHandlerAlreadyRegistered(ILogger logger, EventHandlerId eventHandler);
 }


### PR DESCRIPTION
## Summary

Returns a known Failure when an EventHandler is registered multiple times, instead of throwing an Exception that is eaten up by gRPC. Also the incident is logged with a warning message.