### PR TITLE
Set GuidRepresentation for the MongoDB copy storage to Unspecified

### DIFF
--- a/Source/Projections.Store.Copies.MongoDB/ProjectionCopiesStorage.cs
+++ b/Source/Projections.Store.Copies.MongoDB/ProjectionCopiesStorage.cs
@@ -17,7 +17,7 @@ public class ProjectionCopiesStorage : IProjectionCopiesStorage
         var connectionString = readModelsDatabase.ConnectionString;
 
         var settings = MongoClientSettings.FromUrl(connectionString);
-        settings.GuidRepresentation = GuidRepresentation.Standard;
+        settings.GuidRepresentation = GuidRepresentation.Unspecified;
         
         var client = new MongoClient(settings.Freeze());
         Database = client.GetDatabase(connectionString.DatabaseName);


### PR DESCRIPTION
## Summary

The MongoDB driver has a lot of conversions happening behind the scenes with BsonBinaryData that represents Guids. By setting it to Unspecified in the client settings, it seems to respect the exact type that the ValueConverter decides.