### PR TITLE
When filter result is failed it should log it

### DIFF
--- a/Source/Events.Processing/Filters/Log.cs
+++ b/Source/Events.Processing/Filters/Log.cs
@@ -28,6 +28,9 @@ static partial class Log
 
     [LoggerMessage(0, LogLevel.Debug, "Filter: {Filter} in scope: {Scope} is writing event type: {EventType} to partition: {Partition} in stream: {Stream}")]
     internal static partial void FilteredEventIsIncluded(this ILogger logger, EventProcessorId filter, ScopeId scope, ArtifactId eventType, PartitionId partition, StreamId stream);
+    
+    [LoggerMessage(0, LogLevel.Warning, "Filter: {Filter} in scope: {Scope} failed filtering event type: {EventType}")]
+    internal static partial void FailedToFilterEvent(this ILogger logger, EventProcessorId filter, ScopeId scope, ArtifactId eventType);
 
     [LoggerMessage(0, LogLevel.Trace, "Finding validator for filter: {Filter}")]
     internal static partial void FindingFilterValidator(this ILogger logger, EventProcessorId filter);

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_filtering_failed.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_filtering_failed.cs
@@ -12,13 +12,16 @@ using It = Machine.Specifications.It;
 
 namespace Dolittle.Runtime.Events.Processing.Filters.for_AbstractFilterProcessor.when_processing;
 
-public class and_event_is_not_included : given.all_dependencies
+public class and_filtering_failed : given.all_dependencies
 {
     static IProcessingResult result;
     static PartitionId partition;
 
+    static IFilterResult failed_result;
+
     Establish context = () =>
     {
+        failed_result = new FailedFiltering("some error");
         partition = "   weird partition   ";
         filter_processor
             .Setup(_ => _.Filter(
@@ -27,10 +30,10 @@ public class and_event_is_not_included : given.all_dependencies
                 Moq.It.IsAny<EventProcessorId>(),
                 Moq.It.IsAny<ExecutionContext>(),
                 Moq.It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult<IFilterResult>(new SuccessfulFiltering(false, partition)));
+            .Returns(Task.FromResult(failed_result));
     };
 
     Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
     It should_not_write_stream = () => events_to_streams_writer.Verify(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Times.Never);
-    It should_return_successful_processing_result = () => result.Succeeded.ShouldBeTrue();
+    It should_return_the_failed_result = () => result.ShouldEqual(failed_result);
 }

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_writing_filtered_event_fails.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_writing_filtered_event_fails.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Machine.Specifications;
+using Moq;
+using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
+using It = Machine.Specifications.It;
+using ReturnsExtensions = Moq.ReturnsExtensions;
+
+namespace Dolittle.Runtime.Events.Processing.Filters.for_AbstractFilterProcessor.when_processing;
+
+public class and_writing_filtered_event_fails : given.all_dependencies
+{
+    static IProcessingResult result;
+    static PartitionId partition;
+
+    Establish context = () =>
+    {
+        ReturnsExtensions.ThrowsAsync(events_to_streams_writer
+                .Setup(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>())), new Exception("some error"));
+        partition = "   weird partition   ";
+        ReturnsExtensions.ReturnsAsync(filter_processor
+                .Setup(_ => _.Filter(
+                    Moq.It.IsAny<CommittedEvent>(),
+                    Moq.It.IsAny<PartitionId>(),
+                    Moq.It.IsAny<EventProcessorId>(),
+                    Moq.It.IsAny<ExecutionContext>(),
+                    Moq.It.IsAny<CancellationToken>())), new SuccessfulFiltering(true));
+    };
+
+    Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
+    It should_write_stream = () => events_to_streams_writer.Verify(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Times.Once);
+    It should_return_failed_result = () => result.Succeeded.ShouldBeFalse();
+}

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_writing_filtered_event_fails.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_writing_filtered_event_fails.cs
@@ -20,16 +20,16 @@ public class and_writing_filtered_event_fails : given.all_dependencies
 
     Establish context = () =>
     {
-        ReturnsExtensions.ThrowsAsync(events_to_streams_writer
-                .Setup(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>())), new Exception("some error"));
+        events_to_streams_writer
+            .Setup(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>())).ThrowsAsync(new Exception("some error"));
         partition = "   weird partition   ";
-        ReturnsExtensions.ReturnsAsync(filter_processor
-                .Setup(_ => _.Filter(
-                    Moq.It.IsAny<CommittedEvent>(),
-                    Moq.It.IsAny<PartitionId>(),
-                    Moq.It.IsAny<EventProcessorId>(),
-                    Moq.It.IsAny<ExecutionContext>(),
-                    Moq.It.IsAny<CancellationToken>())), new SuccessfulFiltering(true));
+        filter_processor
+            .Setup(_ => _.Filter(
+                Moq.It.IsAny<CommittedEvent>(),
+                Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<EventProcessorId>(),
+                Moq.It.IsAny<ExecutionContext>(),
+                Moq.It.IsAny<CancellationToken>())).ReturnsAsync(new SuccessfulFiltering(true));
     };
 
     Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary

When AbstractFilterProcessor handles a failed filtering result it logs that it failed filtering. Also catches exceptions when trying to write to the filtered stream, so that it is handled the same way as any other event processing failure.
