### PR TITLE
Improve CLI Runtime selector list

### DIFF
--- a/Source/CLI/Runtime/CommandBase.cs
+++ b/Source/CLI/Runtime/CommandBase.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.CLI.Runtime.EventTypes;
 using Dolittle.Runtime.Events;
@@ -70,7 +71,7 @@ public abstract class CommandBase : CLI.CommandBase
 
         if (addresses.Count == 1)
         {
-            return addresses[0];
+            return new MicroserviceAddress(addresses[0].Host, addresses[0].Port);
         }
             
         await cli.Out.WriteLineAsync("Found multiple available Runtimes, please select one of the following:");
@@ -78,15 +79,22 @@ public abstract class CommandBase : CLI.CommandBase
         {
             for (var i = 0; i < addresses.Count; i++)
             {
-                var (host, port) = addresses[i];
-                await cli.Out.WriteLineAsync($"\t{i}) {host.Value}:{port.Value}");
+                var (name, host, port) = addresses[i];
+                if (name != MicroserviceName.NotSet && !string.IsNullOrWhiteSpace(name))
+                {
+                    await cli.Out.WriteLineAsync($"\t{i}) {name} ({host.Value}:{port.Value})");
+                }
+                else
+                {
+                    await cli.Out.WriteLineAsync($"\t{i}) {host.Value}:{port.Value}");
+                }
             }
 
             var selection = Prompt.GetInt($"Select Runtime (0-{addresses.Count - 1}):");
 
             if (selection >= 0 && selection < addresses.Count)
             {
-                return addresses[selection];
+                return new MicroserviceAddress(addresses[selection].Host, addresses[selection].Port);
             }
                 
             await cli.Out.WriteLineAsync("Invalid number, please select one of the following:");

--- a/Source/CLI/Runtime/CommandBase.cs
+++ b/Source/CLI/Runtime/CommandBase.cs
@@ -61,7 +61,7 @@ public abstract class CommandBase : CLI.CommandBase
     /// <returns>A <see cref="Try{TResult}"/> of type <see cref="MicroserviceAddress"/>.</returns>
     protected async Task<Try<MicroserviceAddress>> SelectRuntimeToConnectTo(CommandLineApplication cli)
     {
-        var addresses = (await _runtimes.GetAvailableRuntimeAddresses(Runtime)).ToList();
+        var addresses = (await _runtimes.GetAvailableRuntimeAddresses(Runtime)).OrderBy(ListTextFor).ToList();
 
         if (!addresses.Any())
         {
@@ -79,15 +79,7 @@ public abstract class CommandBase : CLI.CommandBase
         {
             for (var i = 0; i < addresses.Count; i++)
             {
-                var (name, host, port) = addresses[i];
-                if (name != MicroserviceName.NotSet && !string.IsNullOrWhiteSpace(name))
-                {
-                    await cli.Out.WriteLineAsync($"\t{i}) {name} ({host.Value}:{port.Value})");
-                }
-                else
-                {
-                    await cli.Out.WriteLineAsync($"\t{i}) {host.Value}:{port.Value}");
-                }
+                await cli.Out.WriteLineAsync($"\t{i}) {ListTextFor(addresses[i])})");
             }
 
             var selection = Prompt.GetInt($"Select Runtime (0-{addresses.Count - 1}):");
@@ -123,4 +115,10 @@ public abstract class CommandBase : CLI.CommandBase
             ? eventTypeId.Value.ToString()
             : eventType.Alias;
     }
+
+    static string ListTextFor(NamedRuntimeAddress address)
+        => address.Name != MicroserviceName.NotSet && !string.IsNullOrWhiteSpace(address.Name)
+            ? $"{address.Name} ({address.Host.Value}:{address.Port.Value})"
+            : $"{address.Host.Value}:{address.Port.Value}";
+
 }

--- a/Source/CLI/Runtime/ICanDiscoverRuntimeAddresses.cs
+++ b/Source/CLI/Runtime/ICanDiscoverRuntimeAddresses.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Microservices;
 
 namespace Dolittle.Runtime.CLI.Runtime;
 
@@ -15,6 +14,6 @@ public interface ICanDiscoverRuntimeAddresses
     /// <summary>
     /// Discovers addresses of available Runtimes.
     /// </summary>
-    /// <returns>An <see cref="IEnumerable{T}"/> of type <see cref="MicroserviceAddress"/> to available Runtimes.</returns>
-    Task<IEnumerable<MicroserviceAddress>> Discover();
+    /// <returns>An <see cref="IEnumerable{T}"/> of type <see cref="NamedRuntimeAddress"/> to available Runtimes.</returns>
+    Task<IEnumerable<NamedRuntimeAddress>> Discover();
 }

--- a/Source/CLI/Runtime/ICanLocateRuntimes.cs
+++ b/Source/CLI/Runtime/ICanLocateRuntimes.cs
@@ -16,6 +16,6 @@ public interface ICanLocateRuntimes
     /// Gets the addresses of Runtimes that are available to connect to, or the address provided in the argument.
     /// </summary>
     /// <param name="argument">An optional address provided to the CLI as an argument.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> of type <see cref="MicroserviceAddress"/> to available Runtimes.</returns>
-    Task<IEnumerable<MicroserviceAddress>> GetAvailableRuntimeAddresses(MicroserviceAddress argument = null);
+    /// <returns>An <see cref="IEnumerable{T}"/> of type <see cref="NamedRuntimeAddress"/> to available Runtimes.</returns>
+    Task<IEnumerable<NamedRuntimeAddress>> GetAvailableRuntimeAddresses(MicroserviceAddress argument = null);
 }

--- a/Source/CLI/Runtime/NamedRuntimeAddress.cs
+++ b/Source/CLI/Runtime/NamedRuntimeAddress.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Microservices;
+
+namespace Dolittle.Runtime.CLI.Runtime;
+
+/// <summary>
+/// Represents the address to a named instance of a Runtime for a Microservice.
+/// </summary>
+/// <param name="Name">The name of the Microservice.</param>
+/// <param name="Host">The host of a microservice.</param>
+/// <param name="Port">The host of a microservice.</param>
+public record NamedRuntimeAddress(
+    MicroserviceName Name,
+    MicroserviceHost Host,
+    MicroservicePort Port);

--- a/Source/CLI/Runtime/RuntimeLocator.cs
+++ b/Source/CLI/Runtime/RuntimeLocator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Microservices;
 using Dolittle.Runtime.Services;
 
@@ -27,7 +28,7 @@ public class RuntimeLocator : ICanLocateRuntimes
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<MicroserviceAddress>> GetAvailableRuntimeAddresses(MicroserviceAddress argument = null)
+    public async Task<IEnumerable<NamedRuntimeAddress>> GetAvailableRuntimeAddresses(MicroserviceAddress argument = null)
     {
         if (argument == null)
         {
@@ -35,7 +36,8 @@ public class RuntimeLocator : ICanLocateRuntimes
             return results.SelectMany(_ => _);
         }
             
-        var address = new MicroserviceAddress(
+        var address = new NamedRuntimeAddress(
+            MicroserviceName.NotSet,
             string.IsNullOrWhiteSpace(argument.Host) ? DefaultRuntimeHost : argument.Host,
             argument.Port == 0 ? EndpointsConfigurationDefaultProvider.DefaultManagementPort : argument.Port);
                 


### PR DESCRIPTION
## Summary

Brings a small improvement to the "Select Runtime" list in the CLI when multiple Runtimes are found. I was playing around with it for a Docker Compose setup, and it was a bit hard to remember which ports belong to which microservice. So this PR adds a name from the containers to the list, and sorts the list so it should be a little easier to use.