### PR TITLE
Create CLI commands for Projections

### DIFF
--- a/Source/CLI/Runtime/EventHandlers/EventHandlerStatus.cs
+++ b/Source/CLI/Runtime/EventHandlers/EventHandlerStatus.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Dolittle.Runtime.Artifacts;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.EventHandlers;
 using Dolittle.Runtime.Events.Store;
 

--- a/Source/CLI/Runtime/EventHandlers/Get/Command.cs
+++ b/Source/CLI/Runtime/EventHandlers/Get/Command.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.CLI.Options;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
 using Dolittle.Runtime.CLI.Runtime.EventTypes;
 using Dolittle.Runtime.Serialization.Json;
 using McMaster.Extensions.CommandLineUtils;

--- a/Source/CLI/Runtime/EventHandlers/Get/UnpartitionedEventHandlerDetailedView.cs
+++ b/Source/CLI/Runtime/EventHandlers/Get/UnpartitionedEventHandlerDetailedView.cs
@@ -6,10 +6,10 @@ using System;
 namespace Dolittle.Runtime.CLI.Runtime.EventHandlers.Get;
 
 /// <summary>
-/// Represents a detailed view of an unpartitioned Event Handler state.
+/// Represents a detailed view of an unpartitioned Event Handler Stream Processor state.
 /// </summary>
 /// <param name="Tenant">The Tenant.</param>
-/// <param name="Position">The stream position-</param>
+/// <param name="Position">The stream position.</param>
 /// <param name="Status">The status.</param>
 /// <param name="FailureReason">The reason for failure.</param>
 /// <param name="RetryTime">The retry time.</param>

--- a/Source/CLI/Runtime/EventHandlers/GetOneEventHandlerFailed.cs
+++ b/Source/CLI/Runtime/EventHandlers/GetOneEventHandlerFailed.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Processing.EventHandlers;
+
+namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
+
+/// <summary>
+/// Exception that gets thrown when getting one Event Handler fails.
+/// </summary>
+public class GetOneEventHandlerFailed : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetOneEventHandlerFailed"/> class.
+    /// </summary>
+    /// <param name="eventHandler">The Event Handler that getting one failed for.</param>
+    /// <param name="reason">The reason why getting one Event Handler failed.</param>
+    public GetOneEventHandlerFailed(EventHandlerId eventHandler, string reason)
+        : base($"Could not get event handler {eventHandler.EventHandler} in scope {eventHandler.Scope} because {reason}")
+    {
+    }
+}

--- a/Source/CLI/Runtime/EventHandlers/IManagementClient.cs
+++ b/Source/CLI/Runtime/EventHandlers/IManagementClient.cs
@@ -35,20 +35,20 @@ public interface IManagementClient
     Task ReprocessAllEvents(EventHandlerId eventHandler, MicroserviceAddress runtime);
         
     /// <summary>
-    /// Gets all running Event Handlers or for a specific Tenant if specified.
+    /// Get the <see cref="EventHandlerStatus"/> of all registered Event Handlers.
     /// </summary>
     /// <param name="runtime">The address of the Runtime to connect to.</param>
-    /// <param name="tenant">The Tenant to get Event Handlers for.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <param name="tenant">The Tenant to get Stream Processor states for, or null to get all.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="EventHandlerStatus"/> of all registered Projections.</returns>
     Task<IEnumerable<EventHandlerStatus>> GetAll(MicroserviceAddress runtime, TenantId tenant = null);
 
     /// <summary>
-    /// Gets the running Event Handler with the given identifier and for a specific Tenant if specified.
+    /// Get the <see cref="EventHandlerStatus"/> of a registered Event Handler by <see cref="EventHandlerId"/>.
     /// </summary>
     /// <param name="runtime">The address of the Runtime to connect to.</param>
     /// <param name="eventHandler">The Event Handler identifier.</param>
-    /// <param name="tenant">The Tenant to get Event Handlers for.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <param name="tenant">The Tenant to get Stream Processor states for, or null to get all.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="Try"/> containing the <see cref="EventHandlerStatus"/>-</returns>
     Task<Try<EventHandlerStatus>> Get(MicroserviceAddress runtime, EventHandlerId eventHandler, TenantId tenant = null);
 
 }

--- a/Source/CLI/Runtime/EventHandlers/List/Command.cs
+++ b/Source/CLI/Runtime/EventHandlers/List/Command.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.CLI.Options;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
 using Dolittle.Runtime.CLI.Runtime.EventTypes;
 using Dolittle.Runtime.Serialization.Json;
 using McMaster.Extensions.CommandLineUtils;
@@ -66,6 +67,7 @@ public class Command : CommandBase
         => Wide
             ? WriteOutput(cli, eventHandlerStatuses.Select(CreateDetailedView))
             : WriteOutput(cli, eventHandlerStatuses.Select(CreateSimpleView));
+    
     static EventHandlerSimpleView CreateSimpleView(EventHandlerStatus status)
         => status.Partitioned switch
         {

--- a/Source/CLI/Runtime/EventHandlers/ManagementClient.cs
+++ b/Source/CLI/Runtime/EventHandlers/ManagementClient.cs
@@ -93,6 +93,7 @@ public class ManagementClient : IManagementClient
         return response.EventHandlers.Select(CreateEventHandlerStatus);
     }
 
+    /// <inheritdoc />
     public async Task<Try<EventHandlerStatus>> Get(MicroserviceAddress runtime, EventHandlerId eventHandler, TenantId tenant = null)
     {
         var client = _clients.CreateClientFor<EventHandlersClient>(runtime);

--- a/Source/CLI/Runtime/EventHandlers/ManagementClient.cs
+++ b/Source/CLI/Runtime/EventHandlers/ManagementClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.Artifacts;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Processing.EventHandlers;
 using Dolittle.Runtime.Events.Processing.Management.Contracts;
 using Dolittle.Runtime.Events.Store.Streams;
@@ -14,6 +15,7 @@ using Dolittle.Runtime.Protobuf;
 using Dolittle.Runtime.Rudimentary;
 using ManagementContracts = Dolittle.Runtime.Events.Processing.Management.Contracts;
 using static Dolittle.Runtime.Events.Processing.Management.Contracts.EventHandlers;
+using TenantScopedStreamProcessorStatus = Dolittle.Runtime.CLI.Runtime.Events.Processing.TenantScopedStreamProcessorStatus;
 
 namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
 
@@ -23,14 +25,17 @@ namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
 public class ManagementClient : IManagementClient
 {
     readonly ICanCreateClients _clients;
+    readonly IConvertStreamProcessorStatus _converter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ManagementClient"/> class.
     /// </summary>
     /// <param name="clients">The client creator to us to create clients that connect to the Runtime.</param>
-    public ManagementClient(ICanCreateClients clients)
+    /// <param name="converter">The converter to use to convert stream processor statuses.</param>
+    public ManagementClient(ICanCreateClients clients, IConvertStreamProcessorStatus converter)
     {
         _clients = clients;
+        _converter = converter;
     }
 
     /// <inheritdoc />
@@ -95,42 +100,11 @@ public class ManagementClient : IManagementClient
         return result == default ? new NoEventHandlerWithId(eventHandler) : result;
     }
 
-    static EventHandlerStatus CreateEventHandlerStatus(ManagementContracts.EventHandlerStatus status)
+    EventHandlerStatus CreateEventHandlerStatus(ManagementContracts.EventHandlerStatus status)
         => new(
             new EventHandlerId(status.ScopeId.ToGuid(), status.EventHandlerId.ToGuid()),
             status.EventTypes.Select(_ => new Artifact(_.Id.ToGuid(), _.Generation)),
             status.Partitioned,
             status.Alias,
-            GetStates(status));
-
-    static IEnumerable<TenantScopedStreamProcessorStatus> GetStates(ManagementContracts.EventHandlerStatus status)
-        => status.Tenants.Select(_ => _.StatusCase switch
-        {
-            ManagementContracts.TenantScopedStreamProcessorStatus.StatusOneofCase.Partitioned => CreatePartitionedState(_, _.Partitioned),
-            ManagementContracts.TenantScopedStreamProcessorStatus.StatusOneofCase.Unpartitioned => CreateUnpartitionedState(_, _.Unpartitioned) as TenantScopedStreamProcessorStatus,
-            _ => throw new InvalidTenantScopedStreamProcessorStatusTypeReceived(_.StatusCase),
-        });
-
-    static PartitionedTenantScopedStreamProcessorStatus CreatePartitionedState(ManagementContracts.TenantScopedStreamProcessorStatus status, ManagementContracts.PartitionedTenantScopedStreamProcessorStatus partitionedStatus)
-        => new(
-            status.TenantId.ToGuid(),
-            status.StreamPosition,
-            partitionedStatus.FailingPartitions.Select(_ => new FailingPartition(
-                _.PartitionId,
-                _.StreamPosition,
-                _.FailureReason,
-                _.RetryCount,
-                _.RetryTime.ToDateTimeOffset(),
-                _.LastFailed.ToDateTimeOffset())),
-            status.LastSuccessfullyProcessed.ToDateTimeOffset());
-
-    static UnpartitionedTenantScopedStreamProcessorStatus CreateUnpartitionedState(ManagementContracts.TenantScopedStreamProcessorStatus status, ManagementContracts.UnpartitionedTenantScopedStreamProcessorStatus unpartitionedStatus)
-        => new(
-            status.TenantId.ToGuid(),
-            status.StreamPosition,
-            unpartitionedStatus.IsFailing,
-            unpartitionedStatus.FailureReason,
-            unpartitionedStatus.RetryCount,
-            unpartitionedStatus.RetryTime.ToDateTimeOffset(),
-            status.LastSuccessfullyProcessed.ToDateTimeOffset());
+            _converter.Convert(status.Tenants));
 }

--- a/Source/CLI/Runtime/Events/Processing/ConvertStreamProcessorStatus.cs
+++ b/Source/CLI/Runtime/Events/Processing/ConvertStreamProcessorStatus.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Dolittle.Runtime.Protobuf;
+using ManagementContracts = Dolittle.Runtime.Events.Processing.Management.Contracts;
+
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
+
+/// <summary>
+/// Represents an implementation of <see cref="IConvertStreamProcessorStatus"/>.
+/// </summary>
+public class ConvertStreamProcessorStatus : IConvertStreamProcessorStatus
+{
+    /// <inheritdoc />
+    public IEnumerable<TenantScopedStreamProcessorStatus> Convert(IEnumerable<ManagementContracts.TenantScopedStreamProcessorStatus> statuses)
+        => statuses.Select(Convert);
+
+    static TenantScopedStreamProcessorStatus Convert(ManagementContracts.TenantScopedStreamProcessorStatus status)
+        => status.StatusCase switch
+        {
+            ManagementContracts.TenantScopedStreamProcessorStatus.StatusOneofCase.Partitioned => CreatePartitionedState(status, status.Partitioned),
+            ManagementContracts.TenantScopedStreamProcessorStatus.StatusOneofCase.Unpartitioned => CreateUnpartitionedState(status, status.Unpartitioned),
+            _ => throw new InvalidTenantScopedStreamProcessorStatusTypeReceived(status.StatusCase),
+        };
+    
+    static PartitionedTenantScopedStreamProcessorStatus CreatePartitionedState(ManagementContracts.TenantScopedStreamProcessorStatus status, ManagementContracts.PartitionedTenantScopedStreamProcessorStatus partitionedStatus)
+        => new(
+            status.TenantId.ToGuid(),
+            status.StreamPosition,
+            partitionedStatus.FailingPartitions.Select(_ => new FailingPartition(
+                _.PartitionId,
+                _.StreamPosition,
+                _.FailureReason,
+                _.RetryCount,
+                _.RetryTime.ToDateTimeOffset(),
+                _.LastFailed.ToDateTimeOffset())),
+            status.LastSuccessfullyProcessed.ToDateTimeOffset());
+
+    static UnpartitionedTenantScopedStreamProcessorStatus CreateUnpartitionedState(ManagementContracts.TenantScopedStreamProcessorStatus status, ManagementContracts.UnpartitionedTenantScopedStreamProcessorStatus unpartitionedStatus)
+        => new(
+            status.TenantId.ToGuid(),
+            status.StreamPosition,
+            unpartitionedStatus.IsFailing,
+            unpartitionedStatus.FailureReason,
+            unpartitionedStatus.RetryCount,
+            unpartitionedStatus.RetryTime.ToDateTimeOffset(),
+            status.LastSuccessfullyProcessed.ToDateTimeOffset());
+}

--- a/Source/CLI/Runtime/Events/Processing/FailingPartition.cs
+++ b/Source/CLI/Runtime/Events/Processing/FailingPartition.cs
@@ -3,15 +3,15 @@
 
 using System;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
 
 /// <summary>
-/// Represents a failing Partition of a Partitioned Event Handler.
+/// Represents a failing Partition of a Partitioned Stream Processor.
 /// </summary>
 /// <param name="Id">The Partition identifier.</param>
 /// <param name="Position">The position of the failing Event in the Stream.</param>
-/// <param name="FailureReason">The reason why the Event Handler is failing.</param>
-/// <param name="ProcessingAttempts">The number of times the Event Handler has tried to process a failing Event.</param>
+/// <param name="FailureReason">The reason why the Stream Processor is failing.</param>
+/// <param name="ProcessingAttempts">The number of times the Stream Processor has tried to process a failing Event.</param>
 /// <param name="RetryTime">The next time to process the failed Event.</param>
 /// <param name="LastFailed">The last time processing the failed Event was attempted.</param>
 public record FailingPartition(

--- a/Source/CLI/Runtime/Events/Processing/IConvertStreamProcessorStatus.cs
+++ b/Source/CLI/Runtime/Events/Processing/IConvertStreamProcessorStatus.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using ManagementContracts = Dolittle.Runtime.Events.Processing.Management.Contracts;
+
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
+
+/// <summary>
+/// Defines a system that can convert Stream Processor statuses from Contracts to Runtime representation.
+/// </summary>
+public interface IConvertStreamProcessorStatus
+{
+    /// <summary>
+    /// Converts a set of <see cref="ManagementContracts.TenantScopedStreamProcessorStatus"/> to <see cref="TenantScopedStreamProcessorStatus"/>.
+    /// </summary>
+    /// <param name="statuses">The statuses to convert.</param>
+    /// <returns>The converted statuses.</returns>
+    IEnumerable<TenantScopedStreamProcessorStatus> Convert(IEnumerable<ManagementContracts.TenantScopedStreamProcessorStatus> statuses);
+}

--- a/Source/CLI/Runtime/Events/Processing/InvalidTenantScopedStreamProcessorStatusTypeReceived.cs
+++ b/Source/CLI/Runtime/Events/Processing/InvalidTenantScopedStreamProcessorStatusTypeReceived.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using ManagementContracts = Dolittle.Runtime.Events.Processing.Management.Contracts;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
 
 /// <summary>
 /// Exception that gets thrown when the Runtime returns a <see cref="TenantScopedStreamProcessorStatus"/> type that is invalid.
@@ -14,7 +15,7 @@ public class InvalidTenantScopedStreamProcessorStatusTypeReceived : Exception
     /// Initializes a new instance of the <see cref="InvalidTenantScopedStreamProcessorStatusTypeReceived"/> class.
     /// </summary>
     /// <param name="statusType">The status type that was received.</param>
-    public InvalidTenantScopedStreamProcessorStatusTypeReceived(Events.Processing.Management.Contracts.TenantScopedStreamProcessorStatus.StatusOneofCase statusType)
+    public InvalidTenantScopedStreamProcessorStatusTypeReceived(ManagementContracts.TenantScopedStreamProcessorStatus.StatusOneofCase statusType)
         : base($"Invalid {nameof(TenantScopedStreamProcessorStatus)} received: ${statusType}")
     {
     }

--- a/Source/CLI/Runtime/Events/Processing/PartitionedTenantScopedStreamProcessorStatus.cs
+++ b/Source/CLI/Runtime/Events/Processing/PartitionedTenantScopedStreamProcessorStatus.cs
@@ -4,18 +4,21 @@
 using System;
 using System.Collections.Generic;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
 
 /// <summary>
-/// Represents the status of a Partitioned Event Handler for a specific Tenant.
+/// Represents the status of a Partitioned Stream Processor for a specific Tenant.
 /// </summary>
 /// <param name="TenantId">The identifier of the Tenant.</param>
-/// <param name="Position">The position of the next Event the Event Handler will process.</param>
-/// <param name="FailingPartitions">The failing partitions for the Event Handler.</param>
+/// <param name="Position">The position of the next Event the Stream Processor will process.</param>
+/// <param name="FailingPartitions">The failing partitions for the Stream Processor.</param>
 /// <param name="LastSuccessfullyProcessed">When the last successfully processing of an Event was.</param>
 public record PartitionedTenantScopedStreamProcessorStatus(
         Guid TenantId,
         ulong Position,
         IEnumerable<FailingPartition> FailingPartitions,
         DateTimeOffset LastSuccessfullyProcessed)
-    : TenantScopedStreamProcessorStatus(TenantId, Position, LastSuccessfullyProcessed);
+    : TenantScopedStreamProcessorStatus(
+        TenantId,
+        Position,
+        LastSuccessfullyProcessed);

--- a/Source/CLI/Runtime/Events/Processing/ServiceCollectionExtensions.cs
+++ b/Source/CLI/Runtime/Events/Processing/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds services related to management of event processors.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    public static void AddEventsProcessingServices(this IServiceCollection services)
+    {
+        services.AddTransient<IConvertStreamProcessorStatus, ConvertStreamProcessorStatus>();
+    }
+}

--- a/Source/CLI/Runtime/Events/Processing/TenantScopedStreamProcessorStatus.cs
+++ b/Source/CLI/Runtime/Events/Processing/TenantScopedStreamProcessorStatus.cs
@@ -3,12 +3,12 @@
 
 using System;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
 
 /// <summary>
-/// Represents the status of an Event Handler for a specific Tenant.
+/// Represents the status of an Stream Processor for a specific Tenant.
 /// </summary>
 /// <param name="TenantId">The identifier of the Tenant.</param>
-/// <param name="Position">The position of the next Event the Event Handler will process.</param>
+/// <param name="Position">The position of the next Event the Stream Processor will process.</param>
 /// <param name="LastSuccessfullyProcessed">When the last successfully processing of an Event was.</param>
 public record TenantScopedStreamProcessorStatus(Guid TenantId, ulong Position, DateTimeOffset LastSuccessfullyProcessed);

--- a/Source/CLI/Runtime/Events/Processing/UnpartitionedTenantScopedStreamProcessorStatus.cs
+++ b/Source/CLI/Runtime/Events/Processing/UnpartitionedTenantScopedStreamProcessorStatus.cs
@@ -3,16 +3,16 @@
 
 using System;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers;
+namespace Dolittle.Runtime.CLI.Runtime.Events.Processing;
 
 /// <summary>
-/// Represents the status of an Unpartitioned Event Handler for a specific Tenant.
+/// Represents the status of an Unpartitioned Stream Processor for a specific Tenant.
 /// </summary>
 /// <param name="TenantId">The identifier of the Tenant.</param>
-/// <param name="Position">The position of the next Event the Event Handler will process.</param>
-/// <param name="IsFailing">Whether the Event Handler is currently failing or not.</param>
-/// <param name="FailureReason">The reason why the Event Handler is failing (if it is).</param>
-/// <param name="ProcessingAttempts">The number of times the Event Handler has tried to process a failing Event.</param>
+/// <param name="Position">The position of the next Event the Stream Processor will process.</param>
+/// <param name="IsFailing">Whether the Stream Processor is currently failing or not.</param>
+/// <param name="FailureReason">The reason why the Stream Processor is failing (if it is).</param>
+/// <param name="ProcessingAttempts">The number of times the Stream Processor has tried to process a failing Event.</param>
 /// <param name="RetryTime">The next time to process the failed Event.</param>
 /// <param name="LastSuccessfullyProcessed">When the last successfully processing of an Event was.</param>
 public record UnpartitionedTenantScopedStreamProcessorStatus(
@@ -23,4 +23,7 @@ public record UnpartitionedTenantScopedStreamProcessorStatus(
         uint ProcessingAttempts,
         DateTimeOffset RetryTime,
         DateTimeOffset LastSuccessfullyProcessed)
-    : TenantScopedStreamProcessorStatus(TenantId, Position, LastSuccessfullyProcessed);
+    : TenantScopedStreamProcessorStatus(
+        TenantId, 
+        Position, 
+        LastSuccessfullyProcessed);

--- a/Source/CLI/Runtime/Projections/Command.cs
+++ b/Source/CLI/Runtime/Projections/Command.cs
@@ -13,6 +13,7 @@ namespace Dolittle.Runtime.CLI.Runtime.Projections;
 [Command("projections", Description = "Manage Projections")]
 [Subcommand(typeof(List.Command))]
 [Subcommand(typeof(Get.Command))]
+[Subcommand(typeof(Replay.Command))]
 public class Command: CommandBase
 {
     public Command(ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer)

--- a/Source/CLI/Runtime/Projections/Command.cs
+++ b/Source/CLI/Runtime/Projections/Command.cs
@@ -12,6 +12,7 @@ namespace Dolittle.Runtime.CLI.Runtime.Projections;
 /// </summary>
 [Command("projections", Description = "Manage Projections")]
 [Subcommand(typeof(List.Command))]
+[Subcommand(typeof(Get.Command))]
 public class Command: CommandBase
 {
     public Command(ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer)

--- a/Source/CLI/Runtime/Projections/Command.cs
+++ b/Source/CLI/Runtime/Projections/Command.cs
@@ -5,30 +5,22 @@ using Dolittle.Runtime.CLI.Runtime.EventTypes;
 using Dolittle.Runtime.Serialization.Json;
 using McMaster.Extensions.CommandLineUtils;
 
-namespace Dolittle.Runtime.CLI.Runtime;
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
 
 /// <summary>
-/// The "dolittle runtime" command.
+/// The "dolittle runtime projections" command.
 /// </summary>
-[Command("runtime", Description = "Manage a Runtime")]
-[Subcommand(typeof(Aggregates.Command))]
-[Subcommand(typeof(EventHandlers.Command))]
-[Subcommand(typeof(EventTypes.Command))]
-[Subcommand(typeof(Projections.Command))]
-public class Command : CommandBase
+[Command("projections", Description = "Manage Projections")]
+[Subcommand(typeof(List.Command))]
+public class Command: CommandBase
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Command"/> class.
-    /// </summary>
-    /// <param name="runtimes">The Runtime locator to find a Runtime to connect to.</param>
-    /// <param name="jsonSerializer">The json <see cref="ISerializer"/>.</param>
     public Command(ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer)
         : base(runtimes, eventTypesDiscoverer, jsonSerializer)
     {
     }
-        
+
     /// <summary>
-    /// The entrypoint for the "dolittle runtime" command.
+    /// The entrypoint for the "dolittle runtime projections" command.
     /// </summary>
     /// <param name="cli">The <see cref="CommandLineApplication"/> that is executed.</param>
     public void OnExecute(CommandLineApplication cli)

--- a/Source/CLI/Runtime/Projections/CommandBase.cs
+++ b/Source/CLI/Runtime/Projections/CommandBase.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.CLI.Runtime.EventTypes;
+using Dolittle.Runtime.Serialization.Json;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+public abstract class CommandBase : Runtime.CommandBase
+{
+    protected CommandBase(ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer) 
+        : base(runtimes, eventTypesDiscoverer, jsonSerializer)
+    {
+    }
+}

--- a/Source/CLI/Runtime/Projections/Get/Command.cs
+++ b/Source/CLI/Runtime/Projections/Get/Command.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.CLI.Options;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
+using Dolittle.Runtime.CLI.Runtime.EventTypes;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Serialization.Json;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections.Get;
+
+/// <summary>
+/// The "dolittle runtime projections get" command.
+/// </summary>
+[Command("get", Description = "Gets a running Projection")]
+public class Command : CommandBase
+{
+    readonly IManagementClient _client;
+    readonly IResolveProjectionIdAndScope _resolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Command"/> class.
+    /// </summary>
+    /// <param name="client">The management client to use to get all registered Projections.</param>
+    /// <param name="resolver">The resolver to use to resolve arguments to a Projection.</param>
+    /// <param name="runtimes">The locator to use to find the Runtime to connect to.</param>
+    /// <param name="eventTypesDiscoverer">The event types discoverer to use to discover event types.</param>
+    /// <param name="jsonSerializer">The JSON serializer to use.</param>
+    public Command(IManagementClient client, IResolveProjectionIdAndScope resolver, ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer) 
+        : base(runtimes, eventTypesDiscoverer, jsonSerializer)
+    {
+        _client = client;
+        _resolver = resolver;
+    }
+        
+    /// <summary>
+    /// The "--tenant" argument used to provide a Tenant Id.
+    /// </summary>
+    [Option("--tenant", CommandOptionType.SingleValue, Description = "Only show Projection information for the specified Tenant")]
+    TenantId Tenant { get; init; }
+    
+    /// <summary>
+    /// The Projection identifier argument used to provide the identifier of the Projection to get.
+    /// </summary>
+    [Required]
+    [Argument(0, Description = "The identifier or alias of the Projection to get details for")]
+    string IdentifierOrAlias { get; init; }
+    
+    /// <summary>
+    /// The Projection scope argument used to provide the identifier of the Projection to get.
+    /// </summary>
+    [Argument(1, Description = "The scope of the Projection to get details for")]
+    ScopeId Scope { get; init; }
+
+    /// <summary>
+    /// The entrypoint for the "dolittle runtime eventhandlers get" command.
+    /// </summary>
+    /// <param name="cli">The <see cref="CommandLineApplication"/> that is executed.</param>
+    public async Task OnExecuteAsync(CommandLineApplication cli)
+    {
+        var runtimeAddress = await SelectRuntimeToConnectTo(cli);
+        if (!runtimeAddress.Success)
+        {
+            return;
+        }
+
+        var getIdentity= await _resolver.Resolve(runtimeAddress, IdentifierOrAlias, Scope);
+        if (!getIdentity.Success)
+        {
+            throw getIdentity.Exception;
+        }
+
+        var ( projectionId, scopeId ) = getIdentity.Result;
+        var getStatus = await _client.Get(runtimeAddress, scopeId, projectionId, Tenant).ConfigureAwait(false);
+
+        if (!getStatus.Success)
+        {
+            throw getStatus.Exception;
+        }
+
+        if (Output == OutputType.Json)
+        {
+            await WriteOutput(cli, getStatus.Result).ConfigureAwait(false);
+        }
+        else
+        {
+            await WriteTableOutput(cli, getStatus.Result).ConfigureAwait(false);
+        }
+    }
+        
+    Task WriteTableOutput(CommandLineApplication cli, ProjectionStatus status)
+        => Wide
+            ? WriteOutput(cli, status.States.Select(CreateDetailedStateView))
+            : WriteOutput(cli, status.States.Select(CreateSimpleStateView));
+    
+    static ProjectionSimpleView CreateSimpleStateView(UnpartitionedTenantScopedStreamProcessorStatus status)
+        => new(
+            status.TenantId,
+            status.Position,
+            status.IsFailing ? "❌" : "✅");
+    
+    static ProjectionDetailedView CreateDetailedStateView(UnpartitionedTenantScopedStreamProcessorStatus status)
+        => new(
+            status.TenantId,
+            status.Position, 
+            status.IsFailing ? "❌" : "✅",
+            status.FailureReason,
+            status.RetryTime,
+            status.ProcessingAttempts,
+            status.LastSuccessfullyProcessed);
+}

--- a/Source/CLI/Runtime/Projections/Get/ProjectionDetailedView.cs
+++ b/Source/CLI/Runtime/Projections/Get/ProjectionDetailedView.cs
@@ -3,25 +3,23 @@
 
 using System;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers.Get;
+namespace Dolittle.Runtime.CLI.Runtime.Projections.Get;
 
 /// <summary>
-/// Represents a detailed view of a partitioned Event Handler Stream Processor state.
+/// Represents a detailed view of a Projection Stream Processor state.
 /// </summary>
 /// <param name="Tenant">The Tenant.</param>
 /// <param name="Position">The stream position.</param>
 /// <param name="Status">The status.</param>
-/// <param name="LastSuccessfulOrFailedProcessing">When the last event was successfully processed or failed processing.</param>
-/// <param name="Partition">The Partition identifier.</param>
 /// <param name="FailureReason">The reason for failure.</param>
 /// <param name="RetryTime">The retry time.</param>
 /// <param name="ProcessingAttempts">The number of processing attempts.</param>
-public record PartitionedEventHandlerDetailedView(
+/// <param name="LastSuccessfullyProcessed">When the last event was successfully processed</param>
+public record ProjectionDetailedView(
     Guid Tenant,
     ulong Position,
     string Status,
-    DateTimeOffset LastSuccessfulOrFailedProcessing,
-    string Partition,
     string FailureReason,
     DateTimeOffset RetryTime,
-    uint ProcessingAttempts);
+    uint ProcessingAttempts,
+    DateTimeOffset LastSuccessfullyProcessed);

--- a/Source/CLI/Runtime/Projections/Get/ProjectionSimpleView.cs
+++ b/Source/CLI/Runtime/Projections/Get/ProjectionSimpleView.cs
@@ -3,12 +3,12 @@
 
 using System;
 
-namespace Dolittle.Runtime.CLI.Runtime.EventHandlers.Get;
+namespace Dolittle.Runtime.CLI.Runtime.Projections.Get;
 
 /// <summary>
-/// Represents a simple view of an Event Handler Stream Processor state.
+/// Represents a simple view of a Projection Stream Processor state.
 /// </summary>
 /// <param name="Tenant">The Tenant.</param>
 /// <param name="Position">The stream position.</param>
 /// <param name="Status">The status.</param>
-public record EventHandlerSimpleView(Guid Tenant, ulong Position, string Status);
+public record ProjectionSimpleView(Guid Tenant, ulong Position, string Status);

--- a/Source/CLI/Runtime/Projections/GetAllProjectionsFailed.cs
+++ b/Source/CLI/Runtime/Projections/GetAllProjectionsFailed.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Exception that gets thrown when getting all Projections fails.
+/// </summary>
+public class GetAllProjectionsFailed : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetAllProjectionsFailed"/> class.
+    /// </summary>
+    /// <param name="reason">The reason why getting all Projections failed.</param>
+    public GetAllProjectionsFailed(string reason)
+        : base($"Could not get all projections because {reason}")
+    {
+    }
+}

--- a/Source/CLI/Runtime/Projections/GetOneProjectionFailed.cs
+++ b/Source/CLI/Runtime/Projections/GetOneProjectionFailed.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Projections.Store;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Exception that gets thrown when getting one Projection fails.
+/// </summary>
+public class GetOneProjectionFailed : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetOneProjectionFailed"/> class.
+    /// </summary>
+    /// <param name="scope">The scope of the Projection.</param>
+    /// <param name="projection">The id of the Projection.</param>
+    /// <param name="reason">The reason why getting the Projection failed.</param>
+    public GetOneProjectionFailed(ScopeId scope, ProjectionId projection, string reason)
+        : base($"Could not get projection {projection} in scope {scope} because {reason}")
+    {
+    }
+}

--- a/Source/CLI/Runtime/Projections/IManagementClient.cs
+++ b/Source/CLI/Runtime/Projections/IManagementClient.cs
@@ -33,4 +33,14 @@ public interface IManagementClient
     /// <param name="tenant">The Tenant to get Stream Processor states for, or null to get all.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="Try"/> containing the <see cref="ProjectionStatus"/>-</returns>
     Task<Try<ProjectionStatus>> Get(MicroserviceAddress runtime, ScopeId scope, ProjectionId projection, TenantId tenant = null);
+    
+    /// <summary>
+    /// Replay a registered Projection by <see cref="ScopeId"/> and <see cref="ProjectionId"/>, clearing persisted read models and reprocess events.
+    /// </summary>
+    /// <param name="runtime">The address of the Runtime to connect to.</param>
+    /// <param name="scope">The scope of the Projection.</param>
+    /// <param name="projection">The id of the Projection.</param>
+    /// <param name="tenant">The Tenant to replay the Projection for, or null to get all.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="Try"/> result of the operation.</returns>
+    Task<Try> Replay(MicroserviceAddress runtime, ScopeId scope, ProjectionId projection, TenantId tenant = null);
 }

--- a/Source/CLI/Runtime/Projections/IManagementClient.cs
+++ b/Source/CLI/Runtime/Projections/IManagementClient.cs
@@ -4,7 +4,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Microservices;
+using Dolittle.Runtime.Projections.Store;
+using Dolittle.Runtime.Rudimentary;
 
 namespace Dolittle.Runtime.CLI.Runtime.Projections;
 
@@ -14,10 +17,20 @@ namespace Dolittle.Runtime.CLI.Runtime.Projections;
 public interface IManagementClient
 {
     /// <summary>
-    /// Gets all running Projections for a specific tenant if specified.
+    /// Get the <see cref="ProjectionStatus"/> of all registered Projections.
     /// </summary>
     /// <param name="runtime">The address of the Runtime to connect to.</param>
-    /// <param name="tenant">The Tenant to get Event Handlers for.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <param name="tenant">The Tenant to get Stream Processor states for, or null to get all.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="ProjectionStatus"/> of all registered Projections.</returns>
     Task<IEnumerable<ProjectionStatus>> GetAll(MicroserviceAddress runtime, TenantId tenant = null);
+
+    /// <summary>
+    /// Get the <see cref="ProjectionStatus"/> of a registered Projection by <see cref="ScopeId"/> and <see cref="ProjectionId"/>.
+    /// </summary>
+    /// <param name="runtime">The address of the Runtime to connect to.</param>
+    /// <param name="scope">The scope of the Projection.</param>
+    /// <param name="projection">The id of the Projection.</param>
+    /// <param name="tenant">The Tenant to get Stream Processor states for, or null to get all.</param>
+    /// <returns>A <see cref="Task"/> that, when resolved, returns the <see cref="Try"/> containing the <see cref="ProjectionStatus"/>-</returns>
+    Task<Try<ProjectionStatus>> Get(MicroserviceAddress runtime, ScopeId scope, ProjectionId projection, TenantId tenant = null);
 }

--- a/Source/CLI/Runtime/Projections/IManagementClient.cs
+++ b/Source/CLI/Runtime/Projections/IManagementClient.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.Microservices;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Defines the Projections management client.
+/// </summary>
+public interface IManagementClient
+{
+    /// <summary>
+    /// Gets all running Projections for a specific tenant if specified.
+    /// </summary>
+    /// <param name="runtime">The address of the Runtime to connect to.</param>
+    /// <param name="tenant">The Tenant to get Event Handlers for.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task<IEnumerable<ProjectionStatus>> GetAll(MicroserviceAddress runtime, TenantId tenant = null);
+}

--- a/Source/CLI/Runtime/Projections/IResolveProjectionIdAndScope.cs
+++ b/Source/CLI/Runtime/Projections/IResolveProjectionIdAndScope.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Microservices;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Defines a system that can resolve <see cref="ProjectionIdentifierAndScope"/>.
+/// </summary>
+public interface IResolveProjectionIdAndScope
+{
+    /// <summary>
+    /// Resolves the <see cref="ProjectionIdentifierAndScope"/> from an identifier or alias, and an optional scope
+    /// </summary>
+    /// <param name="runtime">The address of the Runtime.</param>
+    /// <param name="identifierOrAlias">The Projection identifier or alias.</param>
+    /// <param name="scope">The optional scope of the Projection.</param>
+    /// <returns>T <see cref="Task"/> that, when resolved, returns a <see cref="Try"/> with the resolved <see cref="ProjectionIdentifierAndScope"/>.</returns>
+    Task<Try<ProjectionIdentifierAndScope>> Resolve(MicroserviceAddress runtime, string identifierOrAlias, ScopeId scope = null);
+}

--- a/Source/CLI/Runtime/Projections/List/Command.cs
+++ b/Source/CLI/Runtime/Projections/List/Command.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.CLI.Options;
+using Dolittle.Runtime.CLI.Runtime.EventTypes;
+using Dolittle.Runtime.Events.Processing.Management.Contracts;
+using Dolittle.Runtime.Serialization.Json;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections.List;
+
+/// <summary>
+/// The "dolittle runtime projections list" command.
+/// </summary>
+[Command("list", "ls", Description = "List all running Projections")]
+public class Command : CommandBase
+{
+    readonly IManagementClient _client;
+
+    public Command(IManagementClient client, ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer)
+        : base(runtimes, eventTypesDiscoverer, jsonSerializer)
+    {
+        _client = client;
+    }
+        
+    /// <summary>
+    /// The "--tenant" argument used to provide a Tenant Id.
+    /// </summary>
+    [Option("--tenant", CommandOptionType.SingleValue, Description = "Only show Projection information for the specified Tenant")]
+    TenantId Tenant { get; init; }
+
+    /// <summary>
+    /// The entrypoint for the "dolittle runtime projections list" command.
+    /// </summary>
+    /// <param name="cli">The <see cref="CommandLineApplication"/> that is executed.</param>
+    public async Task OnExecuteAsync(CommandLineApplication cli)
+    {
+        var runtimeAddress = await SelectRuntimeToConnectTo(cli);
+        if (!runtimeAddress.Success)
+        {
+            return;
+        }
+        var projectionStatuses = await _client.GetAll(runtimeAddress, Tenant).ConfigureAwait(false);
+
+        if (Output == OutputType.Json)
+        {
+            await WriteOutput(cli, projectionStatuses).ConfigureAwait(false);
+        }
+        else
+        {
+            await WriteTableOutput(cli, projectionStatuses).ConfigureAwait(false);
+        }
+    }
+    
+    Task WriteTableOutput(CommandLineApplication cli, IEnumerable<ProjectionStatus> projectionStatuses)
+        => Wide
+            ? WriteOutput(cli, projectionStatuses.Select(CreateDetailedView))
+            : WriteOutput(cli, projectionStatuses.Select(CreateSimpleView));
+    
+    static ProjectionSimpleView CreateSimpleView(ProjectionStatus status)
+        => new(
+            status.HasAlias ? status.Alias : status.Id.Value.ToString(), 
+            status.IsInDefaultScope ? "Default" : status.Scope.Value.ToString(),
+            status.States.Any(_ => _.IsFailing) ? "❌" : "✅",
+            status.Copies.MongoDB.ShouldCopyToMongoDB ? "✅" : " ");
+
+    static ProjectionDetailedView CreateDetailedView(ProjectionStatus status)
+        => new(
+            status.Alias,
+            status.Id,
+            status.IsInDefaultScope ? "Default" : status.Scope.Value.ToString(),
+            status.States.Any(_ => _.IsFailing) ? "❌" : "✅",
+            status.States.Any() ? status.States.Max(_ => _.LastSuccessfullyProcessed) : DateTimeOffset.MinValue,
+            status.Copies.MongoDB.ShouldCopyToMongoDB ? "✅" : " ");
+}

--- a/Source/CLI/Runtime/Projections/List/Command.cs
+++ b/Source/CLI/Runtime/Projections/List/Command.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Dolittle.Runtime.ApplicationModel;
 using Dolittle.Runtime.CLI.Options;
 using Dolittle.Runtime.CLI.Runtime.EventTypes;
-using Dolittle.Runtime.Events.Processing.Management.Contracts;
 using Dolittle.Runtime.Serialization.Json;
 using McMaster.Extensions.CommandLineUtils;
 
@@ -22,6 +21,13 @@ public class Command : CommandBase
 {
     readonly IManagementClient _client;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Command"/> class.
+    /// </summary>
+    /// <param name="client">The management client to use to get all registered Projections.</param>
+    /// <param name="runtimes">The locator to use to find the Runtime to connect to.</param>
+    /// <param name="eventTypesDiscoverer">The event types discoverer to use to discover event types.</param>
+    /// <param name="jsonSerializer">The JSON serializer to use.</param>
     public Command(IManagementClient client, ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer)
         : base(runtimes, eventTypesDiscoverer, jsonSerializer)
     {

--- a/Source/CLI/Runtime/Projections/List/ProjectionDetailedView.cs
+++ b/Source/CLI/Runtime/Projections/List/ProjectionDetailedView.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections.List;
+
+/// <summary>
+/// Represents the detailed information for a Projection.
+/// </summary>
+/// <param name="Alias">The Projection alias.</param>
+/// <param name="Projection">The Projection identifier.</param>
+/// <param name="Scope">The Projection Scope.</param>
+/// <param name="Status">The status of the Projection.</param>
+/// <param name="LastSuccessfullyProcessed">The last time the Projection successfully processed an Event.</param>
+/// <param name="CopyToMongoDB">Whether or not the Projection has copies stored in MongoDB.</param>
+public record ProjectionDetailedView(
+    string Alias,
+    Guid Projection,
+    string Scope,
+    string Status,
+    DateTimeOffset LastSuccessfullyProcessed,
+    string CopyToMongoDB);

--- a/Source/CLI/Runtime/Projections/List/ProjectionSimpleView.cs
+++ b/Source/CLI/Runtime/Projections/List/ProjectionSimpleView.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections.List;
+
+/// <summary>
+/// Represents the base information for an Projection.
+/// </summary>
+/// <param name="Projection">The Projection identifier.</param>
+/// <param name="Scope">The Projection Scope.</param>
+/// <param name="Status">The status of the Projection.</param>
+/// <param name="HasCopies">Whether or not the Projection has copies.</param>
+public record ProjectionSimpleView(
+    string Projection,
+    string Scope,
+    string Status,
+    string HasCopies);

--- a/Source/CLI/Runtime/Projections/ManagementClient.cs
+++ b/Source/CLI/Runtime/Projections/ManagementClient.cs
@@ -75,6 +75,26 @@ public class ManagementClient : IManagementClient
         return CreateProjectionStatus(response.Projection);
     }
 
+    /// <inheritdoc />
+    public async Task<Try> Replay(MicroserviceAddress runtime, ScopeId scope, ProjectionId projection, TenantId tenant = null)
+    {
+        var client = _clients.CreateClientFor<ProjectionsClient>(runtime);
+        var request = new ReplayProjectionRequest
+        {
+            ScopeId = scope.ToProtobuf(),
+            ProjectionId = projection.ToProtobuf(),
+            TenantId = tenant?.ToProtobuf(),
+        };
+
+        var response = await client.ReplayAsync(request);
+        if (response.Failure != null)
+        {
+            return new ReplayProjectionFailed(scope, projection, response.Failure.Reason);
+        }
+
+        return Try.Succeeded();
+    }
+
     ProjectionStatus CreateProjectionStatus(ManagementContracts.ProjectionStatus status)
         => new (
             status.ProjectionId.ToGuid(),

--- a/Source/CLI/Runtime/Projections/ManagementClient.cs
+++ b/Source/CLI/Runtime/Projections/ManagementClient.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
+using Dolittle.Runtime.Events.Processing.Management.Contracts;
+using Dolittle.Runtime.Events.Processing.Projections;
+using Dolittle.Runtime.Microservices;
+using Dolittle.Runtime.Protobuf;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using ManagementContracts = Dolittle.Runtime.Events.Processing.Management.Contracts;
+using static Dolittle.Runtime.Events.Processing.Management.Contracts.Projections;
+using UnpartitionedTenantScopedStreamProcessorStatus = Dolittle.Runtime.CLI.Runtime.Events.Processing.UnpartitionedTenantScopedStreamProcessorStatus;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Represents an implementation of <see cref="IManagementClient"/>.
+/// </summary>
+public class ManagementClient : IManagementClient
+{
+    readonly ICanCreateClients _clients;
+    readonly IConvertProjectionDefinitions _definitionConverter;
+    readonly IConvertStreamProcessorStatus _statusConverter;
+
+    public ManagementClient(ICanCreateClients clients, IConvertProjectionDefinitions definitionConverter, IConvertStreamProcessorStatus statusConverter)
+    {
+        _clients = clients;
+        _definitionConverter = definitionConverter;
+        _statusConverter = statusConverter;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<ProjectionStatus>> GetAll(MicroserviceAddress runtime, TenantId tenant = null)
+    {
+        var client = _clients.CreateClientFor<ProjectionsClient>(runtime);
+
+        var request = new GetAllProjectionsRequest
+        {
+            TenantId = tenant?.ToProtobuf()
+        };
+
+        var response = await client.GetAllAsync(request);
+        if (response.Failure != null)
+        {
+            throw new GetAllProjectionsFailed(response.Failure.Reason);
+        }
+
+        return response.Projections.Select(CreateProjectionStatus);
+    }
+
+    ProjectionStatus CreateProjectionStatus(ManagementContracts.ProjectionStatus status)
+        => new (
+            status.ProjectionId.ToGuid(),
+            status.ScopeId.ToGuid(),
+            JsonConvert.DeserializeObject<JObject>(status.InitialState),
+            _definitionConverter.ToRuntimeEventSelectors(status.Events),
+            _definitionConverter.ToRuntimeCopySpecification(status.Copies),
+            status.Alias,
+            _statusConverter.Convert(status.Tenants).Cast<UnpartitionedTenantScopedStreamProcessorStatus>());
+}

--- a/Source/CLI/Runtime/Projections/MultipleProjectionsWithIdentifierOrAliasInScope.cs
+++ b/Source/CLI/Runtime/Projections/MultipleProjectionsWithIdentifierOrAliasInScope.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Store;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// The exception that gets thrown when multiple Projections are registered with the specified Identifier or Alias, in a Scope
+/// </summary>
+public class MultipleProjectionsWithIdentifierOrAliasInScope : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultipleProjectionsWithIdentifierOrAliasInScope"/> class.
+    /// </summary>
+    /// <param name="identifierOrAlias">The identifier or alias of the Projection.</param>
+    /// <param name="scope">The scope of the Projection.</param>
+    /// <param name="count">The number of Projections found.</param>
+    public MultipleProjectionsWithIdentifierOrAliasInScope(string identifierOrAlias, ScopeId scope, int count)
+        : base($"{count} projections with alias '{identifierOrAlias}' was found in scope {scope}. Please use the identifier to specify one")
+    {
+    }
+}

--- a/Source/CLI/Runtime/Projections/NoProjectionWithIdentifierOrAliasInScope.cs
+++ b/Source/CLI/Runtime/Projections/NoProjectionWithIdentifierOrAliasInScope.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Store;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// The exception that gets thrown when no Projection is registered with the specified Identifier or Alias, in a Scope
+/// </summary>
+public class NoProjectionWithIdentifierOrAliasInScope : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NoProjectionWithIdentifierOrAliasInScope"/> class.
+    /// </summary>
+    /// <param name="identifierOrAlias">The identifier or alias of the Projection.</param>
+    /// <param name="scope">The scope of the Projection.</param>
+    public NoProjectionWithIdentifierOrAliasInScope(string identifierOrAlias, ScopeId scope)
+        : base($"No projection with identifier or alias '{identifierOrAlias}' was found in scope {scope}")
+    {
+    }
+}

--- a/Source/CLI/Runtime/Projections/ProjectionIdAndScopeResolver.cs
+++ b/Source/CLI/Runtime/Projections/ProjectionIdAndScopeResolver.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Microservices;
+using Dolittle.Runtime.Rudimentary;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Represents an implementation of <see cref="IResolveProjectionIdAndScope"/>.
+/// </summary>
+public class ProjectionIdAndScopeResolver : IResolveProjectionIdAndScope
+{
+    readonly IManagementClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectionIdAndScopeResolver"/> class.
+    /// </summary>
+    /// <param name="client">The management client to use to get all registered projections.</param>
+    public ProjectionIdAndScopeResolver(IManagementClient client)
+    {
+        _client = client;
+    }
+
+    /// <inheritdoc />
+    public async Task<Try<ProjectionIdentifierAndScope>> Resolve(MicroserviceAddress runtime, string identifierOrAlias, ScopeId scope = null)
+    {
+        var projections = await _client.GetAll(runtime).ConfigureAwait(false);
+
+        var matchesWithoutScope = projections.Where(projection =>
+            projection.HasAlias
+                ? projection.Alias.Value == identifierOrAlias
+                : projection.Id.ToString() == identifierOrAlias
+        ).ToList();
+
+        if (matchesWithoutScope.Count == 1)
+        {
+            return new ProjectionIdentifierAndScope(matchesWithoutScope[0].Id, matchesWithoutScope[0].Scope);
+        }
+
+        scope ??= ScopeId.Default;
+        var matchesWithScope = matchesWithoutScope.Where(projection => projection.Scope == scope).ToList();
+
+        if (matchesWithScope.Count == 1)
+        {
+            return new ProjectionIdentifierAndScope(matchesWithScope[0].Id, matchesWithScope[0].Scope);
+        }
+
+        if (matchesWithoutScope.Count > 1)
+        {
+            return new MultipleProjectionsWithIdentifierOrAliasInScope(identifierOrAlias, scope, matchesWithoutScope.Count);
+        }
+
+        return new NoProjectionWithIdentifierOrAliasInScope(identifierOrAlias, scope);
+    }
+}

--- a/Source/CLI/Runtime/Projections/ProjectionIdentifierAndScope.cs
+++ b/Source/CLI/Runtime/Projections/ProjectionIdentifierAndScope.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Projections.Store;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Represents the unique pair of <see cref="ProjectionId"/> and <see cref="ScopeId"/> that identifies a Projection.
+/// </summary>
+/// <param name="Identifier">The <see cref="ProjectionId"/> of the Projection.</param>
+/// <param name="Scope">The <see cref="ScopeId"/> of the Projection.</param>
+public record ProjectionIdentifierAndScope(ProjectionId Identifier, ScopeId Scope);

--- a/Source/CLI/Runtime/Projections/ProjectionStatus.cs
+++ b/Source/CLI/Runtime/Projections/ProjectionStatus.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
+using Dolittle.Runtime.Events.Processing.Projections;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Projections.Store;
+using Dolittle.Runtime.Projections.Store.Definition;
+using Dolittle.Runtime.Projections.Store.Definition.Copies;
+using Newtonsoft.Json.Linq;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+public record ProjectionStatus(
+    ProjectionId Id,
+    ScopeId Scope,
+    JObject InitialState,
+    IEnumerable<ProjectionEventSelector> Events,
+    ProjectionCopySpecification Copies,
+    ProjectionAlias Alias,
+    IEnumerable<UnpartitionedTenantScopedStreamProcessorStatus> States)
+{
+    
+    /// <summary>
+    /// Gets a value indicating whether the Projection has an alias.
+    /// </summary>
+    public bool HasAlias => !Alias.Equals(ProjectionAlias.NotSet);
+        
+    /// <summary>
+    /// Gets a value indicating whether the Projection is in the default Scope.
+    /// </summary>
+    public bool IsInDefaultScope => Scope.Equals(ScopeId.Default);
+}

--- a/Source/CLI/Runtime/Projections/Replay/Command.cs
+++ b/Source/CLI/Runtime/Projections/Replay/Command.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Dolittle.Runtime.ApplicationModel;
+using Dolittle.Runtime.CLI.Runtime.EventTypes;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Serialization.Json;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections.Replay;
+
+/// <summary>
+/// The "dolittle runtime projections replay" command.
+/// </summary>
+[Command("replay", Description = "Replay a Projection")]
+public class Command : CommandBase
+{
+    readonly IManagementClient _client;
+    readonly IResolveProjectionIdAndScope _resolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Command"/> class.
+    /// </summary>
+    /// <param name="client">The management client to use to get all registered Projections.</param>
+    /// <param name="resolver">The resolver to use to resolve arguments to a Projection.</param>
+    /// <param name="runtimes">The locator to use to find the Runtime to connect to.</param>
+    /// <param name="eventTypesDiscoverer">The event types discoverer to use to discover event types.</param>
+    /// <param name="jsonSerializer">The JSON serializer to use.</param>
+    public Command(IManagementClient client, IResolveProjectionIdAndScope resolver, ICanLocateRuntimes runtimes, IDiscoverEventTypes eventTypesDiscoverer, ISerializer jsonSerializer)
+        : base(runtimes, eventTypesDiscoverer, jsonSerializer)
+    {
+        _client = client;
+        _resolver = resolver;
+    }
+    
+        
+    /// <summary>
+    /// The "--tenant" argument used to specify a single Tenant to replay a Projection for.
+    /// </summary>
+    [Option("--tenant", CommandOptionType.SingleValue, Description = "Only replay the Projection for a specific Tenant")]
+    TenantId Tenant { get; init; }
+    
+    /// <summary>
+    /// The Projection identifier argument used to provide the identifier of the Projection to replay.
+    /// </summary>
+    [Required]
+    [Argument(0, Description = "The identifier or alias of the Projection to replay")]
+    string IdentifierOrAlias { get; init; }
+    
+    /// <summary>
+    /// The Projection scope argument used to provide the identifier of the Projection to replay.
+    /// </summary>
+    [Argument(1, Description = "The scope of the Projection to replay")]
+    ScopeId Scope { get; init; }
+    
+    /// <summary>
+    /// The entrypoint for the "dolittle runtime eventhandlers replay" command.
+    /// </summary>
+    /// <param name="cli">The <see cref="CommandLineApplication"/> that is executed.</param>
+    public async Task OnExecuteAsync(CommandLineApplication cli)
+    {
+        var runtimeAddress = await SelectRuntimeToConnectTo(cli);
+        if (!runtimeAddress.Success)
+        {
+            return;
+        }
+
+        var getIdentity= await _resolver.Resolve(runtimeAddress, IdentifierOrAlias, Scope);
+        if (!getIdentity.Success)
+        {
+            throw getIdentity.Exception;
+        }
+
+        var ( projectionId, scopeId ) = getIdentity.Result;
+        var replaying = await _client.Replay(runtimeAddress, scopeId, projectionId, Tenant).ConfigureAwait(false);
+
+        if (!replaying.Success)
+        {
+            throw replaying.Exception;
+        }
+    }
+}

--- a/Source/CLI/Runtime/Projections/ReplayProjectionFailed.cs
+++ b/Source/CLI/Runtime/Projections/ReplayProjectionFailed.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Projections.Store;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+/// <summary>
+/// Exception that gets thrown when replaying a Projection fails.
+/// </summary>
+public class ReplayProjectionFailed : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplayProjectionFailed"/> class.
+    /// </summary>
+    /// <param name="scope">The scope of the Projection.</param>
+    /// <param name="projection">The id of the Projection.</param>
+    /// <param name="reason">The reason why replaying the Projection failed.</param>
+    public ReplayProjectionFailed(ScopeId scope, ProjectionId projection, string reason)
+        : base($"Could not replay projection {projection} in scope {scope} because {reason}")
+    {
+    }
+}

--- a/Source/CLI/Runtime/Projections/ServiceCollectionExtensions.cs
+++ b/Source/CLI/Runtime/Projections/ServiceCollectionExtensions.cs
@@ -16,6 +16,6 @@ public static class ServiceCollectionExtensions
     {
         services.AddTransient<IManagementClient, ManagementClient>();
         services.AddTransient<IConvertProjectionDefinitions, ConvertProjectionDefinitions>();
-        //services.AddTransient<IResolveEventHandlerId, EventHandlerIdResolver>();
+        services.AddTransient<IResolveProjectionIdAndScope, ProjectionIdAndScopeResolver>();
     }
 }

--- a/Source/CLI/Runtime/Projections/ServiceCollectionExtensions.cs
+++ b/Source/CLI/Runtime/Projections/ServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Events.Processing.Projections;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dolittle.Runtime.CLI.Runtime.Projections;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds services related to management of Projections.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    public static void AddProjectionServices(this IServiceCollection services)
+    {
+        services.AddTransient<IManagementClient, ManagementClient>();
+        services.AddTransient<IConvertProjectionDefinitions, ConvertProjectionDefinitions>();
+        //services.AddTransient<IResolveEventHandlerId, EventHandlerIdResolver>();
+    }
+}

--- a/Source/CLI/Runtime/ServiceCollectionExtensions.cs
+++ b/Source/CLI/Runtime/ServiceCollectionExtensions.cs
@@ -4,7 +4,9 @@
 using Docker.DotNet;
 using Dolittle.Runtime.CLI.Runtime.Aggregates;
 using Dolittle.Runtime.CLI.Runtime.EventHandlers;
+using Dolittle.Runtime.CLI.Runtime.Events.Processing;
 using Dolittle.Runtime.CLI.Runtime.EventTypes;
+using Dolittle.Runtime.CLI.Runtime.Projections;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Dolittle.Runtime.CLI.Runtime;
@@ -23,8 +25,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDockerClient>(provider =>
             new DockerClientConfiguration().CreateClient());
             
-        services.AddEventHandlerServices();
         services.AddAggregatesServices();
+        services.AddEventHandlerServices();
         services.AddEventTypesServices();
+        services.AddEventsProcessingServices();
+        services.AddProjectionServices();
     }
 }


### PR DESCRIPTION
## Summary

Implements the "runtime projections list", "runtime projections get" and "runtime projections replay" commands in the CLI. The list and get outputs are mostly copies of the tabular structure for Event Handlers. The replay has fewer options than Event Handlers, since it only really makes sense to replay a Projection from the beginning.