### PR TITLE
Last fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,18 +276,18 @@ jobs:
           asset_path: ./Source/CLI/bin/Release/net6.0/osx-x64/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-macos-x64
           asset_content_type: application/octet-stream
-      #      - name: Publish for macOS arm64
-      #        working-directory: ./Source/CLI
-      #        run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=osx.11.0-arm64
-      #      - name: Upload macOS arm64
-      #        uses: actions/upload-release-asset@v1
-      #        env:
-      #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #        with:
-      #          upload_url: ${{ needs.setup.outputs.release-upload-url }}
-      #          asset_path: ./Source/CLI/bin/Release/net6.0/osx.11.0-arm64/publish/Dolittle.Runtime.CLI
-      #          asset_name: dolittle-macos-arm64
-      #          asset_content_type: application/octet-stream
+      - name: Publish for macOS arm64
+        working-directory: ./Source/CLI
+        run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=osx.11.0-arm64
+      - name: Upload macOS arm64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release-upload-url }}
+          asset_path: ./Source/CLI/bin/Release/net6.0/osx.11.0-arm64/publish/Dolittle.Runtime.CLI
+          asset_name: dolittle-macos-arm64
+          asset_content_type: application/octet-stream
       - name: Publish for Windows x64
         working-directory: ./Source/CLI
         run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=win-x64

--- a/Source/Platform/Handshake/RuntimeServices.cs
+++ b/Source/Platform/Handshake/RuntimeServices.cs
@@ -24,7 +24,7 @@ public class RuntimeServices : ICanBindRuntimeServices
     }
 
     /// <inheritdoc/>
-    public ServiceAspect Aspect => "Server";
+    public ServiceAspect Aspect => "Platform.Handshake";
 
     /// <inheritdoc/>
     public IEnumerable<Service> BindServices() =>

--- a/Source/Platform/VersionInfo.cs
+++ b/Source/Platform/VersionInfo.cs
@@ -5,6 +5,8 @@ using Dolittle.Runtime.Versioning;
 
 namespace Dolittle.Runtime.Platform;
 
+#pragma warning disable SA1122 // To allow replacing pre release with "" instead of string.Empty
+
 /// <summary>
 /// Represents a container for the Dolittle Runtime version.
 /// </summary>

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>5.0.0</AutofacVersion>
         <AutofacExtensionsVersion>6.0.0</AutofacExtensionsVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>6.4.0-gimli.3</ContractsVersion>
+        <ContractsVersion>6.4.0</ContractsVersion>
         <CoverletVersion>2.9.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary

Fix ServiceAspect descriptor for Handshake service, allow usage of `""` in VersionInfo so it will build on final release, use latest contracts, and enable macOS M1 build of CLI again.