### PR TITLE
More conversions

### DIFF
--- a/Source/Events.Processing/Projections/ProjectionsProtocol.cs
+++ b/Source/Events.Processing/Projections/ProjectionsProtocol.cs
@@ -108,8 +108,17 @@ public class ProjectionsProtocol : IProjectionsProtocol
                 conversion.ConvertTo switch
                 {
                     ProjectionCopyToMongoDB.Types.BSONType.None => ConversionBSONType.None,
-                    ProjectionCopyToMongoDB.Types.BSONType.Date => ConversionBSONType.Date,
-                    ProjectionCopyToMongoDB.Types.BSONType.Guid => ConversionBSONType.Guid,
+                    
+                    ProjectionCopyToMongoDB.Types.BSONType.DateAsDate => ConversionBSONType.DateAsDate,
+                    ProjectionCopyToMongoDB.Types.BSONType.DateAsArray => ConversionBSONType.DateAsArray,
+                    ProjectionCopyToMongoDB.Types.BSONType.DateAsDocument => ConversionBSONType.DateAsDocument,
+                    ProjectionCopyToMongoDB.Types.BSONType.DateAsString => ConversionBSONType.DateAsString,
+                    ProjectionCopyToMongoDB.Types.BSONType.DateAsInt64 => ConversionBSONType.DateAsInt64,
+                    
+                    ProjectionCopyToMongoDB.Types.BSONType.GuidasStandardBinary => ConversionBSONType.GuidAsStandardBinary,
+                    ProjectionCopyToMongoDB.Types.BSONType.GuidasCsharpLegacyBinary => ConversionBSONType.GuidAsCsharpLegacyBinary,
+                    ProjectionCopyToMongoDB.Types.BSONType.GuidasString => ConversionBSONType.GuidAsString,
+                    
                     _ => throw new InvalidMongoDBFieldConversion(conversion.PropertyName, conversion.ConvertTo),
                 },
                 conversion.RenameTo != default,

--- a/Source/Projections.Store.Copies.MongoDB/MongoDBProjectionCopyStore.cs
+++ b/Source/Projections.Store.Copies.MongoDB/MongoDBProjectionCopyStore.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Lifecycle;
 using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Projections.Store.Definition.Copies;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Projections.Store.State;
 using MongoDB.Bson;
@@ -18,6 +19,8 @@ namespace Dolittle.Runtime.Projections.Store.Copies.MongoDB;
 [SingletonPerTenant]
 public class MongoDBProjectionCopyStore : IProjectionCopyStore
 {
+    const string ProjectionDocumentKeyProperty = "_dolittle_projection_key";
+    
     readonly IProjectionCopiesStorage _storage;
     readonly IProjectionConverter _converter;
 
@@ -105,8 +108,8 @@ public class MongoDBProjectionCopyStore : IProjectionCopyStore
         => projection.Copies.MongoDB.Collection;
     
     static FilterDefinition<BsonDocument> GetFilterFor(ProjectionKey key)
-        => Builders<BsonDocument>.Filter.Eq("_id", key.Value);
+        => Builders<BsonDocument>.Filter.Eq(ProjectionDocumentKeyProperty, key.Value);
 
     static void AddKeyTo(BsonDocument document, ProjectionKey key)
-        => document.Set("_id", key.Value);
+        => document.Set(ProjectionDocumentKeyProperty, key.Value);
 }

--- a/Source/Projections.Store.Copies.MongoDB/ValueConverter.cs
+++ b/Source/Projections.Store.Copies.MongoDB/ValueConverter.cs
@@ -5,8 +5,11 @@ using System;
 using System.Globalization;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using MongoDB.Bson;
+using MongoDB.Bson.IO;
 
 namespace Dolittle.Runtime.Projections.Store.Copies.MongoDB;
+
+#pragma warning disable CS8509
 
 /// <summary>
 /// Represents an implementation of <see cref="IValueConverter"/>.
@@ -15,25 +18,75 @@ public class ValueConverter : IValueConverter
 {
     /// <inheritdoc />
     public BsonValue Convert(BsonValue value, ConversionBSONType conversion)
+    {
+        switch (conversion)
+        {
+            case ConversionBSONType.None:
+                return value;
+            case ConversionBSONType.DateAsDate:
+            case ConversionBSONType.DateAsArray:
+            case ConversionBSONType.DateAsDocument:
+            case ConversionBSONType.DateAsString:
+            case ConversionBSONType.DateAsInt64:
+                return ConvertToDate(value, conversion);
+            case ConversionBSONType.GuidAsStandardBinary:
+            case ConversionBSONType.GuidAsCsharpLegacyBinary:
+            case ConversionBSONType.GuidAsString:
+                return ConvertToGuid(value, conversion);
+            default:
+                throw new UnknownBSONConversionType(conversion);
+        }
+    }
+
+    static BsonValue ConvertToDate(BsonValue value, ConversionBSONType conversion)
+    {
+        if (value is BsonDateTime dateTimeValue)
+        {
+            return ConvertDateTo(new DateTimeOffset(dateTimeValue.ToUniversalTime(), TimeSpan.Zero), conversion);
+        }
+
+        if (value is BsonString stringValue)
+        {
+            return ConvertDateTo(DateTimeOffset.Parse(stringValue.Value, CultureInfo.InvariantCulture), conversion);
+        }
+
+        throw new CannotConvertValueUsingConversion(value, conversion);
+    }
+
+    static BsonValue ConvertDateTo(DateTimeOffset value, ConversionBSONType conversion)
         => conversion switch
         {
-            ConversionBSONType.None => value,
-            ConversionBSONType.DateAsDate => ConvertToDateAsDate(value),
-            ConversionBSONType.GuidAsStandardBinary => ConvertToGuidAsStandardBinary(value),
-            _ => throw new UnknownBSONConversionType(conversion),
+            ConversionBSONType.DateAsDate => new BsonDateTime(value.UtcDateTime),
+            ConversionBSONType.DateAsArray => new BsonArray
+            {
+                new BsonInt64(value.Ticks),
+                new BsonInt32((int) value.Offset.TotalMinutes),
+            },
+            ConversionBSONType.DateAsDocument => new BsonDocument
+            {
+                new BsonElement("DateTime", BsonUtils.ToMillisecondsSinceEpoch(value.UtcDateTime)),
+                new BsonElement("Ticks", new BsonInt64(value.Ticks)),
+                new BsonElement("Offset", new BsonInt32((int) value.Offset.TotalMinutes)),
+            },
+            ConversionBSONType.DateAsString => JsonConvert.ToString(value),
+            ConversionBSONType.DateAsInt64 => new BsonInt64(value.Ticks),
         };
 
-    static BsonDateTime ConvertToDateAsDate(BsonValue value)
-        => value switch
+    static BsonValue ConvertToGuid(BsonValue value, ConversionBSONType conversion)
+    {
+        if (value is BsonString stringValue)
         {
-            BsonDateTime dateTimeValue => dateTimeValue,
-            BsonString stringValue => new BsonDateTime(DateTimeOffset.Parse(stringValue.Value, CultureInfo.InvariantCulture).UtcDateTime),
-            _ => throw new CannotConvertValueUsingConversion(value, ConversionBSONType.DateAsDate),
-        };
+            return ConvertGuidTo(Guid.Parse(stringValue.Value), conversion);
+        }
+        
+        throw new CannotConvertValueUsingConversion(value, conversion);
+    }
 
-    static BsonBinaryData ConvertToGuidAsStandardBinary(BsonValue value)
-        => value switch
+    static BsonValue ConvertGuidTo(Guid value, ConversionBSONType conversion)
+        => conversion switch
         {
-            _ => throw new CannotConvertValueUsingConversion(value, ConversionBSONType.GuidAsStandardBinary),
+            ConversionBSONType.GuidAsStandardBinary => new BsonBinaryData(value, GuidRepresentation.Standard),
+            ConversionBSONType.GuidAsCsharpLegacyBinary => new BsonBinaryData(value, GuidRepresentation.CSharpLegacy),
+            ConversionBSONType.GuidAsString => new BsonString(value.ToString()),
         };
 }

--- a/Source/Projections.Store.Copies.MongoDB/ValueConverter.cs
+++ b/Source/Projections.Store.Copies.MongoDB/ValueConverter.cs
@@ -18,22 +18,22 @@ public class ValueConverter : IValueConverter
         => conversion switch
         {
             ConversionBSONType.None => value,
-            ConversionBSONType.Date => ConvertToDate(value),
-            ConversionBSONType.Guid => ConvertToGuid(value),
+            ConversionBSONType.DateAsDate => ConvertToDateAsDate(value),
+            ConversionBSONType.GuidAsStandardBinary => ConvertToGuidAsStandardBinary(value),
             _ => throw new UnknownBSONConversionType(conversion),
         };
 
-    static BsonDateTime ConvertToDate(BsonValue value)
+    static BsonDateTime ConvertToDateAsDate(BsonValue value)
         => value switch
         {
             BsonDateTime dateTimeValue => dateTimeValue,
             BsonString stringValue => new BsonDateTime(DateTimeOffset.Parse(stringValue.Value, CultureInfo.InvariantCulture).UtcDateTime),
-            _ => throw new CannotConvertValueUsingConversion(value, ConversionBSONType.Date),
+            _ => throw new CannotConvertValueUsingConversion(value, ConversionBSONType.DateAsDate),
         };
 
-    static BsonBinaryData ConvertToGuid(BsonValue value)
+    static BsonBinaryData ConvertToGuidAsStandardBinary(BsonValue value)
         => value switch
         {
-            _ => throw new CannotConvertValueUsingConversion(value, ConversionBSONType.Guid),
+            _ => throw new CannotConvertValueUsingConversion(value, ConversionBSONType.GuidAsStandardBinary),
         };
 }

--- a/Source/Projections.Store.MongoDB/Definition/ProjectionCopyToMongoDBPropertyConversion.cs
+++ b/Source/Projections.Store.MongoDB/Definition/ProjectionCopyToMongoDBPropertyConversion.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace Dolittle.Runtime.Projections.Store.MongoDB.Definition;
 
@@ -19,6 +21,7 @@ public class ProjectionCopyToMongoDBPropertyConversion
     /// <summary>
     /// Gets or sets the conversion to apply to the property.
     /// </summary>
+    [BsonRepresentation(BsonType.String)]
     public ConversionBSONType ConversionType { get; set; }
     
     /// <summary>

--- a/Source/Projections.Store/Definition/Copies/MongoDB/ConversionBSONType.cs
+++ b/Source/Projections.Store/Definition/Copies/MongoDB/ConversionBSONType.cs
@@ -16,12 +16,42 @@ public enum ConversionBSONType : ushort
     None = 0,
     
     /// <summary>
-    /// Convert to a BSON Date.
+    /// Convert a Date to a BSON Date.
     /// </summary>
-    Date,
+    DateAsDate,
     
     /// <summary>
-    /// Convert to a BSON Binary Guid.
+    /// Convert a Date to a BSON Array with .NET ticks and offset in minutes as elements.
     /// </summary>
-    Guid 
+    DateAsArray,
+    
+    /// <summary>
+    /// Convert a Date to a BSON Document with "DateTime": BSON Date, "Ticks": .NET ticks and "Offset": offset in minutes as properties.
+    /// </summary>
+    DateAsDocument,
+    
+    /// <summary>
+    /// Convert a Date to a BSON String using the Newtonsoft serializer to string.
+    /// </summary>
+    DateAsString,
+    
+    /// <summary>
+    /// Convert a Date to a BSON Int64 with value from .NET ticks.
+    /// </summary>
+    DateAsInt64,
+    
+    /// <summary>
+    /// Convert a Guid to a BSON Binary Guid with standard representation.
+    /// </summary>
+    GuidAsStandardBinary,
+    
+    /// <summary>
+    /// Convert a Guid to a BSON Binary Guid with C# legacy representation.
+    /// </summary>
+    GuidAsCsharpLegacyBinary,
+    
+    /// <summary>
+    /// Convert a Guid to a BSON String.
+    /// </summary>
+    GuidAsString,
 }

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/by_adding_a_conversion.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/by_adding_a_conversion.cs
@@ -33,7 +33,7 @@ public class by_adding_a_conversion : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                 },
             })
             .build();
@@ -48,8 +48,8 @@ public class by_adding_a_conversion : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
-                            new PropertyConversion("field two", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field two", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                         },
                     }
                 }

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/by_removing_a_conversion.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/by_removing_a_conversion.cs
@@ -33,8 +33,8 @@ public class by_removing_a_conversion : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
-                    new PropertyConversion("field two", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field two", ConversionBSONType.GuidAsStandardBinary, false, "", Array.Empty<PropertyConversion>()),
                 },
             })
             .build();
@@ -49,7 +49,7 @@ public class by_removing_a_conversion : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                         },
                     }
                 }

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/conversion_type_for_nested_property.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/conversion_type_for_nested_property.cs
@@ -33,12 +33,12 @@ public class conversion_type_for_nested_property : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                     new PropertyConversion("field two", ConversionBSONType.None, false, "", new []
                     {
                         new PropertyConversion("first level", ConversionBSONType.None, false, "", new []
                         {
-                            new PropertyConversion("second level", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("second level", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                         })
                     }),
                 },
@@ -55,12 +55,12 @@ public class conversion_type_for_nested_property : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                             new PropertyConversion("field two", ConversionBSONType.None, false, "", new []
                             {
                                 new PropertyConversion("first level", ConversionBSONType.None, false, "", new []
                                 {
-                                    new PropertyConversion("second level", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                                    new PropertyConversion("second level", ConversionBSONType.GuidAsStandardBinary, false, "", Array.Empty<PropertyConversion>()),
                                 })
                             }),
                         },

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/conversion_type_for_one_property.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/conversion_type_for_one_property.cs
@@ -33,8 +33,8 @@ public class conversion_type_for_one_property : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
-                    new PropertyConversion("field two", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field two", ConversionBSONType.GuidAsStandardBinary, false, "", Array.Empty<PropertyConversion>()),
                 },
             })
             .build();
@@ -49,8 +49,8 @@ public class conversion_type_for_one_property : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
-                            new PropertyConversion("field two", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field two", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                         },
                     }
                 }

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/rename_to_for_nested_property.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/rename_to_for_nested_property.cs
@@ -33,12 +33,12 @@ public class rename_to_for_nested_property : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                     new PropertyConversion("field two", ConversionBSONType.None, false, "", new []
                     {
                         new PropertyConversion("first level", ConversionBSONType.None, true, "something", new []
                         {
-                            new PropertyConversion("second level", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("second level", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                         })
                     }),
                 },
@@ -55,12 +55,12 @@ public class rename_to_for_nested_property : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                             new PropertyConversion("field two", ConversionBSONType.None, false, "", new []
                             {
                                 new PropertyConversion("first level", ConversionBSONType.None, true, "something else", new []
                                 {
-                                    new PropertyConversion("second level", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                                    new PropertyConversion("second level", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                                 })
                             }),
                         },

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/rename_to_for_one_property.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/rename_to_for_one_property.cs
@@ -33,8 +33,8 @@ public class rename_to_for_one_property : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, true, "field three", Array.Empty<PropertyConversion>()),
-                    new PropertyConversion("field two", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, true, "field three", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field two", ConversionBSONType.GuidAsStandardBinary, false, "", Array.Empty<PropertyConversion>()),
                 },
             })
             .build();
@@ -49,8 +49,8 @@ public class rename_to_for_one_property : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, true, "field four", Array.Empty<PropertyConversion>()),
-                            new PropertyConversion("field two", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, true, "field four", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field two", ConversionBSONType.GuidAsStandardBinary, false, "", Array.Empty<PropertyConversion>()),
                         },
                     }
                 }

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/should_rename_for_nested_property.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/should_rename_for_nested_property.cs
@@ -33,12 +33,12 @@ public class should_rename_for_nested_property : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                     new PropertyConversion("field two", ConversionBSONType.None, false, "", new []
                     {
                         new PropertyConversion("first level", ConversionBSONType.None, false, "", new []
                         {
-                            new PropertyConversion("second level", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("second level", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                         })
                     }),
                 },
@@ -55,12 +55,12 @@ public class should_rename_for_nested_property : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
                             new PropertyConversion("field two", ConversionBSONType.None, false, "", new []
                             {
                                 new PropertyConversion("first level", ConversionBSONType.None, false, "", new []
                                 {
-                                    new PropertyConversion("second level", ConversionBSONType.Guid, true, "whatever", Array.Empty<PropertyConversion>()),
+                                    new PropertyConversion("second level", ConversionBSONType.DateAsDate, true, "whatever", Array.Empty<PropertyConversion>()),
                                 })
                             }),
                         },

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/should_rename_for_one_property.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_conversions_have_changed/should_rename_for_one_property.cs
@@ -33,8 +33,8 @@ public class should_rename_for_one_property : given.all_dependencies
             {
                 Conversions = new []
                 {
-                    new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
-                    new PropertyConversion("field two", ConversionBSONType.Guid, true, "field three", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
+                    new PropertyConversion("field two", ConversionBSONType.GuidAsStandardBinary, true, "field three", Array.Empty<PropertyConversion>()),
                 },
             })
             .build();
@@ -49,8 +49,8 @@ public class should_rename_for_one_property : given.all_dependencies
                     {
                         Conversions = new []
                         {
-                            new PropertyConversion("field one", ConversionBSONType.Date, false, "", Array.Empty<PropertyConversion>()),
-                            new PropertyConversion("field two", ConversionBSONType.Guid, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field one", ConversionBSONType.DateAsDate, false, "", Array.Empty<PropertyConversion>()),
+                            new PropertyConversion("field two", ConversionBSONType.GuidAsStandardBinary, false, "", Array.Empty<PropertyConversion>()),
                         },
                     }
                 }

--- a/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_removing/and_deletion_is_acknowledged.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_removing/and_deletion_is_acknowledged.cs
@@ -17,7 +17,7 @@ public class and_deletion_is_acknowledged : given.a_projection_copy_store_and_a_
 
     It should_get_the_correct_collection = () => database.Verify(_ => _.GetCollection<BsonDocument>(collection_name, Moq.It.IsAny<MongoCollectionSettings>()));
     It should_delete_the_document_with_the_correct_filter = () => collection.Verify(_ => _.DeleteOneAsync(
-        IsFilter(document => document["_id"].AsString == projection_key.Value),
+        IsFilter(document => document["_dolittle_projection_key"].AsString == projection_key.Value),
         cancellation_token), Times.Once);
     It should_return_true = () => result.ShouldBeTrue();
 }

--- a/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_removing/and_deletion_is_not_acknowledged.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_removing/and_deletion_is_not_acknowledged.cs
@@ -24,7 +24,7 @@ public class and_deletion_is_not_acknowledged : given.a_projection_copy_store_an
 
     It should_get_the_correct_collection = () => database.Verify(_ => _.GetCollection<BsonDocument>(collection_name, Moq.It.IsAny<MongoCollectionSettings>()));
     It should_delete_the_document_with_the_correct_filter = () => collection.Verify(_ => _.DeleteOneAsync(
-        IsFilter(document => document["_id"].AsString == projection_key.Value),
+        IsFilter(document => document["_dolittle_projection_key"].AsString == projection_key.Value),
         cancellation_token), Times.Once);
     It should_return_false = () => result.ShouldBeFalse();
 }

--- a/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_replacing/and_replacing_is_acknowledged.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_replacing/and_replacing_is_acknowledged.cs
@@ -19,8 +19,8 @@ public class and_replacing_is_acknowledged : given.a_projection_copy_store_and_a
     It should_get_the_correct_collection = () => database.Verify(_ => _.GetCollection<BsonDocument>(collection_name, Moq.It.IsAny<MongoCollectionSettings>()));
     It should_convert_the_projection = () => converter.Verify(_ => _.Convert(projection_state, Moq.It.IsAny<PropertyConversion[]>()));
     It should_replace_the_document_with_the_correct_filter_and_document_and_options = () => collection.Verify(_ => _.ReplaceOneAsync(
-        IsFilter(document => document["_id"].AsString == projection_key.Value),
-        Moq.It.Is<BsonDocument>(document => document == converted_bson_document && document["_id"].AsString == projection_key.Value),
+        IsFilter(document => document["_dolittle_projection_key"].AsString == projection_key.Value),
+        Moq.It.Is<BsonDocument>(document => document == converted_bson_document && document["_dolittle_projection_key"].AsString == projection_key.Value),
         Moq.It.Is<ReplaceOptions>(options => options.IsUpsert == true),
         cancellation_token), Times.Once);
     It should_return_true = () => result.ShouldBeTrue();

--- a/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_replacing/and_replacing_is_not_acknowledged.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_MongoDBProjectionCopyStore/when_replacing/and_replacing_is_not_acknowledged.cs
@@ -26,8 +26,8 @@ public class and_replacing_is_not_acknowledged : given.a_projection_copy_store_a
     It should_get_the_correct_collection = () => database.Verify(_ => _.GetCollection<BsonDocument>(collection_name, Moq.It.IsAny<MongoCollectionSettings>()));
     It should_convert_the_projection = () => converter.Verify(_ => _.Convert(projection_state, Moq.It.IsAny<PropertyConversion[]>()));
     It should_replace_the_document_with_the_correct_filter_and_document_and_options = () => collection.Verify(_ => _.ReplaceOneAsync(
-        IsFilter(document => document["_id"].AsString == projection_key.Value),
-        Moq.It.Is<BsonDocument>(document => document == converted_bson_document && document["_id"].AsString == projection_key.Value),
+        IsFilter(document => document["_dolittle_projection_key"].AsString == projection_key.Value),
+        Moq.It.Is<BsonDocument>(document => document == converted_bson_document && document["_dolittle_projection_key"].AsString == projection_key.Value),
         Moq.It.Is<ReplaceOptions>(options => options.IsUpsert == true),
         cancellation_token), Times.Once);
     It should_return_false = () => result.ShouldBeFalse();

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/a_property_on_a_primitive.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/a_property_on_a_primitive.cs
@@ -32,7 +32,7 @@ public class a_property_on_a_primitive : given.a_converter_and_inputs
                 {
                     new PropertyConversion(
                         "some_property",
-                        ConversionBSONType.Date,
+                        ConversionBSONType.DateAsDate,
                         false,
                         "",
                         Array.Empty<PropertyConversion>()),

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/a_property_that_does_not_exist.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/a_property_that_does_not_exist.cs
@@ -25,7 +25,7 @@ public class a_property_that_does_not_exist : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "some_other_property",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_multiple_conversions/on_a_complex_state.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_multiple_conversions/on_a_complex_state.cs
@@ -76,7 +76,7 @@ public class on_a_complex_state : given.a_converter_and_inputs
                 {
                     new PropertyConversion(
                         "name",
-                        ConversionBSONType.Date,
+                        ConversionBSONType.DateAsDate,
                         false,
                         "",
                         Array.Empty<PropertyConversion>()),
@@ -97,7 +97,7 @@ public class on_a_complex_state : given.a_converter_and_inputs
                         {
                             new PropertyConversion(
                                 "released",
-                                ConversionBSONType.Date,
+                                ConversionBSONType.DateAsDate,
                                 false,
                                 "",
                                 Array.Empty<PropertyConversion>()),
@@ -106,12 +106,12 @@ public class on_a_complex_state : given.a_converter_and_inputs
         };
 
         value_converter
-            .Setup(_ => _.Convert(Moq.It.IsAny<BsonString>(), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(Moq.It.IsAny<BsonString>(), ConversionBSONType.DateAsDate))
             .Returns(new BsonArray());
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_converter_eight_times = () => value_converter.Verify(_ => _.Convert(Moq.It.IsAny<BsonString>(), ConversionBSONType.Date), Times.Exactly(8));
+    It should_call_the_converter_eight_times = () => value_converter.Verify(_ => _.Convert(Moq.It.IsAny<BsonString>(), ConversionBSONType.DateAsDate), Times.Exactly(8));
     It should_not_convert_anything_else = () => value_converter.VerifyNoOtherCalls();
     It should_return_the_correct_document = () => result.ShouldEqual(
         new BsonDocument("people", new BsonArray(new []

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_multiple_conversions/on_a_simple_state.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_multiple_conversions/on_a_simple_state.cs
@@ -31,19 +31,19 @@ public class on_a_simple_state : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "some_string",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
             new PropertyConversion(
                 "some_int",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
             new PropertyConversion(
                 "some_date",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -54,20 +54,20 @@ public class on_a_simple_state : given.a_converter_and_inputs
         converted_date = new BsonArray();
 
         value_converter
-            .Setup(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.DateAsDate))
             .Returns(converted_string);
         value_converter
-            .Setup(_ => _.Convert(new BsonInt32(42), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonInt32(42), ConversionBSONType.DateAsDate))
             .Returns(converted_int);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_date);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_convert_the_string = () => value_converter.Verify(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_int = () => value_converter.Verify(_ => _.Convert(new BsonInt32(42), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_date = () => value_converter.Verify(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.Date), Times.Once);
+    It should_convert_the_string = () => value_converter.Verify(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_int = () => value_converter.Verify(_ => _.Convert(new BsonInt32(42), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_date = () => value_converter.Verify(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.DateAsDate), Times.Once);
     It should_not_convert_anything_else = () => value_converter.VerifyNoOtherCalls();
     It should_have_the_correct_string = () => result["some_string"].ShouldBeTheSameAs(converted_string);
     It should_have_the_correct_int = () => result["some_int"].ShouldBeTheSameAs(converted_int);

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_multiple_conversions/on_objects.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_multiple_conversions/on_objects.cs
@@ -43,14 +43,14 @@ public class on_objects : given.a_converter_and_inputs
                 {
                     new PropertyConversion(
                         "some_int",
-                        ConversionBSONType.Date,
+                        ConversionBSONType.DateAsDate,
                         false,
                         "",
                         Array.Empty<PropertyConversion>()),
                 }),
             new PropertyConversion(
                 "second_object",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -60,16 +60,16 @@ public class on_objects : given.a_converter_and_inputs
         converted_object = new BsonArray();
 
         value_converter
-            .Setup(_ => _.Convert(new BsonInt32(42), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonInt32(42), ConversionBSONType.DateAsDate))
             .Returns(converted_int);
         value_converter
-            .Setup(_ => _.Convert(Moq.It.IsAny<BsonDocument>(), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(Moq.It.IsAny<BsonDocument>(), ConversionBSONType.DateAsDate))
             .Returns(converted_object);
     };
     
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_convert_the_int = () => value_converter.Verify(_ => _.Convert(new BsonInt32(42), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_object = () => value_converter.Verify(_ => _.Convert(Moq.It.IsAny<BsonDocument>(), ConversionBSONType.Date), Times.Once);
+    It should_convert_the_int = () => value_converter.Verify(_ => _.Convert(new BsonInt32(42), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_object = () => value_converter.Verify(_ => _.Convert(Moq.It.IsAny<BsonDocument>(), ConversionBSONType.DateAsDate), Times.Once);
     It should_not_convert_anything_else = () => value_converter.VerifyNoOtherCalls();
     It should_not_have_touched_the_string = () => result["first_object"]["some_string"].ShouldEqual(new BsonString("hello world"));
     It should_have_the_converted_int = () => result["first_object"]["some_int"].ShouldBeTheSameAs(converted_int);

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_complex_state.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_complex_state.cs
@@ -89,7 +89,7 @@ public class on_a_complex_state : given.a_converter_and_inputs
                         {
                             new PropertyConversion(
                                 "released",
-                                ConversionBSONType.Date,
+                                ConversionBSONType.DateAsDate,
                                 false,
                                 "",
                                 Array.Empty<PropertyConversion>()),
@@ -104,28 +104,28 @@ public class on_a_complex_state : given.a_converter_and_inputs
         converted_five = new BsonArray();
 
         value_converter
-            .Setup(_ => _.Convert(new BsonString("1905-09-26T00:00:00.000Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("1905-09-26T00:00:00.000Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_one);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("1905-11-21T00:00:00.000Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("1905-11-21T00:00:00.000Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_two);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("1963-01-01T00:00:00.000Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("1963-01-01T00:00:00.000Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_three);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("1988-01-01T00:00:00.000Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("1988-01-01T00:00:00.000Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_four);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("2013-01-01T00:00:00.000Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("2013-01-01T00:00:00.000Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_five);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_convert_the_first_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1905-09-26T00:00:00.000Z"), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_second_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1905-11-21T00:00:00.000Z"), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_third_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1963-01-01T00:00:00.000Z"), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_fourth_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1988-01-01T00:00:00.000Z"), ConversionBSONType.Date), Times.Once);
-    It should_convert_the_fifth_value = () => value_converter.Verify(_ => _.Convert(new BsonString("2013-01-01T00:00:00.000Z"), ConversionBSONType.Date), Times.Once);
+    It should_convert_the_first_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1905-09-26T00:00:00.000Z"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_second_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1905-11-21T00:00:00.000Z"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_third_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1963-01-01T00:00:00.000Z"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_fourth_value = () => value_converter.Verify(_ => _.Convert(new BsonString("1988-01-01T00:00:00.000Z"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_convert_the_fifth_value = () => value_converter.Verify(_ => _.Convert(new BsonString("2013-01-01T00:00:00.000Z"), ConversionBSONType.DateAsDate), Times.Once);
     It should_not_convert_anything_else = () => value_converter.VerifyNoOtherCalls();
     It should_have_the_first_converted_value = () => result["people"][0]["works"][0]["released"].ShouldBeTheSameAs(converted_one);
     It should_have_the_second_converted_value = () => result["people"][0]["works"][1]["released"].ShouldBeTheSameAs(converted_two);

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_bool.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_bool.cs
@@ -29,7 +29,7 @@ public class converting_some_bool : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "some_bool",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -37,12 +37,12 @@ public class converting_some_bool : given.a_converter_and_inputs
 
         converted_value = new BsonArray();
         value_converter
-            .Setup(_ => _.Convert(new BsonBoolean(true), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonBoolean(true), ConversionBSONType.DateAsDate))
             .Returns(converted_value);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonBoolean(true), ConversionBSONType.Date), Times.Once);
+    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonBoolean(true), ConversionBSONType.DateAsDate), Times.Once);
     It should_have_the_correct_string = () => result["some_string"].ShouldEqual(new BsonString("hello world"));
     It should_have_the_correct_int = () => result["some_int"].ShouldEqual(new BsonInt32(42));
     It should_have_the_converted_value = () => result["some_bool"].ShouldBeTheSameAs(converted_value);

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_date.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_date.cs
@@ -29,7 +29,7 @@ public class converting_some_date : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "some_date",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -37,12 +37,12 @@ public class converting_some_date : given.a_converter_and_inputs
         
         converted_value = new BsonArray();
         value_converter
-            .Setup(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.DateAsDate))
             .Returns(converted_value);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.Date), Times.Once);
+    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonString("2002-02-02T02:02:02.002Z"), ConversionBSONType.DateAsDate), Times.Once);
     It should_have_the_correct_string = () => result["some_string"].ShouldEqual(new BsonString("hello world"));
     It should_have_the_correct_int = () => result["some_int"].ShouldEqual(new BsonInt32(42));
     It should_have_the_correct_bool = () => result["some_bool"].ShouldEqual(new BsonBoolean(true));

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_int.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_int.cs
@@ -29,7 +29,7 @@ public class converting_some_int : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "some_int",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -37,12 +37,12 @@ public class converting_some_int : given.a_converter_and_inputs
 
         converted_value = new BsonArray();
         value_converter
-            .Setup(_ => _.Convert(new BsonInt32(42), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonInt32(42), ConversionBSONType.DateAsDate))
             .Returns(converted_value);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonInt32(42), ConversionBSONType.Date), Times.Once);
+    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonInt32(42), ConversionBSONType.DateAsDate), Times.Once);
     It should_have_the_correct_string = () => result["some_string"].ShouldEqual(new BsonString("hello world"));
     It should_have_the_converted_value = () => result["some_int"].ShouldBeTheSameAs(converted_value);
     It should_have_the_correct_bool = () => result["some_bool"].ShouldEqual(new BsonBoolean(true));

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_string.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_a_simple_state/converting_some_string.cs
@@ -29,7 +29,7 @@ public class converting_some_string : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "some_string",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -37,12 +37,12 @@ public class converting_some_string : given.a_converter_and_inputs
 
         converted_value = new BsonArray();
         value_converter
-            .Setup(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.DateAsDate))
             .Returns(converted_value);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.Date), Times.Once);
+    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.DateAsDate), Times.Once);
     It should_have_the_converted_value = () => result["some_string"].ShouldBeTheSameAs(converted_value);
     It should_have_the_correct_int = () => result["some_int"].ShouldEqual(new BsonInt32(42));
     It should_have_the_correct_bool = () => result["some_bool"].ShouldEqual(new BsonBoolean(true));

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_an_array.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_an_array.cs
@@ -28,7 +28,7 @@ public class on_an_array : given.a_converter_and_inputs
         {
             new PropertyConversion(
                 "an_array_of_strings",
-                ConversionBSONType.Date,
+                ConversionBSONType.DateAsDate,
                 false,
                 "",
                 Array.Empty<PropertyConversion>()),
@@ -39,20 +39,20 @@ public class on_an_array : given.a_converter_and_inputs
         converted_c = new BsonArray();
 
         value_converter
-            .Setup(_ => _.Convert(new BsonString("a"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("a"), ConversionBSONType.DateAsDate))
             .Returns(converted_a);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("b"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("b"), ConversionBSONType.DateAsDate))
             .Returns(converted_b);
         value_converter
-            .Setup(_ => _.Convert(new BsonString("c"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("c"), ConversionBSONType.DateAsDate))
             .Returns(converted_c);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_value_converter_with_a = () => value_converter.Verify(_ => _.Convert(new BsonString("a"), ConversionBSONType.Date), Times.Once);
-    It should_call_the_value_converter_with_b = () => value_converter.Verify(_ => _.Convert(new BsonString("b"), ConversionBSONType.Date), Times.Once);
-    It should_call_the_value_converter_with_c = () => value_converter.Verify(_ => _.Convert(new BsonString("c"), ConversionBSONType.Date), Times.Once);
+    It should_call_the_value_converter_with_a = () => value_converter.Verify(_ => _.Convert(new BsonString("a"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_call_the_value_converter_with_b = () => value_converter.Verify(_ => _.Convert(new BsonString("b"), ConversionBSONType.DateAsDate), Times.Once);
+    It should_call_the_value_converter_with_c = () => value_converter.Verify(_ => _.Convert(new BsonString("c"), ConversionBSONType.DateAsDate), Times.Once);
     It should_have_the_converted_values = () => result["an_array_of_strings"].AsBsonArray.ShouldContainOnly(converted_a, converted_b, converted_c);
     It should_not_convert_anything_else = () => value_converter.VerifyNoOtherCalls();
 }

--- a/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_an_object.cs
+++ b/Specifications/Projections.Store.Copies.MongoDB/for_ProjectionConverter/when_converting/with_one_conversion/on_an_object.cs
@@ -37,7 +37,7 @@ public class on_an_object : given.a_converter_and_inputs
                 {
                     new PropertyConversion(
                         "some_string",
-                        ConversionBSONType.Date,
+                        ConversionBSONType.DateAsDate,
                         false,
                         "",
                         Array.Empty<PropertyConversion>()),
@@ -47,12 +47,12 @@ public class on_an_object : given.a_converter_and_inputs
         converted_value = new BsonArray();
 
         value_converter
-            .Setup(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.Date))
+            .Setup(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.DateAsDate))
             .Returns(converted_value);
     };
 
     It should_call_the_renamer = () => property_renamer.Verify(_ => _.RenamePropertiesIn(Moq.It.IsAny<BsonDocument>(), conversions_to_apply), Times.Once);
-    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.Date), Times.Once);
+    It should_call_the_converter = () => value_converter.Verify(_ => _.Convert(new BsonString("hello world"), ConversionBSONType.DateAsDate), Times.Once);
     It should_have_the_converted_value = () => result["object"]["some_string"].ShouldBeTheSameAs(converted_value);
     It should_leave_the_other_property_alone = () => result["object"]["some_int"].ShouldEqual(new BsonInt32(42));
     It should_not_convert_anything_else = () => value_converter.VerifyNoOtherCalls();

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>5.0.0</AutofacVersion>
         <AutofacExtensionsVersion>6.0.0</AutofacExtensionsVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>6.6.0-sam.2</ContractsVersion>
+        <ContractsVersion>6.6.0-sam.3</ContractsVersion>
         <CoverletVersion>3.1.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary

Adds the new conversion types for projections from latest contracts, and implements the `ValueConverter` for those types. Also change persistence of conversion enum in MongoDB to string so that we can change the ordering or add new later without breaking backwards compatibility. Lastly, change the property in the copied MongoDB documents for read model copies used for the projection key from `_id` to `_dolittle_projection_key`. We might want to look at adding an index for this property later.