### PR TITLE
Add the M1 contrib package to the CLI

### DIFF
--- a/Source/CLI/CLI.csproj
+++ b/Source/CLI/CLI.csproj
@@ -28,6 +28,7 @@
 
     <ItemGroup>
         <PackageReference Include="ConsoleTables" Version="$(ConsoleTablesVersion)" />
+        <PackageReference Include="Contrib.Grpc.Core.M1" Version="$(GrpcVersion)" />
         <PackageReference Include="Docker.DotNet" Version="$(DockerDotNetVersion)" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterVersion)" />


### PR DESCRIPTION
## Summary

Add the gRPC M1 Contrib package to the CLI so that it can run on Apple M1 chips.