### PR TITLE
Implement Projections management service

### DIFF
--- a/Source/Events.Processing.Management/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing.Management/EventHandlers/EventHandlersService.cs
@@ -9,9 +9,7 @@ using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.Events.Processing.EventHandlers;
 using Dolittle.Runtime.Events.Processing.Management.Contracts;
 using Dolittle.Runtime.Events.Store.Streams;
-using Dolittle.Runtime.Projections.Store.State;
 using Dolittle.Runtime.Protobuf;
-using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -20,12 +18,21 @@ using Artifact = Dolittle.Artifacts.Contracts.Artifact;
 
 namespace Dolittle.Runtime.Events.Processing.Management.EventHandlers;
 
+/// <summary>
+/// Represents an implementation of <see cref="EventHandlersBase"/>.
+/// </summary>
 public class EventHandlersService : EventHandlersBase
 {
     readonly IEventHandlers _eventHandlers;
     readonly IExceptionToFailureConverter _exceptionToFailureConverter;
     readonly ILogger _logger;
         
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHandlersService"/> class.
+    /// </summary>
+    /// <param name="eventHandlers">The <see cref="IEventHandlers"/> to use to perform operations on Event Handlers.</param>
+    /// <param name="exceptionToFailureConverter">The <see cref="IExceptionToFailureConverter"/> to use to convert exceptions to failures.</param>
+    /// <param name="logger">The logger to use for logging.</param>
     public EventHandlersService(
         IEventHandlers eventHandlers,
         IExceptionToFailureConverter exceptionToFailureConverter,

--- a/Source/Events.Processing.Management/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing.Management/EventHandlers/EventHandlersService.cs
@@ -8,9 +8,8 @@ using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.Events.Processing.EventHandlers;
 using Dolittle.Runtime.Events.Processing.Management.Contracts;
-using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Events.Processing.Management.StreamProcessors;
 using Dolittle.Runtime.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using static Dolittle.Runtime.Events.Processing.Management.Contracts.EventHandlers;
@@ -25,21 +24,25 @@ public class EventHandlersService : EventHandlersBase
 {
     readonly IEventHandlers _eventHandlers;
     readonly IExceptionToFailureConverter _exceptionToFailureConverter;
+    readonly IConvertStreamProcessorStatuses _streamProcessorStatusConverter;
     readonly ILogger _logger;
-        
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventHandlersService"/> class.
     /// </summary>
     /// <param name="eventHandlers">The <see cref="IEventHandlers"/> to use to perform operations on Event Handlers.</param>
     /// <param name="exceptionToFailureConverter">The <see cref="IExceptionToFailureConverter"/> to use to convert exceptions to failures.</param>
+    /// <param name="streamProcessorStatusConverter">The <see cref="IConvertStreamProcessorStatuses"/> to use to convert stream processor states.</param>
     /// <param name="logger">The logger to use for logging.</param>
     public EventHandlersService(
         IEventHandlers eventHandlers,
         IExceptionToFailureConverter exceptionToFailureConverter,
+        IConvertStreamProcessorStatuses streamProcessorStatusConverter,
         ILogger logger)
     {
         _eventHandlers = eventHandlers;
         _exceptionToFailureConverter = exceptionToFailureConverter;
+        _streamProcessorStatusConverter = streamProcessorStatusConverter;
         _logger = logger;
     }
 
@@ -115,55 +118,8 @@ public class EventHandlersService : EventHandlersBase
             throw state.Exception;
         }
 
-        return state.Result.Where(_ => IsSpecificTenantOrAny(_, tenant)).Select(CreateStatusFromState);
-    }
-
-    static bool IsSpecificTenantOrAny(KeyValuePair<TenantId, IStreamProcessorState> state, TenantId tenant)
-        => tenant == null || state.Key.Equals(tenant);
-
-    static TenantScopedStreamProcessorStatus CreateStatusFromState(KeyValuePair<TenantId, IStreamProcessorState> tenantAndState)
-    {
-        var (tenant, state) = tenantAndState;
-        var status = new TenantScopedStreamProcessorStatus
-        {
-            StreamPosition = state.Position,
-            TenantId = tenant.ToProtobuf(),
-        };
-
-        switch (state)
-        {
-            case Streams.Partitioned.StreamProcessorState partitionedState:
-            {
-                status.LastSuccessfullyProcessed = partitionedState.LastSuccessfullyProcessed.ToTimestamp();
-                status.Partitioned = new PartitionedTenantScopedStreamProcessorStatus();
-                foreach (var (partition, failure) in partitionedState.FailingPartitions)
-                {
-                    status.Partitioned.FailingPartitions.Add(
-                        new FailingPartition
-                        {
-                            PartitionId = partition,
-                            FailureReason = failure.Reason,
-                            LastFailed = failure.LastFailed.ToTimestamp(),
-                            RetryCount = failure.ProcessingAttempts,
-                            RetryTime = failure.RetryTime.ToTimestamp(),
-                            StreamPosition = failure.Position
-                        });
-                }
-
-                break;
-            }
-            case Streams.StreamProcessorState unpartitionedState:
-                status.LastSuccessfullyProcessed = unpartitionedState.LastSuccessfullyProcessed.ToTimestamp();
-                status.Unpartitioned = new UnpartitionedTenantScopedStreamProcessorStatus
-                {
-                    FailureReason = unpartitionedState.FailureReason,
-                    IsFailing = unpartitionedState.IsFailing,
-                    RetryCount = unpartitionedState.ProcessingAttempts,
-                    RetryTime = unpartitionedState.RetryTime.ToTimestamp()
-                };
-                break;
-        }
-            
-        return status;
+        return tenant == null
+            ? _streamProcessorStatusConverter.Convert(state.Result)
+            : _streamProcessorStatusConverter.ConvertForTenant(state.Result, tenant);
     }
 }

--- a/Source/Events.Processing.Management/ManagementServices.cs
+++ b/Source/Events.Processing.Management/ManagementServices.cs
@@ -2,25 +2,30 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using Dolittle.Runtime.Events.Processing.Management.EventHandlers;
+using Dolittle.Runtime.Events.Processing.Management.Projections;
 using Dolittle.Runtime.Management;
 using Dolittle.Runtime.Services;
 
-namespace Dolittle.Runtime.Events.Processing.Management.EventHandlers;
+namespace Dolittle.Runtime.Events.Processing.Management;
 
 /// <summary>
-/// Represents an implementation of <see cref="ICanBindManagementServices"/> that exposes EventHandler management services.
+/// Represents an implementation of <see cref="ICanBindManagementServices"/> that exposes event processing management services.
 /// </summary>
 public class ManagementServices : ICanBindManagementServices
 {
     readonly EventHandlersService _eventHandlers;
+    readonly ProjectionsService _projections;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ManagementServices"/> class.
     /// </summary>
-    /// <param name="eventHandlers">The <see cref="EventHandlersService"/>.</param>
-    public ManagementServices(EventHandlersService eventHandlers)
+    /// <param name="eventHandlers">The Event Handlers management service.</param>
+    /// <param name="projections">The Projections management service.</param>
+    public ManagementServices(EventHandlersService eventHandlers, ProjectionsService projections)
     {
         _eventHandlers = eventHandlers;
+        _projections = projections;
     }
 
     /// <inheritdoc />
@@ -31,5 +36,6 @@ public class ManagementServices : ICanBindManagementServices
         new[]
         {
             new Service(_eventHandlers, Contracts.EventHandlers.BindService(_eventHandlers), Contracts.EventHandlers.Descriptor),
+            new Service(_projections, Contracts.Projections.BindService(_projections), Contracts.Projections.Descriptor),
         };
 }

--- a/Source/Events.Processing.Management/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing.Management/Projections/ProjectionsService.cs
@@ -64,6 +64,27 @@ public class ProjectionsService : ProjectionsBase
         return Task.FromResult(response);
     }
 
+    /// <inheritdoc />
+    public override async Task<ReplayProjectionResponse> Replay(ReplayProjectionRequest request, ServerCallContext context)
+    {
+        var result = request.TenantId == null
+            ? await _projections.ReplayEventsForAllTenants(request.ScopeId.ToGuid(), request.ProjectionId.ToGuid()).ConfigureAwait(false)
+            : await _projections.ReplayEventsForTenant(request.ScopeId.ToGuid(), request.ProjectionId.ToGuid(), request.TenantId.ToGuid()).ConfigureAwait(false);
+
+        var response = new ReplayProjectionResponse();
+        if (!result.Success)
+        {
+            response.Failure = new Failure
+            {
+                Id = FailureId.Other.ToProtobuf(),
+                Reason = result.Exception.Message,
+            };
+        }
+
+        return response;
+    }
+
+
     ProjectionStatus CreateStatusFromInfo(ProjectionInfo info, TenantId tenant = null)
     {
         var status = new ProjectionStatus

--- a/Source/Events.Processing.Management/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing.Management/Projections/ProjectionsService.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Processing.Management.Contracts;
+using Dolittle.Runtime.Events.Processing.Projections;
+using Dolittle.Runtime.Protobuf;
+using Grpc.Core;
+using static Dolittle.Runtime.Events.Processing.Management.Contracts.Projections;
+
+namespace Dolittle.Runtime.Events.Processing.Management.Projections;
+
+public class ProjectionsService : ProjectionsBase
+{
+    readonly IProjections _projections;
+
+    public ProjectionsService(IProjections projections)
+    {
+        _projections = projections;
+    }
+
+    /// <inheritdoc />
+    public override Task<GetAllProjectionsResponse> GetAll(GetAllProjectionsRequest request, ServerCallContext context)
+    {
+        var response = new GetAllProjectionsResponse();
+        response.Projections.AddRange(_projections.All.Select(CreateStatusFromInfo));
+        return Task.FromResult(response);
+    }
+
+    ProjectionStatus CreateStatusFromInfo(ProjectionInfo info)
+    {
+        var status = new ProjectionStatus
+        {
+            Alias = info.Alias,
+            // Copies
+            // Others
+            InitialState = info.Definition.InitialState,
+            ScopeId = info.Definition.Scope.ToProtobuf(),
+            ProjectionId = info.Definition.Projection.ToProtobuf(),
+        };
+
+        return status;
+    }
+    
+    
+}

--- a/Source/Events.Processing.Management/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing.Management/Projections/ProjectionsService.cs
@@ -14,10 +14,12 @@ namespace Dolittle.Runtime.Events.Processing.Management.Projections;
 public class ProjectionsService : ProjectionsBase
 {
     readonly IProjections _projections;
+    readonly IConvertProjectionDefinitions _definitionConverter;
 
-    public ProjectionsService(IProjections projections)
+    public ProjectionsService(IProjections projections, IConvertProjectionDefinitions definitionConverter)
     {
         _projections = projections;
+        _definitionConverter = definitionConverter;
     }
 
     /// <inheritdoc />
@@ -33,12 +35,13 @@ public class ProjectionsService : ProjectionsBase
         var status = new ProjectionStatus
         {
             Alias = info.Alias,
-            // Copies
-            // Others
+            Copies = _definitionConverter.ToContractsCopySpecification(info.Definition.Copies),
             InitialState = info.Definition.InitialState,
             ScopeId = info.Definition.Scope.ToProtobuf(),
             ProjectionId = info.Definition.Projection.ToProtobuf(),
         };
+        status.Events.AddRange(_definitionConverter.ToContractsEventSelectors(info.Definition.Events));
+        // Tenants
 
         return status;
     }

--- a/Source/Events.Processing.Management/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing.Management/Projections/ProjectionsService.cs
@@ -1,13 +1,17 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Events.Processing.Management.Contracts;
+using Dolittle.Runtime.Events.Processing.Management.StreamProcessors;
 using Dolittle.Runtime.Events.Processing.Projections;
 using Dolittle.Runtime.Protobuf;
 using Grpc.Core;
 using static Dolittle.Runtime.Events.Processing.Management.Contracts.Projections;
+using Failure = Dolittle.Protobuf.Contracts.Failure;
 
 namespace Dolittle.Runtime.Events.Processing.Management.Projections;
 
@@ -15,22 +19,52 @@ public class ProjectionsService : ProjectionsBase
 {
     readonly IProjections _projections;
     readonly IConvertProjectionDefinitions _definitionConverter;
+    readonly IConvertStreamProcessorStatuses _streamProcessorStatusConverter;
 
-    public ProjectionsService(IProjections projections, IConvertProjectionDefinitions definitionConverter)
+    public ProjectionsService(
+        IProjections projections,
+        IConvertProjectionDefinitions definitionConverter,
+        IConvertStreamProcessorStatuses streamProcessorStatusConverter)
     {
         _projections = projections;
         _definitionConverter = definitionConverter;
+        _streamProcessorStatusConverter = streamProcessorStatusConverter;
     }
 
     /// <inheritdoc />
     public override Task<GetAllProjectionsResponse> GetAll(GetAllProjectionsRequest request, ServerCallContext context)
     {
         var response = new GetAllProjectionsResponse();
-        response.Projections.AddRange(_projections.All.Select(CreateStatusFromInfo));
+        response.Projections.AddRange(_projections.All.Select(_ => CreateStatusFromInfo(_, request.TenantId?.ToGuid())));
         return Task.FromResult(response);
     }
 
-    ProjectionStatus CreateStatusFromInfo(ProjectionInfo info)
+    /// <inheritdoc />
+    public override Task<GetOneProjectionResponse> GetOne(GetOneProjectionRequest request, ServerCallContext context)
+    {
+        var info = _projections.All.FirstOrDefault(projection =>
+            projection.Definition.Scope.Value == request.ScopeId.ToGuid() &&
+            projection.Definition.Projection.Value == request.ProjectionId.ToGuid());
+
+        var response = new GetOneProjectionResponse();
+        
+        if (info == default)
+        {
+            response.Failure = new Failure
+            {
+                Id = FailureId.Other.ToProtobuf(),
+                Reason = $"Projection {request.ProjectionId.ToGuid()} in scope {request.ScopeId.ToGuid()} is not registered",
+            };
+        }
+        else
+        {
+            response.Projection = CreateStatusFromInfo(info, request.TenantId?.ToGuid());
+        }
+
+        return Task.FromResult(response);
+    }
+
+    ProjectionStatus CreateStatusFromInfo(ProjectionInfo info, TenantId tenant = null)
     {
         var status = new ProjectionStatus
         {
@@ -41,10 +75,20 @@ public class ProjectionsService : ProjectionsBase
             ProjectionId = info.Definition.Projection.ToProtobuf(),
         };
         status.Events.AddRange(_definitionConverter.ToContractsEventSelectors(info.Definition.Events));
-        // Tenants
-
+        status.Tenants.AddRange(CreateScopedStreamProcessorStatus(info, tenant));
         return status;
     }
     
-    
+    IEnumerable<TenantScopedStreamProcessorStatus> CreateScopedStreamProcessorStatus(ProjectionInfo info, TenantId tenant = null)
+    {
+        var state = _projections.CurrentStateFor(info.Definition.Scope, info.Definition.Projection);
+        if (!state.Success)
+        {
+            throw state.Exception;
+        }
+
+        return tenant == null
+            ? _streamProcessorStatusConverter.Convert(state.Result)
+            : _streamProcessorStatusConverter.ConvertForTenant(state.Result, tenant);
+    }
 }

--- a/Source/Events.Processing.Management/StreamProcessors/ConvertStreamProcessorStatuses.cs
+++ b/Source/Events.Processing.Management/StreamProcessors/ConvertStreamProcessorStatuses.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Dolittle.Runtime.Events.Processing.Management.StreamProcessors;
+
+/// <summary>
+/// Represents an implementation of <see cref="IConvertStreamProcessorStatuses"/>.
+/// </summary>
+public class ConvertStreamProcessorStatuses : IConvertStreamProcessorStatuses
+{
+    /// <inheritdoc />
+    public IEnumerable<Contracts.TenantScopedStreamProcessorStatus> Convert(IDictionary<TenantId, IStreamProcessorState> states)
+        => Convert(states.AsEnumerable());
+
+    /// <inheritdoc />
+    public IEnumerable<Contracts.TenantScopedStreamProcessorStatus> ConvertForTenant(IDictionary<TenantId, IStreamProcessorState> states, TenantId tenant)
+        => Convert(states.Where(_ => _.Key == tenant));
+
+    static IEnumerable<Contracts.TenantScopedStreamProcessorStatus> Convert(IEnumerable<KeyValuePair<TenantId, IStreamProcessorState>> states)
+    {
+        var statuses = new List<Contracts.TenantScopedStreamProcessorStatus>();
+        foreach (var (tenant, state) in states)
+        {
+            var status = new Contracts.TenantScopedStreamProcessorStatus
+            {
+                StreamPosition = state.Position,
+                TenantId = tenant.ToProtobuf(),
+            };
+
+            switch (state)
+            {
+                case Streams.Partitioned.StreamProcessorState partitionedState:
+                {
+                    status.LastSuccessfullyProcessed = partitionedState.LastSuccessfullyProcessed.ToTimestamp();
+                    status.Partitioned = new Contracts.PartitionedTenantScopedStreamProcessorStatus();
+                    foreach (var (partition, failure) in partitionedState.FailingPartitions)
+                    {
+                        status.Partitioned.FailingPartitions.Add(
+                            new Contracts.FailingPartition
+                            {
+                                PartitionId = partition,
+                                FailureReason = failure.Reason,
+                                LastFailed = failure.LastFailed.ToTimestamp(),
+                                RetryCount = failure.ProcessingAttempts,
+                                RetryTime = failure.RetryTime.ToTimestamp(),
+                                StreamPosition = failure.Position
+                            });
+                    }
+
+                    break;
+                }
+                case Streams.StreamProcessorState unpartitionedState:
+                    status.LastSuccessfullyProcessed = unpartitionedState.LastSuccessfullyProcessed.ToTimestamp();
+                    status.Unpartitioned = new Contracts.UnpartitionedTenantScopedStreamProcessorStatus
+                    {
+                        FailureReason = unpartitionedState.FailureReason,
+                        IsFailing = unpartitionedState.IsFailing,
+                        RetryCount = unpartitionedState.ProcessingAttempts,
+                        RetryTime = unpartitionedState.RetryTime.ToTimestamp()
+                    };
+                    break;
+            }
+            statuses.Add(status);
+        }
+
+        return statuses;
+    }
+}

--- a/Source/Events.Processing.Management/StreamProcessors/IConvertStreamProcessorStatuses.cs
+++ b/Source/Events.Processing.Management/StreamProcessors/IConvertStreamProcessorStatuses.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Events.Store.Streams;
+
+namespace Dolittle.Runtime.Events.Processing.Management.StreamProcessors;
+
+public interface IConvertStreamProcessorStatuses
+{
+    /// <summary>
+    /// Converts stream processor states per tenant from Runtime to Contracts representation.
+    /// </summary>
+    /// <param name="states">The dictionary of <see cref="TenantId"/> to <see cref="IStreamProcessorState"/> to convert.</param>
+    /// <returns>The converted <see cref="Contracts.TenantScopedStreamProcessorStatus"/>.</returns>
+    IEnumerable<Contracts.TenantScopedStreamProcessorStatus> Convert(IDictionary<TenantId, IStreamProcessorState> states);
+    
+    /// <summary>
+    /// Converts stream processor states per tenant from Runtime to Contracts representation for a specific tenant.
+    /// </summary>
+    /// <param name="states">The dictionary of <see cref="TenantId"/> to <see cref="IStreamProcessorState"/> to convert.</param>
+    /// <param name="tenant">The tenant to convert for and return.</param>
+    /// <returns>The converted <see cref="Contracts.TenantScopedStreamProcessorStatus"/> containing only the status for the given tenant, if present.</returns>
+    IEnumerable<Contracts.TenantScopedStreamProcessorStatus> ConvertForTenant(IDictionary<TenantId, IStreamProcessorState> states, TenantId tenant);
+}

--- a/Source/Events.Processing/EventHandlers/EventHandlerAlias.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlerAlias.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Dolittle.Runtime.Rudimentary;
+
 namespace Dolittle.Runtime.Events.Processing.EventHandlers;
 
 /// <summary>
-/// Represents a name alias of an Event Handler
+/// Represents a name alias of an Event Handler.
 /// </summary>
 public record EventHandlerAlias(string Value) : ConceptAs<string>(Value)
 {

--- a/Source/Events.Processing/EventHandlers/IEventHandlers.cs
+++ b/Source/Events.Processing/EventHandlers/IEventHandlers.cs
@@ -21,24 +21,24 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers;
 public interface IEventHandlers
 {
     /// <summary>
-    /// Gets information about all Event Handlers
+    /// Gets information about all currently registered Event Handlers
     /// </summary>
     IEnumerable<EventHandlerInfo> All { get; }
 
     /// <summary>
-    /// Gets the current state of an Event Handler.
+    /// Gets the current state of an Event Handler for all tenants.
     /// </summary>
     /// <param name="eventHandlerId">The <see cref="EventHandlerId"/>.</param>
-    /// <returns>The current state.</returns>
+    /// <returns>The current states of the Event Handler.</returns>
     Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(EventHandlerId eventHandlerId);
 
     /// <summary>
-    /// Registers and starts an event handler.
+    /// Registers and starts an Event Handler for all tenants.
     /// </summary>
     /// <param name="dispatcher">The actual <see cref="ReverseCallDispatcherType"/>.</param>
     /// <param name="arguments">Connecting arguments.</param>
     /// <param name="cancellationToken">Cancellation token that can cancel the hierarchy.</param>
-    /// <returns>The <see cref="Task"/> that, when resolved, returns a <see cref="Try{TResult}"/> with the <see cref="StreamPosition"/> it was set to.</returns>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous processing operation.</returns>
     Task RegisterAndStart(ReverseCallDispatcherType dispatcher, EventHandlerRegistrationArguments arguments, CancellationToken cancellationToken);
 
     /// <summary>

--- a/Source/Events.Processing/Projections/ConvertProjectionDefinitions.cs
+++ b/Source/Events.Processing/Projections/ConvertProjectionDefinitions.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Dolittle.Runtime.Artifacts;
+using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Projections.Store.Definition.Copies;
+using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
+using Dolittle.Runtime.Protobuf;
+using Artifact = Dolittle.Artifacts.Contracts.Artifact;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Represents an implementation of <see cref="IConvertProjectionDefinitions"/>.
+/// </summary>
+public class ConvertProjectionDefinitions : IConvertProjectionDefinitions
+{
+    /// <inheritdoc />
+    public IEnumerable<ProjectionEventSelector> ToRuntimeEventSelectors(IEnumerable<Contracts.ProjectionEventSelector> selectors)
+        => selectors.Select(eventSelector => eventSelector.SelectorCase switch
+        {
+            Contracts.ProjectionEventSelector.SelectorOneofCase.EventSourceKeySelector => ProjectionEventSelector.EventSourceId(eventSelector.EventType.Id.ToGuid()),
+            Contracts.ProjectionEventSelector.SelectorOneofCase.PartitionKeySelector => ProjectionEventSelector.PartitionId(eventSelector.EventType.Id.ToGuid()),
+            Contracts.ProjectionEventSelector.SelectorOneofCase.EventPropertyKeySelector => ProjectionEventSelector.EventProperty(eventSelector.EventType.Id.ToGuid(), eventSelector.EventPropertyKeySelector.PropertyName),
+            _ => throw new InvalidProjectionEventSelector(eventSelector.SelectorCase)
+        });
+
+    /// <inheritdoc />
+    public IEnumerable<Contracts.ProjectionEventSelector> ToContractsEventSelectors(IEnumerable<ProjectionEventSelector> selectors)
+        => selectors.Select(eventSelector =>
+        {
+            var converted = new Contracts.ProjectionEventSelector
+            {
+                EventType = new Artifact
+                {
+                    Id = eventSelector.EventType.ToProtobuf(),
+                    Generation = ArtifactGeneration.First,
+                }
+            };
+
+            switch (eventSelector.KeySelectorType)
+            {
+                case ProjectEventKeySelectorType.EventSourceId:
+                    converted.EventSourceKeySelector = new Contracts.EventSourceIdKeySelector();
+                    break;
+                case ProjectEventKeySelectorType.PartitionId:
+                    converted.PartitionKeySelector = new Contracts.PartitionIdKeySelector();
+                    break;
+                case ProjectEventKeySelectorType.Property:
+                    converted.EventPropertyKeySelector = new Contracts.EventPropertyKeySelector { PropertyName = eventSelector.KeySelectorExpression };
+                    break;
+            }
+            
+            return converted;
+        });
+
+    /// <inheritdoc />
+    public ProjectionCopySpecification ToRuntimeCopySpecification(Contracts.ProjectionCopies copies)
+    {
+        var mongoDB = CopyToMongoDBSpecification.Default;
+        if (copies?.MongoDB is { } copyToMongoDb)
+        {
+            mongoDB = new CopyToMongoDBSpecification(true, copyToMongoDb.Collection, ToRuntimePropertyConversions(copyToMongoDb.Conversions));
+        }
+
+        return new ProjectionCopySpecification(mongoDB);
+    }
+
+    /// <inheritdoc />
+    public Contracts.ProjectionCopies ToContractsCopySpecification(ProjectionCopySpecification copies)
+    {
+        var converted = new Contracts.ProjectionCopies();
+
+        if (copies.MongoDB.ShouldCopyToMongoDB)
+        {
+            converted.MongoDB = new Contracts.ProjectionCopyToMongoDB
+            {
+                Collection = copies.MongoDB.Collection,
+            };
+            converted.MongoDB.Conversions.AddRange(ToContractsPropertyConversions(copies.MongoDB.Conversions));
+        }
+
+        return converted;
+    }
+
+    static PropertyConversion[] ToRuntimePropertyConversions(IEnumerable<Contracts.ProjectionCopyToMongoDB.Types.PropertyConversion> conversions)
+        => conversions.Select(conversion =>
+            new PropertyConversion(
+                conversion.PropertyName,
+                conversion.ConvertTo switch
+                {
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.None => ConversionBSONType.None,
+                    
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsDate => ConversionBSONType.DateAsDate,
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsArray => ConversionBSONType.DateAsArray,
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsDocument => ConversionBSONType.DateAsDocument,
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsString => ConversionBSONType.DateAsString,
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsInt64 => ConversionBSONType.DateAsInt64,
+                    
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.GuidasStandardBinary => ConversionBSONType.GuidAsStandardBinary,
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.GuidasCsharpLegacyBinary => ConversionBSONType.GuidAsCsharpLegacyBinary,
+                    Contracts.ProjectionCopyToMongoDB.Types.BSONType.GuidasString => ConversionBSONType.GuidAsString,
+                    
+                    _ => throw new InvalidMongoDBFieldConversion(conversion.PropertyName, conversion.ConvertTo),
+                },
+                conversion.RenameTo != default,
+                conversion.RenameTo ?? "",
+                ToRuntimePropertyConversions(conversion.Children))
+            ).ToArray();
+
+    static IEnumerable<Contracts.ProjectionCopyToMongoDB.Types.PropertyConversion> ToContractsPropertyConversions(PropertyConversion[] conversions)
+        => conversions.Select(conversion =>
+        {
+            var converted = new Contracts.ProjectionCopyToMongoDB.Types.PropertyConversion
+            {
+                PropertyName = conversion.Property,
+                ConvertTo = conversion.Conversion switch
+                {
+                    ConversionBSONType.None => Contracts.ProjectionCopyToMongoDB.Types.BSONType.None,
+                    
+                    ConversionBSONType.DateAsDate => Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsDate,
+                    ConversionBSONType.DateAsArray => Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsArray,
+                    ConversionBSONType.DateAsDocument => Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsDocument,
+                    ConversionBSONType.DateAsString => Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsString,
+                    ConversionBSONType.DateAsInt64 => Contracts.ProjectionCopyToMongoDB.Types.BSONType.DateAsInt64,
+                    
+                    ConversionBSONType.GuidAsStandardBinary => Contracts.ProjectionCopyToMongoDB.Types.BSONType.GuidasStandardBinary,
+                    ConversionBSONType.GuidAsCsharpLegacyBinary => Contracts.ProjectionCopyToMongoDB.Types.BSONType.GuidasCsharpLegacyBinary,
+                    ConversionBSONType.GuidAsString => Contracts.ProjectionCopyToMongoDB.Types.BSONType.GuidasString,
+                },
+                RenameTo = conversion.ShouldRename ? conversion.RenameTo : null,
+            };
+            converted.Children.AddRange(ToContractsPropertyConversions(conversion.Children));
+            return converted;
+        });
+}

--- a/Source/Events.Processing/Projections/EventProcessor.cs
+++ b/Source/Events.Processing/Projections/EventProcessor.cs
@@ -62,7 +62,7 @@ public class EventProcessor : IEventProcessor
     /// <inheritdoc />
     public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, CancellationToken cancellationToken)
     {
-        _logger.EventProcessorIsProcessing(Identifier, @event.Type.Id, partitionId);
+        Log.EventProcessorIsProcessing(_logger, Identifier, @event.Type.Id, partitionId);
         if (!ShouldProcessEvent(@event))
         {
             return new SuccessfulProcessing();
@@ -82,7 +82,7 @@ public class EventProcessor : IEventProcessor
     /// <inheritdoc/>
     public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, CancellationToken cancellationToken)
     {
-        _logger.EventProcessorIsProcessingAgain(Identifier, @event.Type.Id, partitionId, retryCount, failureReason);
+        Log.EventProcessorIsProcessingAgain(_logger, Identifier, @event.Type.Id, partitionId, retryCount, failureReason);
         if (!ShouldProcessEvent(@event))
         {
             return new SuccessfulProcessing();
@@ -107,7 +107,7 @@ public class EventProcessor : IEventProcessor
     {
         if (!_projectionKeys.TryGetFor(_projectionDefinition, @event, partitionId, out var projectionKey))
         {
-            _logger.CouldNotGetProjectionKey(Identifier, Scope);
+            Log.CouldNotGetProjectionKey(_logger, Identifier, Scope, @event.EventLogSequenceNumber);
             return new CouldNotGetProjectionKey(@event);
         }
         return await _projectionStore.TryGet(_projectionDefinition.Projection, Scope, projectionKey, token).ConfigureAwait(false);

--- a/Source/Events.Processing/Projections/IConvertProjectionDefinitions.cs
+++ b/Source/Events.Processing/Projections/IConvertProjectionDefinitions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Projections.Store.Definition.Copies;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Defines a converter that can convert Projection definitions between Contracts and Runtime representations.
+/// </summary>
+public interface IConvertProjectionDefinitions
+{
+    /// <summary>
+    /// Converts event selectors from Contracts to Runtime representation.
+    /// </summary>
+    /// <param name="selectors">The <see cref="Contracts.ProjectionEventSelector">selectors</see> to convert.</param>
+    /// <returns>The converted <see cref="ProjectionEventSelector">selectors</see>.</returns>
+    IEnumerable<ProjectionEventSelector> ToRuntimeEventSelectors(IEnumerable<Contracts.ProjectionEventSelector> selectors);
+    
+    /// <summary>
+    /// Converts event selectors from Runtime to Contracts representation.
+    /// </summary>
+    /// <param name="selectors">The <see cref="ProjectionEventSelector">selectors</see> to convert.</param>
+    /// <returns>The converted <see cref="Contracts.ProjectionEventSelector">selectors</see>.</returns>
+    IEnumerable<Contracts.ProjectionEventSelector> ToContractsEventSelectors(IEnumerable<ProjectionEventSelector> selectors);
+
+    /// <summary>
+    /// Converts a copy specification from Contracts to Runtime representation.
+    /// </summary>
+    /// <param name="copies">The <see cref="Contracts.ProjectionCopies">copies</see> to convert.</param>
+    /// <returns>The converted <see cref="ProjectionCopySpecification">copies</see>.</returns>
+    ProjectionCopySpecification ToRuntimeCopySpecification(Contracts.ProjectionCopies copies);
+
+    /// <summary>
+    /// Converts a copy specification from Runtime to Contracts representation.
+    /// </summary>
+    /// <param name="copies">The <see cref="ProjectionCopySpecification">copies</see> to convert.</param>
+    /// <returns>The converted <see cref="Contracts.ProjectionCopies">copies</see>.</returns>
+    Contracts.ProjectionCopies ToContractsCopySpecification(ProjectionCopySpecification copies);
+}

--- a/Source/Events.Processing/Projections/IProjection.cs
+++ b/Source/Events.Processing/Projections/IProjection.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.State;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
@@ -14,6 +15,11 @@ namespace Dolittle.Runtime.Events.Processing.Projections;
 /// </summary>
 public interface IProjection
 {
+    /// <summary>
+    /// Gets the <see cref="ProjectionDefinition"/> for this <see cref="IProjection"/>.
+    /// </summary>
+    ProjectionDefinition Definition { get; }
+    
     /// <summary>
     /// Project a <see cref="CommittedEvent" /> from a <see cref="PartitionId">partition</see> onto a <see cref="ProjectionCurrentState"/> to calculate the new <see cref="ProjectionState"/>.
     /// </summary>

--- a/Source/Events.Processing/Projections/IProjection.cs
+++ b/Source/Events.Processing/Projections/IProjection.cs
@@ -21,6 +21,16 @@ public interface IProjection
     ProjectionDefinition Definition { get; }
     
     /// <summary>
+    /// Gets the alias of the Projection if set, or <see cref="ProjectionAlias.NotSet"/> if not passed from the Client.
+    /// </summary>
+    ProjectionAlias Alias { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether or not the Client passed along an alias for the Projection.
+    /// </summary>
+    bool HasAlias { get;  }
+    
+    /// <summary>
     /// Project a <see cref="CommittedEvent" /> from a <see cref="PartitionId">partition</see> onto a <see cref="ProjectionCurrentState"/> to calculate the new <see cref="ProjectionState"/>.
     /// </summary>
     /// <param name="state">The <see cref="ProjectionCurrentState"/> to update.</param>

--- a/Source/Events.Processing/Projections/IProjections.cs
+++ b/Source/Events.Processing/Projections/IProjections.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Projections.Store;
+using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Defines a system that knows about projections.
+/// </summary>
+public interface IProjections
+{
+    /// <summary>
+    /// Gets the definitions for all currently registered Projections.
+    /// </summary>
+    IEnumerable<ProjectionDefinition> All { get; }
+
+    /// <summary>
+    /// Gets the current state of a Projection for all tenants.
+    /// </summary>
+    /// <param name="scopeId">The scope of the Projection to get the state for.</param>
+    /// <param name="projectionId">The id of the Projection to get the state for.</param>
+    /// <returns>The current states of the Projection.</returns>
+    Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(ScopeId scopeId, ProjectionId projectionId);
+
+    /// <summary>
+    /// Registers and starts a Projection for all tenants.
+    /// </summary>
+    /// <param name="projection">The <see cref="IProjection"/> to start.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the processing.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous processing operation.</returns>
+    Task RegisterAndStart(IProjection projection, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Rebuilds Projection all read models for a specified Projection by dropping the old states and reprocessing all the events for a specific tenant.
+    /// </summary>
+    /// <param name="scopeId">The scope of the Projection to replay.</param>
+    /// <param name="projectionId">The id of the Projection to replay.</param>
+    /// <param name="tenantId">The tenant id to replay the Projection for.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns a <see cref="Try"/> result indicating the result of the operation.</returns>
+    Task<Try> ReplayEventsForTenant(ScopeId scopeId, ProjectionId projectionId, TenantId tenantId);
+    
+    /// <summary>
+    /// Rebuilds Projection all read models for a specified Projection by dropping the old states and reprocessing all the events for all tenants.
+    /// </summary>
+    /// <param name="scopeId">The scope of the Projection to replay.</param>
+    /// <param name="projectionId">The id of the Projection to replay.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns a <see cref="Try"/> result indicating the result of the operation.</returns>
+    Task<Try> ReplayEventsForAllTenants(ScopeId scopeId, ProjectionId projectionId);
+}

--- a/Source/Events.Processing/Projections/IProjections.cs
+++ b/Source/Events.Processing/Projections/IProjections.cs
@@ -8,7 +8,6 @@ using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Projections.Store;
-using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Rudimentary;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
@@ -19,9 +18,9 @@ namespace Dolittle.Runtime.Events.Processing.Projections;
 public interface IProjections
 {
     /// <summary>
-    /// Gets the definitions for all currently registered Projections.
+    /// Gets the information for all currently registered Projections.
     /// </summary>
-    IEnumerable<ProjectionDefinition> All { get; }
+    IEnumerable<ProjectionInfo> All { get; }
 
     /// <summary>
     /// Gets the current state of a Projection for all tenants.

--- a/Source/Events.Processing/Projections/IProjections.cs
+++ b/Source/Events.Processing/Projections/IProjections.cs
@@ -32,12 +32,12 @@ public interface IProjections
     Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(ScopeId scopeId, ProjectionId projectionId);
 
     /// <summary>
-    /// Registers and starts a Projection for all tenants.
+    /// Registers a Projection for all tenants.
     /// </summary>
     /// <param name="projection">The <see cref="IProjection"/> to start.</param>
-    /// <param name="cancellationToken">Cancellation token to cancel the processing.</param>
-    /// <returns>A <see cref="Task"/> that represents the asynchronous processing operation.</returns>
-    Task RegisterAndStart(IProjection projection, CancellationToken cancellationToken);
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns a <see cref="Try"/> of the registered <see cref="ProjectionProcessor"/>.</returns>
+    Task<Try<ProjectionProcessor>> Register(IProjection projection, CancellationToken cancellationToken);
 
     /// <summary>
     /// Rebuilds Projection all read models for a specified Projection by dropping the old states and reprocessing all the events for a specific tenant.

--- a/Source/Events.Processing/Projections/Log.cs
+++ b/Source/Events.Processing/Projections/Log.cs
@@ -6,6 +6,7 @@ using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Artifacts;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Projections.Store;
 using Microsoft.Extensions.Logging;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
@@ -17,15 +18,30 @@ static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Connecting Projections")]
     internal static partial void ConnectingProjections(ILogger logger);
-    static readonly Action<ILogger, Guid, Guid, Exception> _receivedProjection = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Trace,
-            new EventId(281764920, nameof(ReceivedProjection)),
-            "Received arguments for projection {Projection} in scope {Scope}");
-    
-    internal static void ReceivedProjection(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _receivedProjection(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, null);
 
+    [LoggerMessage(0, LogLevel.Warning, "Projection {Projection} in scope {Scope} is already registered")]
+    internal static partial void ProjectionAlreadyRegistered(ILogger logger, ScopeId scope, ProjectionId projection);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Failed to register stream processor for projection {Projection} in scope {Scope} is already registered")]
+    internal static partial void FailedToRegisterProjectionStreamProcessor(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Information, "Resetting projection {Projection} in scope {Scope} for tenant {Tenant} because: {Reason}" )]
+    internal static partial void ResettingProjection(ILogger logger, ScopeId scope, ProjectionId projection, TenantId tenant, FailedProjectionDefinitionComparisonReason reason);
+
+    [LoggerMessage(0, LogLevel.Trace, "Received arguments for projection {Projection} in scope {Scope}")]
+    internal static partial void ReceivedProjectionArguments(ILogger logger, ScopeId scope, ProjectionId projection);
+    
+    [LoggerMessage(0, LogLevel.Debug, "Projection {Projection} in scope {Scope} disconnected")]
+    internal static partial void ProjectionDisconnected(ILogger logger, ScopeId scope, ProjectionId projection);
+
+    [LoggerMessage(0, LogLevel.Error, "An error occurred while running projection {Projection} in scope {Scope}")]
+    internal static partial void ErrorWhileRunningProjection(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
+    
+    
+    
+    
+    
+    
     static readonly Action<ILogger, Guid, Guid, Exception> _registeringProjection = LoggerMessage
         .Define<Guid, Guid>(
             LogLevel.Debug,
@@ -43,15 +59,6 @@ static partial class Log
     
     internal static void ErrorWhileRegisteringProjection(this ILogger logger, Exception ex, ProjectionRegistrationArguments arguments)
         => _errorWhileRegisteringProjection(logger, arguments.ProjectionDefinition.Projection, ex);
-
-    static readonly Action<ILogger, Guid, Exception> _projectionAlreadyRegistered = LoggerMessage
-        .Define<Guid>(
-            LogLevel.Warning,
-            new EventId(379156563, nameof(ProjectionAlreadyRegistered)),
-            "Failed to register projection {Projection}. It is already registered");
-    
-    internal static void ProjectionAlreadyRegistered(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _projectionAlreadyRegistered(logger, arguments.ProjectionDefinition.Projection, null);
 
     static readonly Action<ILogger, Guid, Guid, Exception> _startingProjection = LoggerMessage
         .Define<Guid, Guid>(
@@ -98,32 +105,7 @@ static partial class Log
     internal static void PersistingProjectionDefinition(this ILogger logger, ProjectionRegistrationArguments arguments, TenantId tenant)
         => _persistingProjectionDefinition(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, tenant, null);
 
-    static readonly Action<ILogger, Guid, Guid, Guid, string, Exception> _resettingProjections = LoggerMessage
-        .Define<Guid, Guid, Guid, string>(
-            LogLevel.Debug,
-            new EventId(260459678, nameof(ResettingProjections)),
-            "Resetting projection {Projection} in scope {Scope} for tenant {Tenant} because: {Reason}");
-    
-    internal static void ResettingProjections(this ILogger logger, ProjectionRegistrationArguments arguments, TenantId tenant, FailedProjectionDefinitionComparisonReason reason)
-        => _resettingProjections(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, tenant, reason, null);
 
-    static readonly Action<ILogger, Guid, Guid, Exception> _errorWhileRunningProjection = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Warning,
-            new EventId(320592616, nameof(ErrorWhileRunningProjection)),
-            "An error occurred while running projection {Projection} in scope {Scope}");
-    
-    internal static void ErrorWhileRunningProjection(this ILogger logger, Exception ex, ProjectionRegistrationArguments arguments)
-        => _errorWhileRunningProjection(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, ex);
-
-    static readonly Action<ILogger, Guid, Guid, Exception> _eventHandlerDisconnected = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(397656028, nameof(ProjectionDisconnected)),
-            "Projection {Projection} in scope {Scope} disconnected");
-    
-    internal static void ProjectionDisconnected(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _eventHandlerDisconnected(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, null);
 
     static readonly Action<ILogger, Guid, Guid, string, Exception> _eventProcessorIsProcessing = LoggerMessage
         .Define<Guid, Guid, string>(

--- a/Source/Events.Processing/Projections/Log.cs
+++ b/Source/Events.Processing/Projections/Log.cs
@@ -37,6 +37,9 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Error, "An error occurred while running projection {Projection} in scope {Scope}")]
     internal static partial void ErrorWhileRunningProjection(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
     
+    [LoggerMessage(0, LogLevel.Debug,"Persisting definition of projection {Projection} in scope {Scope} for tenant {Tenant}" )]
+    internal static partial void PersistingProjectionDefinition(ILogger logger, ScopeId scope, ProjectionId projection, TenantId tenant);
+    
     
     
     
@@ -95,15 +98,6 @@ static partial class Log
     
     internal static void ComparingProjectionDefintion(this ILogger logger, ProjectionRegistrationArguments arguments)
         => _comparingProjectionDefinition(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, null);
-
-    static readonly Action<ILogger, Guid, Guid, Guid, Exception> _persistingProjectionDefinition = LoggerMessage
-        .Define<Guid, Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(802598225, nameof(PersistingProjectionDefinition)),
-            "Persisting definition of projection {Projection} in scope {Scope} for tenant {Tenant}");
-    
-    internal static void PersistingProjectionDefinition(this ILogger logger, ProjectionRegistrationArguments arguments, TenantId tenant)
-        => _persistingProjectionDefinition(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, tenant, null);
 
 
 

--- a/Source/Events.Processing/Projections/Log.cs
+++ b/Source/Events.Processing/Projections/Log.cs
@@ -40,7 +40,11 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Debug,"Persisting definition of projection {Projection} in scope {Scope} for tenant {Tenant}" )]
     internal static partial void PersistingProjectionDefinition(ILogger logger, ScopeId scope, ProjectionId projection, TenantId tenant);
     
-    
+    [LoggerMessage(0, LogLevel.Debug,"Starting projection {Projection} in scope {Scope}" )]
+    internal static partial void StartingProjection(ILogger logger, ScopeId scope, ProjectionId projection);
+
+    [LoggerMessage(0, LogLevel.Warning,"An error occurred while starting projection {Projection} in scope {Scope}" )]
+    internal static partial void ErrorWhileStartingProjection(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
     
     
     
@@ -63,23 +67,6 @@ static partial class Log
     internal static void ErrorWhileRegisteringProjection(this ILogger logger, Exception ex, ProjectionRegistrationArguments arguments)
         => _errorWhileRegisteringProjection(logger, arguments.ProjectionDefinition.Projection, ex);
 
-    static readonly Action<ILogger, Guid, Guid, Exception> _startingProjection = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(91153857, nameof(StartingProjection)),
-            "Starting projection {ProjectionId} in scope {Scope}");
-    
-    internal static void StartingProjection(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _startingProjection(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, null);
-
-    static readonly Action<ILogger, Guid, Guid, Exception> _errorWhileStartingProjection = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Warning,
-            new EventId(1426452095, nameof(ErrorWhileStartingProjection)),
-            "An error occurred while starting projection {Projection} in scope {Scope}");
-    
-    internal static void ErrorWhileStartingProjection(this ILogger logger, Exception ex, ProjectionRegistrationArguments arguments)
-        => _errorWhileStartingProjection(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, ex);
 
     static readonly Action<ILogger, Guid, Guid, Exception> _couldNotStartProjection = LoggerMessage
         .Define<Guid, Guid>(

--- a/Source/Events.Processing/Projections/Log.cs
+++ b/Source/Events.Processing/Projections/Log.cs
@@ -18,24 +18,33 @@ static partial class Log
 {
     [LoggerMessage(0, LogLevel.Debug, "Connecting Projections")]
     internal static partial void ConnectingProjections(ILogger logger);
-
+    
+    [LoggerMessage(0, LogLevel.Trace, "Received arguments for projection {Projection} in scope {Scope}")]
+    internal static partial void ReceivedProjectionArguments(ILogger logger, ScopeId scope, ProjectionId projection);
+    
+    [LoggerMessage(0, LogLevel.Warning,"An error occurred while registering projection {Projection} in scope {Scope}" )]
+    internal static partial void ErrorWhileRegisteringProjection(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
+    
     [LoggerMessage(0, LogLevel.Warning, "Projection {Projection} in scope {Scope} is already registered")]
     internal static partial void ProjectionAlreadyRegistered(ILogger logger, ScopeId scope, ProjectionId projection);
+    
+    [LoggerMessage(0, LogLevel.Debug,"Registering stream processor for projection {Projection} in scope {Scope}." )]
+    internal static partial void RegisteringStreamProcessorForProjection(ILogger logger, ScopeId scope, ProjectionId projection);
     
     [LoggerMessage(0, LogLevel.Warning, "Failed to register stream processor for projection {Projection} in scope {Scope} is already registered")]
     internal static partial void FailedToRegisterProjectionStreamProcessor(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
     
     [LoggerMessage(0, LogLevel.Information, "Resetting projection {Projection} in scope {Scope} for tenant {Tenant} because: {Reason}" )]
     internal static partial void ResettingProjection(ILogger logger, ScopeId scope, ProjectionId projection, TenantId tenant, FailedProjectionDefinitionComparisonReason reason);
-
-    [LoggerMessage(0, LogLevel.Trace, "Received arguments for projection {Projection} in scope {Scope}")]
-    internal static partial void ReceivedProjectionArguments(ILogger logger, ScopeId scope, ProjectionId projection);
     
     [LoggerMessage(0, LogLevel.Debug, "Projection {Projection} in scope {Scope} disconnected")]
     internal static partial void ProjectionDisconnected(ILogger logger, ScopeId scope, ProjectionId projection);
 
     [LoggerMessage(0, LogLevel.Error, "An error occurred while running projection {Projection} in scope {Scope}")]
     internal static partial void ErrorWhileRunningProjection(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
+    
+    [LoggerMessage(0, LogLevel.Debug,"Comparing projection definition for projection {Projection} in scope {Scope}" )]
+    internal static partial void ComparingProjectionDefiniton(ILogger logger, ScopeId scope, ProjectionId projection);
     
     [LoggerMessage(0, LogLevel.Debug,"Persisting definition of projection {Projection} in scope {Scope} for tenant {Tenant}" )]
     internal static partial void PersistingProjectionDefinition(ILogger logger, ScopeId scope, ProjectionId projection, TenantId tenant);
@@ -45,73 +54,13 @@ static partial class Log
 
     [LoggerMessage(0, LogLevel.Warning,"An error occurred while starting projection {Projection} in scope {Scope}" )]
     internal static partial void ErrorWhileStartingProjection(ILogger logger, ScopeId scope, ProjectionId projection, Exception exception);
-    
-    
-    
-    
-    static readonly Action<ILogger, Guid, Guid, Exception> _registeringProjection = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(75571170, nameof(RegisteringProjection)),
-            "Registering stream processor for projection {Projection} on source stream {SourceStream}");
-    
-    internal static void RegisteringProjection(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _registeringProjection(logger, arguments.ProjectionDefinition.Projection, StreamId.EventLog, null);
 
-    static readonly Action<ILogger, Guid, Exception> _errorWhileRegisteringProjection = LoggerMessage
-        .Define<Guid>(
-            LogLevel.Warning,
-            new EventId(57136794, nameof(ErrorWhileRegisteringProjection)),
-            "An error occurred while registering projection {Projection}");
-    
-    internal static void ErrorWhileRegisteringProjection(this ILogger logger, Exception ex, ProjectionRegistrationArguments arguments)
-        => _errorWhileRegisteringProjection(logger, arguments.ProjectionDefinition.Projection, ex);
+    [LoggerMessage(0, LogLevel.Trace, "Projection Event processor {EventProcessor} is processing event type {EventType} for partition {Partition}")]
+    internal static partial void EventProcessorIsProcessing(ILogger logger, EventProcessorId eventProcessor, ArtifactId eventType, PartitionId partition);
 
+    [LoggerMessage(0, LogLevel.Trace, "Projection Event processor {EventProcessor} is processing event type {EventType} for partition {Partition} again for the {RetryCount} time, because of {FailureReason}")]
+    internal static partial void EventProcessorIsProcessingAgain(ILogger logger, EventProcessorId eventProcessor, ArtifactId eventType, PartitionId partition, uint retryCount, string failureReason);
 
-    static readonly Action<ILogger, Guid, Guid, Exception> _couldNotStartProjection = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Warning,
-            new EventId(365915237, nameof(CouldNotStartProjection)),
-            "Could not start projection {Projection} in scope {Scope}");
-    
-    internal static void CouldNotStartProjection(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _couldNotStartProjection(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, null);
-
-    static readonly Action<ILogger, Guid, Guid, Exception> _comparingProjectionDefinition = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(76472302, nameof(ComparingProjectionDefintion)),
-            "Comparing projection definition for projection {Projection} in scope {Scope}");
-    
-    internal static void ComparingProjectionDefintion(this ILogger logger, ProjectionRegistrationArguments arguments)
-        => _comparingProjectionDefinition(logger, arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, null);
-
-
-
-    static readonly Action<ILogger, Guid, Guid, string, Exception> _eventProcessorIsProcessing = LoggerMessage
-        .Define<Guid, Guid, string>(
-            LogLevel.Trace,
-            new EventId(176851418, nameof(EventProcessorIsProcessing)),
-            "Projection Event processor {EventProcessor} is processing event type {EventTypeId} for partition {PartitionId}");
-    
-    internal static void EventProcessorIsProcessing(this ILogger logger, EventProcessorId projectionId, ArtifactId eventType, PartitionId partition)
-        => _eventProcessorIsProcessing(logger, projectionId, eventType, partition, null);
-
-    static readonly Action<ILogger, Guid, Guid, string, uint, string, Exception> _eventProcessorIsProcessingAgain = LoggerMessage
-        .Define<Guid, Guid, string, uint, string>(
-            LogLevel.Debug,
-            new EventId(828753281, nameof(EventProcessorIsProcessingAgain)),
-            "Projection Event processor {EventProcessor} is processing event type {EventTypeId} for partition {PartitionId} again for the {RetryCount} time, because of {FailureReason}");
-    
-    internal static void EventProcessorIsProcessingAgain(this ILogger logger, EventProcessorId projectionId, ArtifactId eventType, PartitionId partition, uint retryCount, string failureReason)
-        => _eventProcessorIsProcessingAgain(logger, projectionId, eventType, partition, retryCount, failureReason, null);
-
-    static readonly Action<ILogger, Guid, Guid, Exception> _couldNotGetProjectionKey = LoggerMessage
-        .Define<Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(176305120, nameof(CouldNotGetProjectionKey)),
-            "Could not get projection key for projection {Projection} in scope {Scope}");
-    
-    internal static void CouldNotGetProjectionKey(this ILogger logger, EventProcessorId projectionId, ScopeId scope)
-        => _couldNotGetProjectionKey(logger, projectionId, scope, null);
+    [LoggerMessage(0, LogLevel.Debug, "Could not get projection key for projection {Projection} in scope {Scope} for event at {EventLogPosition}")]
+    internal static partial void CouldNotGetProjectionKey(ILogger logger, EventProcessorId projection, ScopeId scope, EventLogSequenceNumber eventLogPosition);
 }

--- a/Source/Events.Processing/Projections/Projection.cs
+++ b/Source/Events.Processing/Projections/Projection.cs
@@ -20,18 +20,30 @@ public class Projection : IProjection
     /// <summary>
     /// Initializes a new instance of the <see cref="Projection"/> class.
     /// </summary>
-    /// <param name="projectionDefinition">The <see cref="ProjectionDefinition" />.</param>
     /// <param name="dispatcher">The <see cref="IReverseCallDispatcher{TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse}"/> dispatcher to use to send requests to the head.</param>
+    /// <param name="projectionDefinition">The <see cref="ProjectionDefinition" />.</param>
+    /// <param name="alias">The alias of the Projection (if provided) from the Client.</param>
+    /// <param name="hasAlias">A value indicating whether an alias was provided by the Client.</param>
     public Projection(
+        IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> dispatcher,
         ProjectionDefinition projectionDefinition,
-        IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> dispatcher)
+        ProjectionAlias alias,
+        bool hasAlias)
     {
         Definition = projectionDefinition;
         _dispatcher = dispatcher;
+        Alias = alias;
+        HasAlias = hasAlias;
     }
 
     /// <inheritdoc/>
     public ProjectionDefinition Definition { get; }
+
+    /// <inheritdoc />
+    public ProjectionAlias Alias { get; }
+
+    /// <inheritdoc />
+    public bool HasAlias { get; }
 
     /// <inheritdoc/>
     public Task<IProjectionResult> Project(ProjectionCurrentState state, CommittedEvent @event, PartitionId partitionId, CancellationToken cancellationToken)

--- a/Source/Events.Processing/Projections/Projection.cs
+++ b/Source/Events.Processing/Projections/Projection.cs
@@ -15,7 +15,6 @@ namespace Dolittle.Runtime.Events.Processing.Projections;
 
 public class Projection : IProjection
 {
-    readonly ProjectionDefinition _projectionDefinition;
     readonly IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> _dispatcher;
 
     /// <summary>
@@ -27,9 +26,12 @@ public class Projection : IProjection
         ProjectionDefinition projectionDefinition,
         IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> dispatcher)
     {
-        _projectionDefinition = projectionDefinition;
+        Definition = projectionDefinition;
         _dispatcher = dispatcher;
     }
+
+    /// <inheritdoc/>
+    public ProjectionDefinition Definition { get; }
 
     /// <inheritdoc/>
     public Task<IProjectionResult> Project(ProjectionCurrentState state, CommittedEvent @event, PartitionId partitionId, CancellationToken cancellationToken)
@@ -51,7 +53,7 @@ public class Projection : IProjection
         {
             Event = @event.ToProtobuf(),
             PartitionId = partitionId.Value,
-            ScopeId = _projectionDefinition.Scope.ToProtobuf(),
+            ScopeId = Definition.Scope.ToProtobuf(),
         };
         request.CurrentState = state.ToProtobuf();
 

--- a/Source/Events.Processing/Projections/ProjectionAlias.cs
+++ b/Source/Events.Processing/Projections/ProjectionAlias.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Represents a name alias of a Projection.
+/// </summary>
+public record ProjectionAlias(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Gets the <see cref="ProjectionAlias"/> to use when none is provided by the Client.
+    /// </summary>
+    public static ProjectionAlias NotSet => "No alias";
+        
+    /// <summary>
+    /// Implicitly convert from <see cref="string"/> to <see cref="ProjectionAlias"/>.
+    /// </summary>
+    /// <param name="alias"><see cref="string"/> representation.</param>
+    public static implicit operator ProjectionAlias(string alias) => new(alias);
+}

--- a/Source/Events.Processing/Projections/ProjectionAlreadyRegistered.cs
+++ b/Source/Events.Processing/Projections/ProjectionAlreadyRegistered.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Projections.Store;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Exception that gets thrown when attempting to register a Projection that is already registered.
+/// </summary>
+public class ProjectionAlreadyRegistered : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectionAlreadyRegistered"/> class.
+    /// </summary>
+    /// <param name="scope">The scope of the Projection that was already registered.</param>
+    /// <param name="projection">The id of the Projection that was already registered.</param>
+    public ProjectionAlreadyRegistered(ScopeId scope, ProjectionId projection)
+        : base($"The projection {projection} in scope {scope} is already registered")
+    {
+    }
+}

--- a/Source/Events.Processing/Projections/ProjectionInfo.cs
+++ b/Source/Events.Processing/Projections/ProjectionInfo.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Projections.Store.Definition;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Represents the information for a <see cref="Projection"/>.
+/// </summary>
+/// <param name="Definition">The definition of the Projection.</param>
+/// <param name="HasAlias">Whether or not an alias was provided by the Client for the Projection.</param>
+/// <param name="Alias">The alias of the Projection.</param>
+public record ProjectionInfo(
+    ProjectionDefinition Definition,
+    bool HasAlias,
+    ProjectionAlias Alias);

--- a/Source/Events.Processing/Projections/ProjectionNotRegistered.cs
+++ b/Source/Events.Processing/Projections/ProjectionNotRegistered.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Projections.Store;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+/// <summary>
+/// Exception that gets thrown when attempting to perform an action on a Projection that not registered.
+/// </summary>
+public class ProjectionNotRegistered : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectionNotRegistered"/> class.
+    /// </summary>
+    /// <param name="scope">The scope of the Projection that is not registered.</param>
+    /// <param name="projection">The id of the Projection that is not registered.</param>
+    public ProjectionNotRegistered(ScopeId scope, ProjectionId projection)
+        : base($"The projection {projection} in scope {scope} is not registered")
+    {
+    }
+}

--- a/Source/Events.Processing/Projections/ProjectionProcessor.cs
+++ b/Source/Events.Processing/Projections/ProjectionProcessor.cs
@@ -2,23 +2,47 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Threading;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Events.Processing.Streams;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Rudimentary;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
 
 public class ProjectionProcessor : IDisposable
 {
+    readonly IProjection _projection;
+    readonly StreamProcessor _streamProcessor;
+    readonly Action _unregister;
+
     public ProjectionProcessor(IProjection projection, StreamProcessor streamProcessor, Action unregister)
     {
+        _projection = projection;
+        _streamProcessor = streamProcessor;
+        _unregister = unregister;
     }
 
-    public Task Start(CancellationToken cancellationToken)
+    public ProjectionDefinition Definition => _projection.Definition;
+
+    public async Task Start()
     {
+        await _streamProcessor.Initialize();
+        await _streamProcessor.Start();
     }
+
+    /// <summary>
+    /// Gets all current <see cref="IStreamProcessorState"/> states for this <see cref="ProjectionProcessor"/>. 
+    /// </summary>
+    /// <returns>The <see cref="IStreamProcessorState"/> per <see cref="TenantId"/>.</returns>
+    public Try<IDictionary<TenantId, IStreamProcessorState>> GetCurrentStates()
+        => _streamProcessor.GetCurrentStates();
 
     public void Dispose()
     {
+        //TODO: Implement properly
+        _unregister();
     }
 }

--- a/Source/Events.Processing/Projections/ProjectionProcessor.cs
+++ b/Source/Events.Processing/Projections/ProjectionProcessor.cs
@@ -40,6 +40,14 @@ public class ProjectionProcessor : IDisposable
     public ProjectionDefinition Definition => _projection.Definition;
 
     /// <summary>
+    /// Gets the <see cref="ProjectionInfo"/> for this projection processor.
+    /// </summary>
+    public ProjectionInfo Info => new(
+        _projection.Definition,
+        _projection.HasAlias,
+        _projection.Alias);
+
+    /// <summary>
     /// Starts the projection processor.
     /// </summary>
     /// <returns>A <see cref="Task"/> that represents the asynchronous processing.</returns>

--- a/Source/Events.Processing/Projections/ProjectionProcessor.cs
+++ b/Source/Events.Processing/Projections/ProjectionProcessor.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Events.Processing.Streams;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Reflection;
 using Dolittle.Runtime.Rudimentary;
 using Microsoft.Extensions.Logging;
 
@@ -81,6 +83,17 @@ public class ProjectionProcessor : IDisposable
     /// <returns>The <see cref="IStreamProcessorState"/> per <see cref="TenantId"/>.</returns>
     public Try<IDictionary<TenantId, IStreamProcessorState>> GetCurrentStates()
         => _streamProcessor.GetCurrentStates();
+
+    public async Task<Try> ReplayEventsForTenant(TenantId tenant, Func<TenantId, CancellationToken, Task<Try>> dropStates)
+    {
+        return await _streamProcessor.PerformActionAndSetToPosition(tenant, StreamPosition.Start, dropStates);
+    }
+
+    public async Task<IDictionary<TenantId, Try>> ReplayEventsForAllTenants(Func<TenantId, CancellationToken, Task<Try>> dropStates)
+    {
+        var results = await _streamProcessor.PerformActionAndSetToInitialPositionForAllTenants(dropStates).ConfigureAwait(false);
+        return results.ToDictionary(_ => _.Key, _ => (Try)_.Value);
+    }
 
     /// <inheritdoc />
     public void Dispose()

--- a/Source/Events.Processing/Projections/ProjectionProcessor.cs
+++ b/Source/Events.Processing/Projections/ProjectionProcessor.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Processing.Streams;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+public class ProjectionProcessor : IDisposable
+{
+    public ProjectionProcessor(IProjection projection, StreamProcessor streamProcessor, Action unregister)
+    {
+    }
+
+    public Task Start(CancellationToken cancellationToken)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/Source/Events.Processing/Projections/ProjectionRegistrationArguments.cs
+++ b/Source/Events.Processing/Projections/ProjectionRegistrationArguments.cs
@@ -9,8 +9,52 @@ namespace Dolittle.Runtime.Events.Processing.Projections;
 /// <summary>
 /// Represents the runtime representation of the projection registration arguments.
 /// </summary>
-/// <param name="ExecutionContext">The execution context.</param>
-/// <param name="ProjectionDefinition">The projection definition.</param>
-public record ProjectionRegistrationArguments(
-    ExecutionContext ExecutionContext,
-    ProjectionDefinition ProjectionDefinition);
+public record ProjectionRegistrationArguments
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectionRegistrationArguments"/> class.
+    /// </summary>
+    /// <param name="executionContext">The execution context of the Client while registering.</param>
+    /// <param name="projectionDefinition">The Projection definition.</param>
+    public ProjectionRegistrationArguments(ExecutionContext executionContext, ProjectionDefinition projectionDefinition)
+    {
+        ExecutionContext = executionContext;
+        ProjectionDefinition = projectionDefinition;
+        Alias = ProjectionAlias.NotSet;
+        HasAlias = false;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectionRegistrationArguments"/> class.
+    /// </summary>
+    /// <param name="executionContext">The execution context of the Client while registering.</param>
+    /// <param name="projectionDefinition">The Projection definition.</param>
+    /// <param name="alias">The alias of the Projection.</param>
+    public ProjectionRegistrationArguments(ExecutionContext executionContext, ProjectionDefinition projectionDefinition, ProjectionAlias @alias)
+    {
+        ExecutionContext = executionContext;
+        ProjectionDefinition = projectionDefinition;
+        Alias = alias;
+        HasAlias = true;
+    }
+
+    /// <summary>
+    /// Gets the execution context of the Client while registering.
+    /// </summary>
+    public ExecutionContext ExecutionContext { get; }
+    
+    /// <summary>
+    /// Gets the Projection definition.
+    /// </summary>
+    public ProjectionDefinition ProjectionDefinition { get; }
+    
+    /// <summary>
+    /// Gets the alias of the Projection if set, or <see cref="ProjectionAlias.NotSet"/> if not passed from the Client.
+    /// </summary>
+    public ProjectionAlias Alias { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether or not the Client passed along an alias for the Projection.
+    /// </summary>
+    public bool HasAlias { get;  }
+}

--- a/Source/Events.Processing/Projections/Projections.cs
+++ b/Source/Events.Processing/Projections/Projections.cs
@@ -82,6 +82,8 @@ public class Projections : IProjections
             return new ProjectionAlreadyRegistered(identifier.Scope, identifier.Projection);
         }
         
+        Log.RegisteringStreamProcessorForProjection(_logger, identifier.Scope, identifier.Projection);
+        
         var registration = _streamProcessors.TryCreateAndRegister(
             projection.Definition.Scope,
             projection.Definition.Projection.Value,
@@ -153,6 +155,7 @@ public class Projections : IProjections
     {
         var tenantsToResetFor = new List<TenantId>();
         
+        Log.ComparingProjectionDefiniton(_logger, identifier.Scope, identifier.Projection);
         var tenantComparisonResults = await _projectionDefinitionComparer.DiffersFromPersisted(definition, cancellationToken).ConfigureAwait(false);
         foreach (var (tenant, result) in tenantComparisonResults)
         {

--- a/Source/Events.Processing/Projections/Projections.cs
+++ b/Source/Events.Processing/Projections/Projections.cs
@@ -62,12 +62,15 @@ public class Projections : IProjections
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<Projections>();
     }
+
+    /// <inheritdoc />
+    public IEnumerable<ProjectionDefinition> All => _projections.Values.Select(_ => _.Definition);
     
     /// <inheritdoc />
-    public IEnumerable<ProjectionDefinition> All { get; }
-    
-    /// <inheritdoc />
-    public Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(ScopeId scopeId, ProjectionId projectionId) => throw new System.NotImplementedException();
+    public Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(ScopeId scopeId, ProjectionId projectionId) 
+        => _projections.TryGetValue(new ProjectionIdentifier(scopeId, projectionId), out var processor)
+            ? processor.GetCurrentStates()
+            : new ProjectionNotRegistered(scopeId, projectionId);
 
     /// <inheritdoc />
     public async Task<Try<ProjectionProcessor>> Register(IProjection projection, CancellationToken cancellationToken)

--- a/Source/Events.Processing/Projections/Projections.cs
+++ b/Source/Events.Processing/Projections/Projections.cs
@@ -104,7 +104,9 @@ public class Projections : IProjections
         var processor = new ProjectionProcessor(
             projection,
             registration.Result,
-            () => _projections.TryRemove(identifier, out _));
+            () => _projections.TryRemove(identifier, out _),
+            _loggerFactory.CreateLogger<ProjectionProcessor>(),
+            cancellationToken);
         
         if (!_projections.TryAdd(identifier, processor))
         {

--- a/Source/Events.Processing/Projections/Projections.cs
+++ b/Source/Events.Processing/Projections/Projections.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.DependencyInversion;
+using Dolittle.Runtime.Events.Processing.Streams;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Projections.Store;
+using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Rudimentary;
+using Microsoft.Extensions.Logging;
+
+namespace Dolittle.Runtime.Events.Processing.Projections;
+
+record ProjectionIdentifier(ScopeId Scope, ProjectionId Projection);
+
+/// <summary>
+/// Represents an implementation of <see cref="IProjections"/>.
+/// </summary>
+public class Projections : IProjections
+{
+    readonly ConcurrentDictionary<ProjectionIdentifier, ProjectionProcessor> _projections = new();
+    
+    readonly IStreamProcessors _streamProcessors;
+    readonly ICompareProjectionDefinitionsForAllTenants _projectionDefinitionComparer;
+    readonly FactoryFor<IProjectionPersister> _getProjectionPersister;
+    readonly FactoryFor<IProjectionStore> _getProjectionStore;
+    readonly IProjectionKeys _projectionKeys;
+    readonly ILoggerFactory _loggerFactory;
+    readonly ILogger _logger;
+
+    public Projections(
+        IStreamProcessors streamProcessors,
+        ICompareProjectionDefinitionsForAllTenants projectionDefinitionComparer,
+        FactoryFor<IProjectionPersister> getProjectionPersister,
+        FactoryFor<IProjectionStore> getProjectionStore,
+        IProjectionKeys projectionKeys,
+        ILoggerFactory loggerFactory)
+    {
+        _streamProcessors = streamProcessors;
+        _projectionDefinitionComparer = projectionDefinitionComparer;
+        _getProjectionPersister = getProjectionPersister;
+        _getProjectionStore = getProjectionStore;
+        _projectionKeys = projectionKeys;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<Projections>();
+    }
+    
+    /// <inheritdoc />
+    public IEnumerable<ProjectionDefinition> All { get; }
+    
+    /// <inheritdoc />
+    public Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(ScopeId scopeId, ProjectionId projectionId) => throw new System.NotImplementedException();
+
+    /// <inheritdoc />
+    public async Task<Try<ProjectionProcessor>> Register(IProjection projection, CancellationToken cancellationToken)
+    {
+        var identifier = new ProjectionIdentifier(projection.Definition.Scope, projection.Definition.Projection);
+        if (_projections.ContainsKey(identifier))
+        {
+            Log.ProjectionAlreadyRegistered(_logger, identifier.Scope, identifier.Projection);
+            return new ProjectionAlreadyRegistered(identifier.Scope, identifier.Projection);
+        }
+        
+        var registration = _streamProcessors.TryCreateAndRegister(
+            projection.Definition.Scope,
+            projection.Definition.Projection.Value,
+            new EventLogStreamDefinition(),
+            () => new EventProcessor(
+                projection.Definition,
+                _getProjectionPersister(),
+                _getProjectionStore(),
+                _projectionKeys,
+                projection,
+                _loggerFactory.CreateLogger<EventProcessor>()),
+            cancellationToken);
+
+        if (!registration.Success)
+        {
+            Log.FailedToRegisterProjectionStreamProcessor(_logger, identifier.Scope, identifier.Projection, registration.Exception);
+            return registration.Exception;
+        }
+
+        var processor = new ProjectionProcessor(
+            projection,
+            registration.Result,
+            () => _projections.TryRemove(identifier, out _));
+        
+        if (!_projections.TryAdd(identifier, processor))
+        {
+            Log.ProjectionAlreadyRegistered(_logger, identifier.Scope, identifier.Projection);
+            return new ProjectionAlreadyRegistered(identifier.Scope, identifier.Projection);
+        }
+
+        var tenantComparisonResults = await _projectionDefinitionComparer.DiffersFromPersisted(projection.Definition, cancellationToken).ConfigureAwait(false);
+        var tenantsToResetFor = tenantComparisonResults
+            .Where(_ =>
+            {
+                var (tenantId, result) = _;
+                if (result.Succeeded)
+                {
+                    return false;
+                }
+                
+                Log.ResettingProjection(_logger, identifier.Scope, identifier.Projection, tenantId, result.FailureReason);
+                return true;
+            })
+            .Select(_ => _.Key);
+        
+        var dropping = await DropStatesAndResetStreamProcessorsFor(tenantsToResetFor, cancellationToken);
+        if (!dropping.Success)
+        {
+            processor.Dispose();
+            return dropping.Exception;
+        }
+
+        var persistence = await PersistDefinitionForAllTenants(projection.Definition, cancellationToken);
+        if (!persistence.Success)
+        {
+            processor.Dispose();
+            return persistence.Exception;
+        }
+
+        return processor;
+    }
+
+    /// <inheritdoc />
+    public Task<Try> ReplayEventsForTenant(ScopeId scopeId, ProjectionId projectionId, TenantId tenantId) => throw new System.NotImplementedException();
+
+    /// <inheritdoc />
+    public Task<Try> ReplayEventsForAllTenants(ScopeId scopeId, ProjectionId projectionId) => throw new System.NotImplementedException();
+
+    Task<Try> DropStatesAndResetStreamProcessorsFor(IEnumerable<TenantId> tenants, CancellationToken cancellationToken)
+    {
+        
+    }
+
+    Task<Try> PersistDefinitionForAllTenants(ProjectionDefinition definition, CancellationToken cancellationToken)
+    {
+        
+    }
+}

--- a/Source/Events.Processing/Projections/Projections.cs
+++ b/Source/Events.Processing/Projections/Projections.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +15,7 @@ using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Rudimentary;
+using Dolittle.Runtime.Tenancy;
 using Microsoft.Extensions.Logging;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
@@ -31,7 +33,10 @@ public class Projections : IProjections
     readonly ICompareProjectionDefinitionsForAllTenants _projectionDefinitionComparer;
     readonly FactoryFor<IProjectionPersister> _getProjectionPersister;
     readonly FactoryFor<IProjectionStore> _getProjectionStore;
+    readonly FactoryFor<IProjectionDefinitions> _getProjectionDefinitions;
+    readonly FactoryFor<IStreamProcessorStateRepository> _getStreamProcessorStates;
     readonly IProjectionKeys _projectionKeys;
+    readonly IPerformActionOnAllTenants _onAllTenants;
     readonly ILoggerFactory _loggerFactory;
     readonly ILogger _logger;
 
@@ -40,14 +45,20 @@ public class Projections : IProjections
         ICompareProjectionDefinitionsForAllTenants projectionDefinitionComparer,
         FactoryFor<IProjectionPersister> getProjectionPersister,
         FactoryFor<IProjectionStore> getProjectionStore,
+        FactoryFor<IProjectionDefinitions> getProjectionDefinitions,
+        FactoryFor<IStreamProcessorStateRepository> getStreamProcessorStates,
         IProjectionKeys projectionKeys,
+        IPerformActionOnAllTenants onAllTenants,
         ILoggerFactory loggerFactory)
     {
         _streamProcessors = streamProcessors;
         _projectionDefinitionComparer = projectionDefinitionComparer;
         _getProjectionPersister = getProjectionPersister;
         _getProjectionStore = getProjectionStore;
+        _getProjectionDefinitions = getProjectionDefinitions;
+        _getStreamProcessorStates = getStreamProcessorStates;
         _projectionKeys = projectionKeys;
+        _onAllTenants = onAllTenants;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<Projections>();
     }
@@ -98,33 +109,11 @@ public class Projections : IProjections
             return new ProjectionAlreadyRegistered(identifier.Scope, identifier.Projection);
         }
 
-        var tenantComparisonResults = await _projectionDefinitionComparer.DiffersFromPersisted(projection.Definition, cancellationToken).ConfigureAwait(false);
-        var tenantsToResetFor = tenantComparisonResults
-            .Where(_ =>
-            {
-                var (tenantId, result) = _;
-                if (result.Succeeded)
-                {
-                    return false;
-                }
-                
-                Log.ResettingProjection(_logger, identifier.Scope, identifier.Projection, tenantId, result.FailureReason);
-                return true;
-            })
-            .Select(_ => _.Key);
-        
-        var dropping = await DropStatesAndResetStreamProcessorsFor(tenantsToResetFor, cancellationToken);
-        if (!dropping.Success)
+        var resetting = await ResetProjectionIfDefinitionHasChanged(identifier, projection.Definition, cancellationToken).ConfigureAwait(false);
+        if (!resetting.Success)
         {
             processor.Dispose();
-            return dropping.Exception;
-        }
-
-        var persistence = await PersistDefinitionForAllTenants(projection.Definition, cancellationToken);
-        if (!persistence.Success)
-        {
-            processor.Dispose();
-            return persistence.Exception;
+            return resetting.Exception;
         }
 
         return processor;
@@ -136,13 +125,87 @@ public class Projections : IProjections
     /// <inheritdoc />
     public Task<Try> ReplayEventsForAllTenants(ScopeId scopeId, ProjectionId projectionId) => throw new System.NotImplementedException();
 
-    Task<Try> DropStatesAndResetStreamProcessorsFor(IEnumerable<TenantId> tenants, CancellationToken cancellationToken)
+    async Task<Try> ResetProjectionIfDefinitionHasChanged(ProjectionIdentifier identifier, ProjectionDefinition definition, CancellationToken cancellationToken)
     {
+        var tenantsToResetFor = await GetTenantsWhereDefinitionHasChanged(identifier, definition, cancellationToken);
         
+        var dropping = await DropStatesAndResetStreamProcessorsFor(tenantsToResetFor, definition, cancellationToken);
+        if (!dropping.Success)
+        {
+            return dropping.Exception;
+        }
+
+        var persistence = await PersistDefinitionForAllTenants(definition, cancellationToken);
+        if (!persistence.Success)
+        {
+            return persistence.Exception;
+        }
+        
+        return Try.Succeeded();
     }
 
-    Task<Try> PersistDefinitionForAllTenants(ProjectionDefinition definition, CancellationToken cancellationToken)
+    async Task<IEnumerable<TenantId>> GetTenantsWhereDefinitionHasChanged(ProjectionIdentifier identifier, ProjectionDefinition definition, CancellationToken cancellationToken)
     {
+        var tenantsToResetFor = new List<TenantId>();
         
+        var tenantComparisonResults = await _projectionDefinitionComparer.DiffersFromPersisted(definition, cancellationToken).ConfigureAwait(false);
+        foreach (var (tenant, result) in tenantComparisonResults)
+        {
+            if (result.Succeeded)
+            {
+                continue;
+            }
+            
+            Log.ResettingProjection(_logger, identifier.Scope, identifier.Projection, tenant, result.FailureReason);
+            tenantsToResetFor.Add(tenant);
+        }
+
+        return tenantsToResetFor;
     }
+
+    Task<Try> DropStatesAndResetStreamProcessorsFor(IEnumerable<TenantId> tenants, ProjectionDefinition newDefinition, CancellationToken cancellationToken)
+        => _onAllTenants.TryPerformAsync(async (tenant) =>
+        {
+            if (!tenants.Contains(tenant))
+            {
+                return Try.Succeeded();
+            }
+            
+            var getDefinition = await _getProjectionDefinitions().TryGet(newDefinition.Projection, newDefinition.Scope, cancellationToken).ConfigureAwait(false);
+            if (!getDefinition.Success)
+            {
+                return new CouldNotResetProjectionStates(newDefinition, tenant);
+            }
+            var definition = getDefinition.Result;
+
+            try
+            {
+                await _getStreamProcessorStates().Persist(
+                    new StreamProcessorId(definition.Scope, definition.Projection.Value, StreamId.EventLog),
+                    StreamProcessorState.New,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return new CouldNotResetProjectionStates(newDefinition, tenant);
+            }
+
+            if (!await _getProjectionPersister().TryDrop(definition, cancellationToken).ConfigureAwait(false))
+            {
+                return new CouldNotResetProjectionStates(newDefinition, tenant);
+            }
+
+            return Try.Succeeded();
+        });
+
+    Task<Try> PersistDefinitionForAllTenants(ProjectionDefinition definition, CancellationToken cancellationToken)
+        => _onAllTenants.TryPerformAsync(async (tenant) =>
+        {
+            Log.PersistingProjectionDefinition(_logger, definition.Scope, definition.Projection, tenant);
+            if (!await _getProjectionDefinitions().TryPersist(definition, cancellationToken).ConfigureAwait(false))
+            {
+                return new CouldNotPersistProjectionDefinition(definition, tenant);
+            }
+            return Try.Succeeded();
+        });
 }

--- a/Source/Events.Processing/Projections/Projections.cs
+++ b/Source/Events.Processing/Projections/Projections.cs
@@ -12,6 +12,7 @@ using Dolittle.Runtime.DependencyInversion;
 using Dolittle.Runtime.Events.Processing.Streams;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Lifecycle;
 using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Rudimentary;
@@ -25,6 +26,7 @@ record ProjectionIdentifier(ScopeId Scope, ProjectionId Projection);
 /// <summary>
 /// Represents an implementation of <see cref="IProjections"/>.
 /// </summary>
+[Singleton]
 public class Projections : IProjections
 {
     readonly ConcurrentDictionary<ProjectionIdentifier, ProjectionProcessor> _projections = new();
@@ -64,7 +66,7 @@ public class Projections : IProjections
     }
 
     /// <inheritdoc />
-    public IEnumerable<ProjectionDefinition> All => _projections.Values.Select(_ => _.Definition);
+    public IEnumerable<ProjectionInfo> All => _projections.Values.Select(_ => _.Info);
     
     /// <inheritdoc />
     public Try<IDictionary<TenantId, IStreamProcessorState>> CurrentStateFor(ScopeId scopeId, ProjectionId projectionId) 

--- a/Source/Events.Processing/Projections/ProjectionsProtocol.cs
+++ b/Source/Events.Processing/Projections/ProjectionsProtocol.cs
@@ -1,16 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Linq;
-using Dolittle.Runtime.DependencyInversion;
 using Dolittle.Runtime.Events.Processing.Contracts;
 using Dolittle.Runtime.Protobuf;
 using Dolittle.Services.Contracts;
-using RuntimeProjectionEventSelector = Dolittle.Runtime.Projections.Store.Definition.ProjectionEventSelector;
 using Dolittle.Runtime.Projections.Store.Definition;
-using Dolittle.Runtime.Projections.Store.Definition.Copies;
-using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Services;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
@@ -20,6 +15,17 @@ namespace Dolittle.Runtime.Events.Processing.Projections;
 /// </summary>
 public class ProjectionsProtocol : IProjectionsProtocol
 {
+    readonly IConvertProjectionDefinitions _converter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectionsProtocol"/> class.
+    /// </summary>
+    /// <param name="converter">The converter to use to convert projection definition fields.</param>
+    public ProjectionsProtocol(IConvertProjectionDefinitions converter)
+    {
+        _converter = converter;
+    }
+
     /// <inheritdoc/>
     public ProjectionRegistrationArguments ConvertConnectArguments(ProjectionRegistrationRequest arguments)
         => arguments.HasAlias switch
@@ -86,54 +92,11 @@ public class ProjectionsProtocol : IProjectionsProtocol
         return ConnectArgumentsValidationResult.Ok;
     }
 
-    static ProjectionDefinition ConvertProjectionDefinition(ProjectionRegistrationRequest arguments)
+    ProjectionDefinition ConvertProjectionDefinition(ProjectionRegistrationRequest arguments)
         => new(
             arguments.ProjectionId.ToGuid(),
             arguments.ScopeId.ToGuid(),
-            arguments.Events.Select(eventSelector => eventSelector.SelectorCase switch
-            {
-                Contracts.ProjectionEventSelector.SelectorOneofCase.EventSourceKeySelector => RuntimeProjectionEventSelector.EventSourceId(eventSelector.EventType.Id.ToGuid()),
-                Contracts.ProjectionEventSelector.SelectorOneofCase.PartitionKeySelector => RuntimeProjectionEventSelector.PartitionId(eventSelector.EventType.Id.ToGuid()),
-                Contracts.ProjectionEventSelector.SelectorOneofCase.EventPropertyKeySelector => RuntimeProjectionEventSelector.EventProperty(eventSelector.EventType.Id.ToGuid(), eventSelector.EventPropertyKeySelector.PropertyName),
-                _ => throw new InvalidProjectionEventSelector(eventSelector.SelectorCase)
-            }),
+            _converter.ToRuntimeEventSelectors(arguments.Events),
             arguments.InitialState,
-            ConvertCopySpecification(arguments.Copies)
-        );
-
-    static ProjectionCopySpecification ConvertCopySpecification(ProjectionCopies copies)
-    {
-        var mongoDB = CopyToMongoDBSpecification.Default;
-        if (copies?.MongoDB is { } copyToMongoDb)
-        {
-            mongoDB = new CopyToMongoDBSpecification(true, copyToMongoDb.Collection, ConvertPropertyConversions(copyToMongoDb.Conversions));
-        }
-
-        return new ProjectionCopySpecification(mongoDB);
-    }
-
-    static PropertyConversion[] ConvertPropertyConversions(IEnumerable<ProjectionCopyToMongoDB.Types.PropertyConversion> conversions)
-        => conversions.Select(conversion =>
-            new PropertyConversion(
-                conversion.PropertyName,
-                conversion.ConvertTo switch
-                {
-                    ProjectionCopyToMongoDB.Types.BSONType.None => ConversionBSONType.None,
-                    
-                    ProjectionCopyToMongoDB.Types.BSONType.DateAsDate => ConversionBSONType.DateAsDate,
-                    ProjectionCopyToMongoDB.Types.BSONType.DateAsArray => ConversionBSONType.DateAsArray,
-                    ProjectionCopyToMongoDB.Types.BSONType.DateAsDocument => ConversionBSONType.DateAsDocument,
-                    ProjectionCopyToMongoDB.Types.BSONType.DateAsString => ConversionBSONType.DateAsString,
-                    ProjectionCopyToMongoDB.Types.BSONType.DateAsInt64 => ConversionBSONType.DateAsInt64,
-                    
-                    ProjectionCopyToMongoDB.Types.BSONType.GuidasStandardBinary => ConversionBSONType.GuidAsStandardBinary,
-                    ProjectionCopyToMongoDB.Types.BSONType.GuidasCsharpLegacyBinary => ConversionBSONType.GuidAsCsharpLegacyBinary,
-                    ProjectionCopyToMongoDB.Types.BSONType.GuidasString => ConversionBSONType.GuidAsString,
-                    
-                    _ => throw new InvalidMongoDBFieldConversion(conversion.PropertyName, conversion.ConvertTo),
-                },
-                conversion.RenameTo != default,
-                conversion.RenameTo ?? "",
-                ConvertPropertyConversions(conversion.Children))
-            ).ToArray();
+            _converter.ToRuntimeCopySpecification(arguments.Copies));
 }

--- a/Source/Events.Processing/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing/Projections/ProjectionsService.cs
@@ -162,47 +162,4 @@ public class ProjectionsService : ProjectionsBase
     //        return ex;
     //    }
     //}
-    //async Task ResetIfDefinitionChanged(ProjectionRegistrationArguments arguments, CancellationToken token)
-    //{
-    //    _logger.ComparingProjectionDefintion(arguments);
-    //    var tenantsAndComparisonResult = await _projectionDefinitionComparer.DiffersFromPersisted(arguments.ProjectionDefinition, token).ConfigureAwait(false);
-
-    //    await _onAllTenants.PerformAsync(async tenant =>
-    //    {
-    //        var comparisonResult = tenantsAndComparisonResult[tenant];
-
-    //        if (!comparisonResult.Succeeded)
-    //        {
-    //            _logger.ResettingProjections(arguments, tenant, comparisonResult.FailureReason);
-
-    //            var persistedDefinition = await _getProjectionDefinitions()
-    //                .TryGet(arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, token)
-    //                .ConfigureAwait(false);
-    //            if (!persistedDefinition.Success)
-    //            {
-    //                throw new CouldNotResetProjectionStates(arguments.ProjectionDefinition, tenant);
-    //            }
-
-    //            await ResetStreamProcessorState(persistedDefinition, token).ConfigureAwait(false);
-
-    //            if (!await _getProjectionPersister().TryDrop(persistedDefinition, token).ConfigureAwait(false))
-    //            {
-    //                throw new CouldNotResetProjectionStates(arguments.ProjectionDefinition, tenant);
-    //            }
-    //        }
-
-    //        _logger.PersistingProjectionDefinition(arguments, tenant);
-    //        if (!await _getProjectionDefinitions().TryPersist(arguments.ProjectionDefinition, token).ConfigureAwait(false))
-    //        {
-    //            throw new CouldNotPersistProjectionDefinition(arguments.ProjectionDefinition, tenant);
-    //        }
-    //    }).ConfigureAwait(false);
-    //}
-
-    //Task ResetStreamProcessorState(ProjectionDefinition projection, CancellationToken token)
-    //{
-    //    var processorId = new StreamProcessorId(projection.Scope, new EventProcessorId(projection.Projection), StreamId.EventLog);
-    //    var processorState = StreamProcessorState.New;
-    //    return _getStreamProcessorStates().Persist(processorId, processorState, token);
-    //}
 }

--- a/Source/Events.Processing/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing/Projections/ProjectionsService.cs
@@ -89,7 +89,7 @@ public class ProjectionsService : ProjectionsBase
 
         using var processor = registration.Result;
         var reverseCall = dispatcher.Accept(new ProjectionRegistrationResponse(), cts.Token);
-        var processing = processor.Start(cts.Token);
+        var processing = processor.Start();
 
         // TODO: Take this pattern out to a common extension, we use it all over!!
         var tasks = new[] { reverseCall, processing };
@@ -131,32 +131,6 @@ public class ProjectionsService : ProjectionsBase
     //        if (!cancellationToken.IsCancellationRequested)
     //        {
     //            _logger.ErrorWhileStartingProjection(ex, arguments);
-    //        }
-
-    //        return ex;
-    //    }
-    //}
-
-    //Try<StreamProcessor> TryRegisterProjection(
-    //    ProjectionRegistrationArguments arguments,
-    //    FactoryFor<IEventProcessor> getEventProcessor,
-    //    CancellationToken cancellationToken)
-    //{
-    //    _logger.RegisteringProjection(arguments);
-    //    try
-    //    {
-    //        return _streamProcessors.TryCreateAndRegister(
-    //            arguments.ProjectionDefinition.Scope,
-    //            arguments.ProjectionDefinition.Projection.Value,
-    //            new EventLogStreamDefinition(),
-    //            getEventProcessor,
-    //            cancellationToken);
-    //    }
-    //    catch (Exception ex)
-    //    {
-    //        if (!cancellationToken.IsCancellationRequested)
-    //        {
-    //            _logger.ErrorWhileRegisteringProjection(ex, arguments);
     //        }
 
     //        return ex;

--- a/Source/Events.Processing/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing/Projections/ProjectionsService.cs
@@ -1,15 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Processing.Contracts;
-using Dolittle.Runtime.Events.Processing.Streams;
-using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Execution;
 using Microsoft.Extensions.Logging;
 using Dolittle.Runtime.Protobuf;
@@ -17,11 +13,6 @@ using Dolittle.Runtime.Services;
 using Grpc.Core;
 using Microsoft.Extensions.Hosting;
 using static Dolittle.Runtime.Events.Processing.Contracts.Projections;
-using Dolittle.Runtime.DependencyInversion;
-using Dolittle.Runtime.Projections.Store.State;
-using Dolittle.Runtime.Projections.Store.Definition;
-using Dolittle.Runtime.Tenancy;
-using Dolittle.Runtime.Projections.Store;
 
 namespace Dolittle.Runtime.Events.Processing.Projections;
 
@@ -30,65 +21,36 @@ namespace Dolittle.Runtime.Events.Processing.Projections;
 /// </summary>
 public class ProjectionsService : ProjectionsBase
 {
-    readonly IStreamProcessors _streamProcessors;
-    readonly IExecutionContextManager _executionContextManager;
     readonly IInitiateReverseCallServices _reverseCallServices;
+    readonly IExecutionContextManager _executionContextManager;
     readonly IProjectionsProtocol _protocol;
-    readonly ICompareProjectionDefinitionsForAllTenants _projectionDefinitionComparer;
-    readonly FactoryFor<IProjectionPersister> _getProjectionPersister;
-    readonly FactoryFor<IProjectionStore> _getProjectionStore;
-    readonly FactoryFor<IProjectionDefinitions> _getProjectionDefinitions;
-    readonly FactoryFor<IResilientStreamProcessorStateRepository> _getStreamProcessorStates;
-    readonly IProjectionKeys _projectionKeys;
-    readonly IPerformActionOnAllTenants _onAllTenants;
-    readonly ILoggerFactory _loggerFactory;
-    readonly ILogger _logger;
+    readonly IProjections _projections;
     readonly IHostApplicationLifetime _hostApplicationLifetime;
+    readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectionsService"/> class.
     /// </summary>
-    /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime" />.</param>
-    /// <param name="streamProcessors">The <see cref="IStreamProcessors" />.</param>
-    /// <param name="executionContextManager">The <see cref="IExecutionContextManager" />.</param>
-    /// <param name="reverseCallServices">The <see cref="IInitiateReverseCallServices" />.</param>
-    /// <param name="protocol">The <see cref="IProjectionsProtocol" />.</param>
-    /// <param name="projectionDefinitionComparer">The <see cref="ICompareProjectionDefinitionsForAllTenants" />.</param>
-    /// <param name="getProjectionPersister">The <see cref="FactoryFor{T}" /> for <see cref="IProjectionPersister" />.</param>
-    /// <param name="getProjectionStore">The <see cref="FactoryFor{T}" /> for <see cref="IProjectionStore" />.</param>
-    /// <param name="getProjectionDefinitions">The <see cref="FactoryFor{T}" /> for <see cref="IProjectionDefinitions" />.</param>
-    /// <param name="getStreamProcessorStates">The <see cref="FactoryFor{T}" /> for <see cref="IResilientStreamProcessorStateRepository" />.</param>
-    /// <param name="projectionKeys">The <see cref="IProjectionKeys" />.</param>
-    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+    /// <param name="reverseCallServices">The initiator to use to start reverse call protocols.</param>
+    /// <param name="executionContextManager">The execution context manager to use to set the execution context from incoming requests.</param>
+    /// <param name="protocol">The projections protocol to use to parse and create messages.</param>
+    /// <param name="projections">The <see cref="IProjections"/> to use to register projections.</param>
+    /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/> to use to stop ongoing reverse calls when the application is shutting down.</param>
+    /// <param name="logger">The logger to use for logging.</param>
     public ProjectionsService(
-        IHostApplicationLifetime hostApplicationLifetime,
-        IStreamProcessors streamProcessors,
-        IExecutionContextManager executionContextManager,
         IInitiateReverseCallServices reverseCallServices,
+        IExecutionContextManager executionContextManager,
         IProjectionsProtocol protocol,
-        ICompareProjectionDefinitionsForAllTenants projectionDefinitionComparer,
-        FactoryFor<IProjectionPersister> getProjectionPersister,
-        FactoryFor<IProjectionStore> getProjectionStore,
-        FactoryFor<IProjectionDefinitions> getProjectionDefinitions,
-        FactoryFor<IResilientStreamProcessorStateRepository> getStreamProcessorStates,
-        IProjectionKeys projectionKeys,
-        IPerformActionOnAllTenants onAllTenants,
-        ILoggerFactory loggerFactory)
+        IProjections projections,
+        IHostApplicationLifetime hostApplicationLifetime,
+        ILogger logger)
     {
-        _hostApplicationLifetime = hostApplicationLifetime;
-        _streamProcessors = streamProcessors;
-        _executionContextManager = executionContextManager;
         _reverseCallServices = reverseCallServices;
+        _executionContextManager = executionContextManager;
         _protocol = protocol;
-        _projectionDefinitionComparer = projectionDefinitionComparer;
-        _getProjectionPersister = getProjectionPersister;
-        _getProjectionStore = getProjectionStore;
-        _getProjectionDefinitions = getProjectionDefinitions;
-        _projectionKeys = projectionKeys;
-        _onAllTenants = onAllTenants;
-        _loggerFactory = loggerFactory;
-        _logger = loggerFactory.CreateLogger<ProjectionsService>();
-        _getStreamProcessorStates = getStreamProcessorStates;
+        _projections = projections;
+        _hostApplicationLifetime = hostApplicationLifetime;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -99,71 +61,45 @@ public class ProjectionsService : ProjectionsBase
     {
         Log.ConnectingProjections(_logger);
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(_hostApplicationLifetime.ApplicationStopping, context.CancellationToken);
-        var tryConnect = await _reverseCallServices.Connect(
-            runtimeStream,
-            clientStream,
-            context,
-            _protocol,
-            cts.Token).ConfigureAwait(false);
+        var tryConnect = await _reverseCallServices.Connect(runtimeStream, clientStream, context, _protocol, cts.Token).ConfigureAwait(false);
         if (!tryConnect.Success)
         {
             return;
         }
-        var (dispatcher, arguments) = tryConnect.Result;
-        _logger.ReceivedProjection(arguments);
-        _logger.SettingExecutionContext(arguments.ExecutionContext);
-        _executionContextManager.CurrentFor(arguments.ExecutionContext);
+        
+        var (dispatcher, (executionContext, projectionDefinition)) = tryConnect.Result;
+        Log.ReceivedProjectionArguments(_logger, projectionDefinition.Scope, projectionDefinition.Projection);
+        _logger.SettingExecutionContext(executionContext);
+        _executionContextManager.CurrentFor(executionContext);
 
-        var registration = TryRegisterProjection(
-            arguments,
-            () => new EventProcessor(
-                arguments.ProjectionDefinition,
-                _getProjectionPersister(),
-                _getProjectionStore(),
-                _projectionKeys,
-                new Projection(
-                    arguments.ProjectionDefinition,
-                    dispatcher),
-                _loggerFactory.CreateLogger<EventProcessor>()),
-            cts.Token);
+        
+        var projection = new Projection(projectionDefinition, dispatcher);
+        var registration = await _projections.Register(projection, cts.Token);
 
         if (!registration.Success)
         {
-            if (registration.Exception is StreamProcessorAlreadyRegistered)
+            await dispatcher.Reject(new ProjectionRegistrationResponse
             {
-                _logger.ProjectionAlreadyRegistered(arguments);
-                var failure = new Failure(
+                Failure = new Failure(
                     ProjectionFailures.FailedToRegisterProjection,
-                    $"Failed to register Projection: {arguments.ProjectionDefinition.Projection.Value}. Event Processor already registered with the same id.");
-                await dispatcher.Reject(new ProjectionRegistrationResponse { Failure = failure }, cts.Token).ConfigureAwait(false);
-                return;
-            }
-            var exception = registration.Exception;
-            ExceptionDispatchInfo.Capture(exception).Throw();
+                    $"Failed to register Projection {projection.Definition.Projection}. {registration.Exception.Message}")
+            }, cts.Token).ConfigureAwait(false);
+            return;
         }
 
-        using var eventProcessorStreamProcessor = registration.Result;
+        using var processor = registration.Result;
+        var reverseCall = dispatcher.Accept(new ProjectionRegistrationResponse(), cts.Token);
+        var processing = processor.Start(cts.Token);
 
-        var tryStart = await TryStartProjection(
-            dispatcher,
-            arguments,
-            eventProcessorStreamProcessor,
-            cts.Token).ConfigureAwait(false);
-        if (!tryStart.Success)
-        {
-            cts.Cancel();
-            var exception = tryStart.Exception;
-            ExceptionDispatchInfo.Capture(exception).Throw();
-        }
-
-        var tasks = tryStart.Result;
+        // TODO: Take this pattern out to a common extension, we use it all over!!
+        var tasks = new[] { reverseCall, processing };
         try
         {
             await Task.WhenAny(tasks).ConfigureAwait(false);
 
             if (tasks.TryGetFirstInnerMostException(out var ex))
             {
-                _logger.ErrorWhileRunningProjection(ex, arguments);
+                Log.ErrorWhileRunningProjection(_logger, projection.Definition.Scope, projection.Definition.Projection, ex);
                 ExceptionDispatchInfo.Capture(ex).Throw();
             }
         }
@@ -171,102 +107,102 @@ public class ProjectionsService : ProjectionsBase
         {
             cts.Cancel();
             await Task.WhenAll(tasks).ConfigureAwait(false);
-            _logger.ProjectionDisconnected(arguments);
+            Log.ProjectionDisconnected(_logger, projection.Definition.Scope, projection.Definition.Projection);
         }
     }
 
-    async Task<Try<IEnumerable<Task>>> TryStartProjection(
-        IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> dispatcher,
-        ProjectionRegistrationArguments arguments,
-        StreamProcessor eventProcessorStreamProcessor,
-        CancellationToken cancellationToken)
-    {
-        _logger.StartingProjection(arguments);
-        try
-        {
-            var runningDispatcher = dispatcher.Accept(new ProjectionRegistrationResponse(), cancellationToken);
+    //async Task<Try<IEnumerable<Task>>> TryStartProjection(
+    //    IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> dispatcher,
+    //    ProjectionRegistrationArguments arguments,
+    //    StreamProcessor eventProcessorStreamProcessor,
+    //    CancellationToken cancellationToken)
+    //{
+    //    _logger.StartingProjection(arguments);
+    //    try
+    //    {
+    //        var runningDispatcher = dispatcher.Accept(new ProjectionRegistrationResponse(), cancellationToken);
 
-            await ResetIfDefinitionChanged(arguments, cancellationToken).ConfigureAwait(false);
-            await eventProcessorStreamProcessor.Initialize().ConfigureAwait(false);
-            return new[] { eventProcessorStreamProcessor.Start(), runningDispatcher };
-        }
-        catch (Exception ex)
-        {
-            if (!cancellationToken.IsCancellationRequested)
-            {
-                _logger.ErrorWhileStartingProjection(ex, arguments);
-            }
+    //        await ResetIfDefinitionChanged(arguments, cancellationToken).ConfigureAwait(false);
+    //        await eventProcessorStreamProcessor.Initialize().ConfigureAwait(false);
+    //        return new[] { eventProcessorStreamProcessor.Start(), runningDispatcher };
+    //    }
+    //    catch (Exception ex)
+    //    {
+    //        if (!cancellationToken.IsCancellationRequested)
+    //        {
+    //            _logger.ErrorWhileStartingProjection(ex, arguments);
+    //        }
 
-            return ex;
-        }
-    }
+    //        return ex;
+    //    }
+    //}
 
-    Try<StreamProcessor> TryRegisterProjection(
-        ProjectionRegistrationArguments arguments,
-        FactoryFor<IEventProcessor> getEventProcessor,
-        CancellationToken cancellationToken)
-    {
-        _logger.RegisteringProjection(arguments);
-        try
-        {
-            return _streamProcessors.TryCreateAndRegister(
-                arguments.ProjectionDefinition.Scope,
-                arguments.ProjectionDefinition.Projection.Value,
-                new EventLogStreamDefinition(),
-                getEventProcessor,
-                cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            if (!cancellationToken.IsCancellationRequested)
-            {
-                _logger.ErrorWhileRegisteringProjection(ex, arguments);
-            }
+    //Try<StreamProcessor> TryRegisterProjection(
+    //    ProjectionRegistrationArguments arguments,
+    //    FactoryFor<IEventProcessor> getEventProcessor,
+    //    CancellationToken cancellationToken)
+    //{
+    //    _logger.RegisteringProjection(arguments);
+    //    try
+    //    {
+    //        return _streamProcessors.TryCreateAndRegister(
+    //            arguments.ProjectionDefinition.Scope,
+    //            arguments.ProjectionDefinition.Projection.Value,
+    //            new EventLogStreamDefinition(),
+    //            getEventProcessor,
+    //            cancellationToken);
+    //    }
+    //    catch (Exception ex)
+    //    {
+    //        if (!cancellationToken.IsCancellationRequested)
+    //        {
+    //            _logger.ErrorWhileRegisteringProjection(ex, arguments);
+    //        }
 
-            return ex;
-        }
-    }
-    async Task ResetIfDefinitionChanged(ProjectionRegistrationArguments arguments, CancellationToken token)
-    {
-        _logger.ComparingProjectionDefintion(arguments);
-        var tenantsAndComparisonResult = await _projectionDefinitionComparer.DiffersFromPersisted(arguments.ProjectionDefinition, token).ConfigureAwait(false);
+    //        return ex;
+    //    }
+    //}
+    //async Task ResetIfDefinitionChanged(ProjectionRegistrationArguments arguments, CancellationToken token)
+    //{
+    //    _logger.ComparingProjectionDefintion(arguments);
+    //    var tenantsAndComparisonResult = await _projectionDefinitionComparer.DiffersFromPersisted(arguments.ProjectionDefinition, token).ConfigureAwait(false);
 
-        await _onAllTenants.PerformAsync(async tenant =>
-        {
-            var comparisonResult = tenantsAndComparisonResult[tenant];
+    //    await _onAllTenants.PerformAsync(async tenant =>
+    //    {
+    //        var comparisonResult = tenantsAndComparisonResult[tenant];
 
-            if (!comparisonResult.Succeeded)
-            {
-                _logger.ResettingProjections(arguments, tenant, comparisonResult.FailureReason);
+    //        if (!comparisonResult.Succeeded)
+    //        {
+    //            _logger.ResettingProjections(arguments, tenant, comparisonResult.FailureReason);
 
-                var persistedDefinition = await _getProjectionDefinitions()
-                    .TryGet(arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, token)
-                    .ConfigureAwait(false);
-                if (!persistedDefinition.Success)
-                {
-                    throw new CouldNotResetProjectionStates(arguments.ProjectionDefinition, tenant);
-                }
+    //            var persistedDefinition = await _getProjectionDefinitions()
+    //                .TryGet(arguments.ProjectionDefinition.Projection, arguments.ProjectionDefinition.Scope, token)
+    //                .ConfigureAwait(false);
+    //            if (!persistedDefinition.Success)
+    //            {
+    //                throw new CouldNotResetProjectionStates(arguments.ProjectionDefinition, tenant);
+    //            }
 
-                await ResetStreamProcessorState(persistedDefinition, token).ConfigureAwait(false);
+    //            await ResetStreamProcessorState(persistedDefinition, token).ConfigureAwait(false);
 
-                if (!await _getProjectionPersister().TryDrop(persistedDefinition, token).ConfigureAwait(false))
-                {
-                    throw new CouldNotResetProjectionStates(arguments.ProjectionDefinition, tenant);
-                }
-            }
+    //            if (!await _getProjectionPersister().TryDrop(persistedDefinition, token).ConfigureAwait(false))
+    //            {
+    //                throw new CouldNotResetProjectionStates(arguments.ProjectionDefinition, tenant);
+    //            }
+    //        }
 
-            _logger.PersistingProjectionDefinition(arguments, tenant);
-            if (!await _getProjectionDefinitions().TryPersist(arguments.ProjectionDefinition, token).ConfigureAwait(false))
-            {
-                throw new CouldNotPersistProjectionDefinition(arguments.ProjectionDefinition, tenant);
-            }
-        }).ConfigureAwait(false);
-    }
+    //        _logger.PersistingProjectionDefinition(arguments, tenant);
+    //        if (!await _getProjectionDefinitions().TryPersist(arguments.ProjectionDefinition, token).ConfigureAwait(false))
+    //        {
+    //            throw new CouldNotPersistProjectionDefinition(arguments.ProjectionDefinition, tenant);
+    //        }
+    //    }).ConfigureAwait(false);
+    //}
 
-    Task ResetStreamProcessorState(ProjectionDefinition projection, CancellationToken token)
-    {
-        var processorId = new StreamProcessorId(projection.Scope, new EventProcessorId(projection.Projection), StreamId.EventLog);
-        var processorState = StreamProcessorState.New;
-        return _getStreamProcessorStates().Persist(processorId, processorState, token);
-    }
+    //Task ResetStreamProcessorState(ProjectionDefinition projection, CancellationToken token)
+    //{
+    //    var processorId = new StreamProcessorId(projection.Scope, new EventProcessorId(projection.Projection), StreamId.EventLog);
+    //    var processorState = StreamProcessorState.New;
+    //    return _getStreamProcessorStates().Persist(processorId, processorState, token);
+    //}
 }

--- a/Source/Events.Processing/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing/Projections/ProjectionsService.cs
@@ -78,6 +78,7 @@ public class ProjectionsService : ProjectionsBase
 
         if (!registration.Success)
         {
+            Log.ErrorWhileRegisteringProjection(_logger, projectionDefinition.Scope, projectionDefinition.Projection, registration.Exception);
             await dispatcher.Reject(new ProjectionRegistrationResponse
             {
                 Failure = new Failure(

--- a/Source/Events.Processing/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing/Projections/ProjectionsService.cs
@@ -110,30 +110,4 @@ public class ProjectionsService : ProjectionsBase
             Log.ProjectionDisconnected(_logger, projection.Definition.Scope, projection.Definition.Projection);
         }
     }
-
-    //async Task<Try<IEnumerable<Task>>> TryStartProjection(
-    //    IReverseCallDispatcher<ProjectionClientToRuntimeMessage, ProjectionRuntimeToClientMessage, ProjectionRegistrationRequest, ProjectionRegistrationResponse, ProjectionRequest, ProjectionResponse> dispatcher,
-    //    ProjectionRegistrationArguments arguments,
-    //    StreamProcessor eventProcessorStreamProcessor,
-    //    CancellationToken cancellationToken)
-    //{
-    //    _logger.StartingProjection(arguments);
-    //    try
-    //    {
-    //        var runningDispatcher = dispatcher.Accept(new ProjectionRegistrationResponse(), cancellationToken);
-
-    //        await ResetIfDefinitionChanged(arguments, cancellationToken).ConfigureAwait(false);
-    //        await eventProcessorStreamProcessor.Initialize().ConfigureAwait(false);
-    //        return new[] { eventProcessorStreamProcessor.Start(), runningDispatcher };
-    //    }
-    //    catch (Exception ex)
-    //    {
-    //        if (!cancellationToken.IsCancellationRequested)
-    //        {
-    //            _logger.ErrorWhileStartingProjection(ex, arguments);
-    //        }
-
-    //        return ex;
-    //    }
-    //}
 }

--- a/Source/Events.Processing/Streams/AbstractScopedStreamProcessor.cs
+++ b/Source/Events.Processing/Streams/AbstractScopedStreamProcessor.cs
@@ -28,6 +28,7 @@ public abstract class AbstractScopedStreamProcessor
     readonly object _setPositionLock = new();
     CancellationTokenSource _resetStreamProcessor;
     TaskCompletionSource<Try<StreamPosition>> _resetStreamProcessorCompletionSource;
+    Func<TenantId, CancellationToken, Task<Try>> _resetStreamProcessorAction;
     IStreamProcessorState _currentState;
     bool _started;
     StreamPosition _newPosition;
@@ -105,8 +106,9 @@ public abstract class AbstractScopedStreamProcessor
     /// from a <see cref="StreamPosition"/> that is higher than the current <see cref="StreamPosition"/>.
     /// </remarks>
     /// <param name="position">The <see cref="StreamPosition"/> to start processing events from.</param>
+    /// <param name="action">The action to perform before setting the position.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns a <see cref="Try{TResult}"/> with a <see cref="StreamPosition"/>.</returns>
-    public Task<Try<StreamPosition>> ReprocessEventsFrom(StreamPosition position)
+    public Task<Try<StreamPosition>> PerformActionAndReprocessEventsFrom(StreamPosition position, Func<TenantId, CancellationToken, Task<Try>> action)
     {
         try
         {
@@ -122,6 +124,7 @@ public abstract class AbstractScopedStreamProcessor
                     return Task.FromResult<Try<StreamPosition>>(new AlreadySettingNewStreamProcessorPosition(Identifier));
                 }
                 _newPosition = position;
+                _resetStreamProcessorAction = action;
                 _resetStreamProcessorCompletionSource = tcs;
             }
             
@@ -277,11 +280,24 @@ public abstract class AbstractScopedStreamProcessor
                         }
                         else
                         {
-                            Log.ScopedStreamProcessorSetToPosition(Logger, Identifier, _newPosition);
-                            _currentState = await SetNewStateWithPosition(_currentState, _newPosition).ConfigureAwait(false);
-                            _resetStreamProcessorCompletionSource.SetResult(_currentState.Position);
+                            // TODO: LOG
+                            var result = await _resetStreamProcessorAction(_tenantId, cancellationToken).ConfigureAwait(false);
+                            if (result.Success)
+                            {
+                                Log.ScopedStreamProcessorSetToPosition(Logger, Identifier, _newPosition);
+                                _currentState = await SetNewStateWithPosition(_currentState, _newPosition).ConfigureAwait(false);
+                                _resetStreamProcessorCompletionSource.SetResult(_currentState.Position);
+                            }
+                            else
+                            {
+                                // TODO: LOG
+                                _resetStreamProcessorCompletionSource.SetResult(Try<StreamPosition>.Failed(result.Exception));
+                            }
+                            
                         }
+
                         _resetStreamProcessorCompletionSource = default;
+                        _resetStreamProcessorAction = default;
                     }
                     try
                     {

--- a/Source/Events.Processing/Streams/StreamProcessor.cs
+++ b/Source/Events.Processing/Streams/StreamProcessor.cs
@@ -149,18 +149,36 @@ public class StreamProcessor : IDisposable
     /// <param name="position">The <see cref="StreamPosition" />.</param>
     /// <returns>The <see cref="Task"/> that, when resolved, returns a <see cref="Try{TResult}"/> with the <see cref="StreamPosition"/> it was set to.</returns>
     public Task<Try<StreamPosition>> SetToPosition(TenantId tenant, StreamPosition position)
-        => _streamProcessors.TryGetValue(tenant, out var streamProcessor)
-            ? streamProcessor.ReprocessEventsFrom(position)
-            : Task.FromResult<Try<StreamPosition>>(new StreamProcessorNotRegisteredForTenant(_identifier, tenant));
+        => PerformActionAndSetToPosition(tenant, position, (_, _) => Task.FromResult(Try.Succeeded()));
 
     /// <summary>
     /// Sets the position of the stream processors for all tenant to be the initial <see cref="StreamPosition"/>.
     /// </summary>
     /// <returns>The <see cref="Task"/> that, when resolved, returns a <see cref="Dictionary{TKey,TValue}"/> with a <see cref="Try{TResult}"/> with the <see cref="StreamPosition"/> it was set to for each <see cref="TenantId"/>.</returns>
-    public async Task<IDictionary<TenantId, Try<StreamPosition>>> SetToInitialPositionForAllTenants()
+    public Task<IDictionary<TenantId, Try<StreamPosition>>> SetToInitialPositionForAllTenants()
+        => PerformActionAndSetToInitialPositionForAllTenants((_, _) => Task.FromResult(Try.Succeeded()));
+
+    /// <summary>
+    /// Performs an action, then sets the position of the stream processor for a tenant.
+    /// </summary>
+    /// <param name="tenant">The <see cref="TenantId"/>.</param>
+    /// <param name="position">The <see cref="StreamPosition" />.</param>
+    /// <param name="action">The action to perform before setting the position.</param>
+    /// <returns>The <see cref="Task"/> that, when resolved, returns a <see cref="Try{TResult}"/> with the <see cref="StreamPosition"/> it was set to.</returns>
+    public Task<Try<StreamPosition>> PerformActionAndSetToPosition(TenantId tenant, StreamPosition position, Func<TenantId, CancellationToken, Task<Try>> action)
+        => _streamProcessors.TryGetValue(tenant, out var streamProcessor)
+            ? streamProcessor.PerformActionAndReprocessEventsFrom(position, action)
+            : Task.FromResult<Try<StreamPosition>>(new StreamProcessorNotRegisteredForTenant(_identifier, tenant));
+    
+    /// <summary>
+    /// Performs an action, then sets the position of the stream processors for all tenant to be the initial <see cref="StreamPosition"/>.
+    /// </summary>
+    /// <param name="action">The action to perform before setting the position.</param>
+    /// <returns>The <see cref="Task"/> that, when resolved, returns a <see cref="Dictionary{TKey,TValue}"/> with a <see cref="Try{TResult}"/> with the <see cref="StreamPosition"/> it was set to for each <see cref="TenantId"/>.</returns>
+    public async Task<IDictionary<TenantId, Try<StreamPosition>>> PerformActionAndSetToInitialPositionForAllTenants(Func<TenantId, CancellationToken, Task<Try>> action)
     {
         var tasks = _streamProcessors
-            .ToDictionary(_ => _.Key, _ => _.Value.ReprocessEventsFrom(StreamPosition.Start));
+            .ToDictionary(_ => _.Key, _ => _.Value.PerformActionAndReprocessEventsFrom(StreamPosition.Start, action));
 
         var result = new Dictionary<TenantId, Try<StreamPosition>>();
 

--- a/Source/Events.Processing/Streams/StreamProcessor.cs
+++ b/Source/Events.Processing/Streams/StreamProcessor.cs
@@ -72,7 +72,7 @@ public class StreamProcessor : IDisposable
     /// <summary>
     /// Gets all current <see cref="IStreamProcessorState"/> states. 
     /// </summary>
-    /// <returns>The  <see cref="IStreamProcessorState"/> per <see cref="TenantId"/>.</returns>
+    /// <returns>The <see cref="IStreamProcessorState"/> per <see cref="TenantId"/>.</returns>
     public Try<IDictionary<TenantId, IStreamProcessorState>> GetCurrentStates()
         => _initialized
             ? _streamProcessors.ToDictionary(_ => _.Key, _ => _.Value.GetCurrentState())
@@ -81,7 +81,7 @@ public class StreamProcessor : IDisposable
     /// <summary>
     /// Initializes the stream processor.
     /// </summary>
-    /// <returns>A <see cref="Task" />that represents the asynchronous operation.</returns>
+    /// <returns>A <see cref="Task" /> that represents the asynchronous operation.</returns>
     public async Task Initialize()
     {
         Log.InitializingStreamProcessor(_logger, _identifier);

--- a/Source/Platform/Handshake/VerifyContractsCompatibility.cs
+++ b/Source/Platform/Handshake/VerifyContractsCompatibility.cs
@@ -27,11 +27,6 @@ public class VerifyContractsCompatibility : IVerifyContractsCompatibility
         {
             return ContractsCompatibility.RuntimeTooOld;
         }
-        
-        if (headContractsVersion.Minor < runtimeContractsVersion.Minor)
-        {
-            return ContractsCompatibility.ClientTooOld;
-        }
 
         return ContractsCompatibility.Compatible;
     }

--- a/Source/Services/Endpoint.cs
+++ b/Source/Services/Endpoint.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Dolittle.Runtime.Collections;
+using Grpc.Reflection;
+using Grpc.Reflection.V1Alpha;
 using Microsoft.Extensions.Logging;
 using grpc = Grpc.Core;
 
@@ -73,6 +76,9 @@ public class Endpoint : IEndpoint
                 _logger.ExposingService(_.Descriptor.FullName);
                 _server.Services.Add(_.ServerDefinition);
             });
+
+            var reflectionService = new ReflectionServiceImpl(services.Select(_ => _.Descriptor));
+            _server.Services.Add(ServerReflection.BindService(reflectionService));
 
             _server.Start();
         }

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Dolittle.Runtime.Contracts" Version="$(ContractsVersion)" />
     <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
     <PackageReference Include="Grpc" Version="$(GrpcVersion)" />
+    <PackageReference Include="Grpc.Reflection" Version="$(GrpcVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/Source/Tenancy/IPerformActionOnAllTenants.cs
+++ b/Source/Tenancy/IPerformActionOnAllTenants.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Execution;
+using Dolittle.Runtime.Rudimentary;
 
 namespace Dolittle.Runtime.Tenancy;
 
@@ -14,24 +15,36 @@ namespace Dolittle.Runtime.Tenancy;
 public interface IPerformActionOnAllTenants
 {
     /// <summary>
-    /// Perform an <see cref ="Action" /> for <see cref="ITenants.All" />.
+    /// Perform an action on all tenants.
     /// </summary>
-    /// <param name="action">The <see cref="Action" />.</param>
+    /// <param name="action">The <see cref="Action{TenantId}">action</see> to perform.</param>
     void Perform(Action<TenantId> action);
 
     /// <summary>
-    /// Performs a <see cref="Task" /> for <see cref="ITenants.All" /> sequentially meaning that it will for each tenant
-    /// perform the <see cref="Task" /> and then wait for that to finish before performing for the next Tenant.
+    /// Try to perform an action on all tenants, stopping on the first failure.
     /// </summary>
-    /// <param name="action">The <see cref="Func{T1, TReturn}" /> that returns the <see cref="Task" /> to perform on the <see cref="TenantId" />.</param>
-    /// <returns>The <see cref="Task" /> representing the asynchronous operation.</returns>
-    Task PerformAsync(Func<TenantId, Task> action);
+    /// <param name="action">The <see cref="Func{TenantId, Try}">action</see> to perform.</param>
+    /// <returns>The first <see cref="Try"/> that failed, or success if all succeeded.</returns>
+    Try TryPerform(Func<TenantId, Try> action);
 
     /// <summary>
-    /// Performs a <see cref="Task" /> for <see cref="ITenants.All" /> in parallel meaning that it will
-    /// perform the <see cref="Task" /> for all Tenants at the same time.
+    /// Perform an asynchronous action on all tenants in sequence by waiting for the <see cref="Task"/> for each tenant to complete.
     /// </summary>
-    /// <param name="action">The <see cref="Func{T1, TReturn}" /> that returns the <see cref="Task" /> to perform on the <see cref="TenantId" />.</param>
-    /// <returns>The <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <param name="action">The <see cref="Func{TenantId, Task}">action</see> to perform.</param>
+    /// <returns>A <see cref="Task"/> that is resolved when the action is performed on all tenants.</returns>
+    Task PerformAsync(Func<TenantId, Task> action);
+    
+    /// <summary>
+    /// Try to perform an asynchronous action on all tenants in sequence by waiting for the <see cref="Task{Try}"/> for each tenant to complete, stopping on the first failure.
+    /// </summary>
+    /// <param name="action">The <see cref="Func{TenantId, Task}">action</see> to perform.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the first <see cref="Try"/> that failed, or success if all succeeded.</returns>
+    Task<Try> TryPerformAsync(Func<TenantId, Task<Try>> action);
+
+    /// <summary>
+    /// Perform an asynchronous action on all tenants in parallel.
+    /// </summary>
+    /// <param name="action">The <see cref="Func{TenantId, Task}">action</see> to perform.</param>
+    /// <returns>A <see cref="Task"/> that is resolved when the action is performed on all tenants.</returns>
     Task PerformInParallel(Func<TenantId, Task> action);
 }

--- a/Specifications/Events.Processing/EventHandlers/for_EventHandler/when_disposing/and_it_fails_registering_event_processor.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventHandler/when_disposing/and_it_fails_registering_event_processor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using Dolittle.Runtime.DependencyInversion;
 using Dolittle.Runtime.Events.Processing.Contracts;
-using Dolittle.Runtime.Events.Processing.Filters;
 using Dolittle.Runtime.Events.Processing.Streams;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/when_filtering_public_event/and_filtered_successfully.cs
+++ b/Specifications/Events.Processing/Filters/EventHorizon/for_PublicFilterProcessor/when_filtering_public_event/and_filtered_successfully.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Processing.Contracts;
 using Dolittle.Runtime.Events.Store.Streams;
-using Dolittle.Runtime.Protobuf;
 using Machine.Specifications;
 
 namespace Dolittle.Runtime.Events.Processing.Filters.EventHorizon.for_PublicFilterProcessor.when_filtering_public_event;

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_included.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_included.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store;

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_not_included.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_not_included.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store;

--- a/Specifications/Events.Processing/Filters/for_FilterValidators/when_validating/and_getting_the_stream_processor_state_fails.cs
+++ b/Specifications/Events.Processing/Filters/for_FilterValidators/when_validating/and_getting_the_stream_processor_state_fails.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Rudimentary;
-using Dolittle.Runtime.Events.Processing.Streams;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Filters/for_FilterValidators/when_validating/and_there_is_no_persisted_filter_definition.cs
+++ b/Specifications/Events.Processing/Filters/for_FilterValidators/when_validating/and_there_is_no_persisted_filter_definition.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Events.Store.Streams.Filters;

--- a/Specifications/Events.Processing/Filters/for_FilterValidators/when_validating/and_there_is_no_persisted_stream_processor_state.cs
+++ b/Specifications/Events.Processing/Filters/for_FilterValidators/when_validating/and_there_is_no_persisted_stream_processor_state.cs
@@ -3,10 +3,8 @@
 
 using System.Threading.Tasks;
 using Dolittle.Runtime.Rudimentary;
-using Dolittle.Runtime.Events.Processing.Streams;
 using Machine.Specifications;
 using Dolittle.Runtime.Events.Store.Streams;
-using System;
 
 namespace Dolittle.Runtime.Events.Processing.Filters.for_FilterValidators.when_validating;
 

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_filter_has_not_processed_any_events.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_filter_has_not_processed_any_events.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading;
-using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
-using Dolittle.Runtime.Events.Processing.Streams;
 using Machine.Specifications;
-using Dolittle.Runtime.Events.Store.Streams;
 
 namespace Dolittle.Runtime.Events.Processing.Filters.for_ValidateFilterByComparingStreams.when_validating;
 

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_old_and_new_filter_includes_the_same_events_in_different_partitions.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_old_and_new_filter_includes_the_same_events_in_different_partitions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_definition_is_not_persisted.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_definition_is_not_persisted.cs
@@ -7,8 +7,6 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_definition_is_persisted.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_definition_is_persisted.cs
@@ -7,8 +7,6 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_initial_state_differs.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_initial_state_differs.cs
@@ -7,8 +7,6 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_to_collection_has_changed.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_mongodb_copy_to_collection_has_changed.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_should_copy_to_mongodb_has_changed.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_should_copy_to_mongodb_has_changed.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_event_selector_expression.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_event_selector_expression.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_event_selector_type.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_event_selector_type.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_number_of_event_types.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_number_of_event_types.cs
@@ -7,8 +7,6 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_set_of_event_types.cs
+++ b/Specifications/Events.Processing/Projections/for_CompareProjectionDefinitionsForAllTenants/when_there_is_one_tenant/and_there_is_a_different_set_of_event_types.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Artifacts;
-using Dolittle.Runtime.Projections.Store;
 using Dolittle.Runtime.Projections.Store.Definition;
 using Dolittle.Runtime.Projections.Store.Definition.Copies.MongoDB;
 using Dolittle.Runtime.Rudimentary;

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/content_structure.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/content_structure.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Dolittle.Runtime.Events.Store;
-using Machine.Specifications;
 
 namespace Dolittle.Runtime.Events.Processing.Projections.for_ProjectionKeyPropertyExtractor;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/given/all_dependencies.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using Dolittle.Runtime.Serialization.Json;
-using Dolittle.Runtime.Types;
 using Machine.Specifications;
-using Moq;
 
 namespace Dolittle.Runtime.Events.Processing.Projections.for_ProjectionKeyPropertyExtractor.given;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_camel_cased.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_camel_cased.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_lower_cased.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_lower_cased.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_pascal_cased.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_pascal_cased.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_upper_cased.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/and_property_is_upper_cased.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/of_type_Guid.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/of_type_Guid.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/of_type_int.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/of_type_int.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/of_type_string.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_extracting_from_existing_property/of_type_string.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_property_does_not_exist.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeyPropertyExtractor/when_property_does_not_exist.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Projections.Store;
 using Machine.Specifications;
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_event_source.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_event_source.cs
@@ -1,4 +1,3 @@
-using System;
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_partition.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_partition.cs
@@ -1,4 +1,3 @@
-using System;
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 

--- a/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_property.cs
+++ b/Specifications/Events.Processing/Projections/for_ProjectionKeys/when_type_is_property.cs
@@ -1,4 +1,3 @@
-using System;
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/given/an_instance_of_failing_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/given/an_instance_of_failing_partitions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Machine.Specifications;
-using Moq;
 
 namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_FailingPartitions.given;
 

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_first_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_first_event.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_everything_is_ok.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
 namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.a_stream_that_has_events_in_two_partitions;
 
 public class and_everything_is_ok : all_dependencies
@@ -42,7 +43,7 @@ public class and_everything_is_ok : all_dependencies
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
-
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(2));
     It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_everything_is_ok.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
@@ -35,7 +36,7 @@ public class and_everything_is_ok : all_dependencies
             .Returns(Task.FromResult<Try<StreamEvent>>(first_event));
     };
 
-    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
     It should_process_four_times = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_performing_action_fails.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_performing_action_fails.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.a_stream_that_has_events_in_two_partitions;
+
+public class and_performing_action_fails : all_dependencies
+{
+    const string reason = "some reason";
+    static PartitionId first_partition_id;
+    static PartitionId second_partition_id;
+    static StreamEvent first_event;
+    static StreamEvent second_event;
+
+    Establish context = () =>
+    {
+        first_partition_id = "first partitionid";
+        second_partition_id = "il secuondo partitionada";
+        first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
+        second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
+        event_processor
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<IProcessingResult>(new SuccessfulProcessing()));
+        setup_event_stream(first_event, second_event);
+        events_fetcher
+            .Setup(_ => _.FetchInPartition(first_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<Try<StreamEvent>>(first_event));
+
+        action_to_perform_before_reprocessing
+            .Setup(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Try.Failed(new Exception()));
+    };
+
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+        
+    It should_process_two_times = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_not_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(2));
+    It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
+}

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_setting_position_after_a_failing_partition.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_setting_position_after_a_failing_partition.cs
@@ -38,7 +38,7 @@ public class and_processing_fails_at_second_event_in_both_partitions : all_depen
             .Returns(Task.FromResult<Try<StreamEvent>>(first_event));
     };
 
-    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 1, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 1, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
     It should_process_first_event_once = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
     It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_setting_position_after_a_failing_partition.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_setting_position_after_a_failing_partition.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
 namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.a_stream_that_has_events_in_two_partitions;
 
 public class and_processing_fails_at_second_event_in_both_partitions : all_dependencies
@@ -43,11 +45,11 @@ public class and_processing_fails_at_second_event_in_both_partitions : all_depen
     It should_process_first_event_once = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
     It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
-
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(2));
     It should_have_persisted_state_with_one_failing_partitions = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);
     It should_have_persisted_state_with_correct_failing_partition = () => current_stream_processor_state.FailingPartitions.ContainsKey(first_partition_id).ShouldBeTrue();
     It should_have_persisted_correct_position_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[first_partition_id].Position.ShouldEqual(new StreamPosition(0));
     It should_have_persisted_correct_retry_time_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[first_partition_id].RetryTime.ShouldEqual(DateTimeOffset.MaxValue);
     It should_have_persisted_correct_reason_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[first_partition_id].Reason.ShouldEqual(reason);
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
 namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.and_stream_has_only_one_partition;
 
 public class and_event_processing_failed_at_second_event : all_dependencies
@@ -36,12 +38,11 @@ public class and_event_processing_failed_at_second_event : all_dependencies
     It should_process_four_events = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-
     It should_have_current_position_equal_2 = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(2));
     It should_have_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);
     It should_have_the_correct_failing_partition = () => current_stream_processor_state.FailingPartitions.ContainsKey(partition_id).ShouldBeTrue();
     It should_have_the_correct_position_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[partition_id].Position.ShouldEqual(new StreamPosition(1));
     It should_have_the_correct_reason_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[partition_id].Reason.ShouldEqual(reason);
     It should_have_the_correct_retry_time_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[partition_id].RetryTime.ShouldEqual(DateTimeOffset.MaxValue);
-        
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
@@ -31,7 +31,7 @@ public class and_event_processing_failed_at_second_event : all_dependencies
             new StreamEvent(second_event, 1, Guid.NewGuid(), partition_id, true));
     };
 
-    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
     It should_process_four_events = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_everything_is_ok.cs
@@ -26,7 +26,7 @@ public class and_everything_is_ok : all_dependencies
         setup_event_stream(event_with_partition);
     };
 
-    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
     It should_process_two_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_everything_is_ok.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
 namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.and_stream_has_only_one_partition;
 
 public class and_everything_is_ok : all_dependencies
@@ -30,8 +32,7 @@ public class and_everything_is_ok : all_dependencies
 
     It should_process_two_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(1));
     It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
-
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_performing_action_fails.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_performing_action_fails.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.and_stream_has_only_one_partition;
+
+public class and_performing_action_fails : all_dependencies
+{
+    const string reason = "some reason";
+    static readonly PartitionId partition_id = "paritition id";
+    static readonly CommittedEvent first_event = committed_events.single();
+
+    Establish context = () =>
+    {
+        var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, true);
+        event_processor
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<IProcessingResult>(new SuccessfulProcessing()));
+        setup_event_stream(event_with_partition);
+
+        action_to_perform_before_reprocessing
+            .Setup(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Try.Failed(new Exception()));
+    };
+
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+
+    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_have_current_position_equal_one = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(1));
+    It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
+}

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_setting_position_to_failing_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_setting_position_to_failing_event.cs
@@ -30,7 +30,7 @@ public class and_setting_position_to_failing_event : all_dependencies
             .Returns(Task.FromResult(Try<StreamEvent>.Succeeded(new StreamEvent(first_event, 0, Guid.NewGuid(), partition_id, true))));
     };
 
-    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
 

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_setting_position_to_failing_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_setting_position_to_failing_event.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
 namespace Dolittle.Runtime.Events.Processing.Streams.Partitioned.for_ScopedStreamProcessor.when_setting_position.and_stream_has_only_one_partition;
 
 public class and_setting_position_to_failing_event : all_dependencies
@@ -33,13 +35,11 @@ public class and_setting_position_to_failing_event : all_dependencies
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), 0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
     It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(1));
     It should_have_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);
     It should_have_the_correct_failing_partition = () => current_stream_processor_state.FailingPartitions.ContainsKey(partition_id).ShouldBeTrue();
     It should_have_the_correct_position_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[partition_id].Position.ShouldEqual(new StreamPosition(0));
-
     It should_have_the_correct_reason_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[partition_id].Reason.ShouldEqual(failure_reason);
     It should_have_the_correct_retry_time_on_the_failing_partition = () => current_stream_processor_state.FailingPartitions[partition_id].RetryTime.ShouldBeGreaterThan(DateTimeOffset.UtcNow);
-        
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/given/all_dependencies.cs
@@ -13,6 +13,7 @@ using Dolittle.Runtime.Resilience;
 using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
 using Moq;
+using It = Moq.It;
 
 namespace Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.given;
 
@@ -30,6 +31,7 @@ public class all_dependencies
     protected static Mock<IEventProcessor> event_processor;
     static IStreamEventWatcher event_waiter;
     protected static CancellationTokenSource cancellation_token_source;
+    protected static Mock<Func<TenantId, CancellationToken, Task<Try>>> action_to_perform_before_reprocessing;
 
     Establish context = () =>
     {
@@ -61,6 +63,11 @@ public class all_dependencies
             event_waiter,
             new TimeToRetryForUnpartitionedStreamProcessor(),
             Mock.Of<ILogger<ScopedStreamProcessor>>());
+
+        action_to_perform_before_reprocessing = new Mock<Func<TenantId, CancellationToken, Task<Try>>>();
+        action_to_perform_before_reprocessing
+            .Setup(_ => _(It.IsAny<TenantId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Try.Succeeded());
     };
         
     Cleanup clean = () => cancellation_token_source.Dispose();
@@ -70,11 +77,11 @@ public class all_dependencies
         cancellation_token_source.CancelAfter(cancelAfter);
         return stream_processor.Start(cancellation_token_source.Token);
     }
-    protected static Task start_stream_processor_set_position_after_and_cancel_after(TimeSpan setPositionAfter, StreamPosition position, TimeSpan cancelAfter)
+    protected static Task start_stream_processor_set_position_after_and_cancel_after(TimeSpan setPositionAfter, StreamPosition position, Func<TenantId, CancellationToken, Task<Try>> beforeReprocessingAction, TimeSpan cancelAfter)
     {
         var result = stream_processor.Start(cancellation_token_source.Token);
         Task.Delay(setPositionAfter).GetAwaiter().GetResult();
-        stream_processor.ReprocessEventsFrom(position).GetAwaiter().GetResult();
+        stream_processor.PerformActionAndReprocessEventsFrom(position, beforeReprocessingAction).GetAwaiter().GetResult();
         cancellation_token_source.CancelAfter(cancelAfter);
         return result;
     }

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_first_event.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_first_event.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_second_event.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_stream_processor_must_retry_processing_an_event_three_times.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_stream_processor_must_retry_processing_an_event_three_times.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/stream_with_one_event/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/stream_with_one_event/and_everything_is_ok.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Rudimentary;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_everything_is_ok.cs
@@ -4,14 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.ApplicationModel;
-using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
-using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
-namespace Events.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.when_setting_position;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.when_setting_position;
 
 public class and_everything_is_ok : all_dependencies
 {
@@ -34,6 +34,5 @@ public class and_everything_is_ok : all_dependencies
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(1));
     It should_not_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeFalse();
     It should_try_fetching_next_event = () => events_fetcher.Verify(_ => _.Fetch((ulong)1, Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeastOnce);
-
-
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_everything_is_ok.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.given;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Rudimentary;
 using Machine.Specifications;
 namespace Events.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.when_setting_position;
 
@@ -25,7 +27,7 @@ public class and_everything_is_ok : all_dependencies
         setup_event_stream(event_with_partition);
     };
 
-    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100),0, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100),0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
     It should_process_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_fetch_event_twice = () => events_fetcher.Verify(_ => _.Fetch((ulong)0, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_performing_action_fails.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_performing_action_fails.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.given;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Rudimentary;
+using Machine.Specifications;
+using Moq;
+using It = Machine.Specifications.It;
+
+namespace Dolittle.Runtime.Events.Processing.Streams.for_ScopedStreamProcessor.when_setting_position;
+
+public class and_performing_action_fails : all_dependencies
+{
+    static readonly PartitionId partition_id = "f6b7a2a4-9d1d-4d9a-8ad5-dbde3bb08ade";
+    static readonly CommittedEvent first_event = committed_events.single();
+
+    Establish context = () =>
+    {
+        var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, false);
+        event_processor
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<IProcessingResult>(new SuccessfulProcessing()));
+        setup_event_stream(event_with_partition);
+
+        action_to_perform_before_reprocessing
+            .Setup(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Try.Failed(new Exception()));
+    };
+
+    Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100),0, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+        
+    It should_not_process_event_again = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_fetch_event_again = () => events_fetcher.Verify(_ => _.Fetch((ulong)0, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_have_current_position_equal_one = () => current_stream_processor_state.Position.ShouldEqual(new StreamPosition(1));
+    It should_not_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeFalse();
+    It should_try_fetching_next_event = () => events_fetcher.Verify(_ => _.Fetch((ulong)1, Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeastOnce);
+    It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);
+}

--- a/Specifications/Events.Processing/Streams/for_StreamProcessors/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Streams/for_StreamProcessors/given/all_dependencies.cs
@@ -3,7 +3,6 @@
 
 using Dolittle.Runtime.DependencyInversion;
 using Dolittle.Runtime.Execution;
-using Microsoft.Extensions.Logging;
 using Dolittle.Runtime.Tenancy;
 using Machine.Specifications;
 using Moq;

--- a/Specifications/Platform/Handshake/for_VerifyContractsCompatibility/when_checking_compatibility/and_runtime_minor_is_greater.cs
+++ b/Specifications/Platform/Handshake/for_VerifyContractsCompatibility/when_checking_compatibility/and_runtime_minor_is_greater.cs
@@ -18,5 +18,5 @@ public class and_runtime_minor_is_greater : given.a_verifier_and_versions
 
     Because of = () => result = verifier.CheckCompatibility(runtime_contracts_version, head_contracts_version);
 
-    It should_return_client_too_old = () => result.ShouldEqual(ContractsCompatibility.ClientTooOld);
+    It should_return_compatible = () => result.ShouldEqual(ContractsCompatibility.Compatible);
 }

--- a/versions.props
+++ b/versions.props
@@ -3,7 +3,7 @@
         <AutofacVersion>5.0.0</AutofacVersion>
         <AutofacExtensionsVersion>6.0.0</AutofacExtensionsVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>6.8.0-merry.0</ContractsVersion>
+        <ContractsVersion>6.8.0-merry.1</ContractsVersion>
         <CoverletVersion>3.1.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary

- Moved a lot of Projection processor logic from the `ProjectionsService` gRPC implementation, to a `Projections` system that keeps track of Projections and exposes management methods.
- Expose gRPC Server Reflection service on all endpoints
- Add Alias to Projections
- Fix bug in Handshake version compatibility checks
- Implement Projections Management service

Docs, a lot of logging - and some error handling in the Projections Management service to do.