### PR TITLE
Hinder event horizon from polling the event store

### DIFF
--- a/Source/EventHorizon/Consumer/Processing/EventsFromEventHorizonFetcher.cs
+++ b/Source/EventHorizon/Consumer/Processing/EventsFromEventHorizonFetcher.cs
@@ -47,6 +47,10 @@ public class EventsFromEventHorizonFetcher : ICanFetchEventsFromStream, IStreamE
         }
     }
 
+    /// <inheritdoc />
+    public async Task<Try<StreamPosition>> GetNextStreamPosition(CancellationToken cancellationToken)
+        => new NotImplementedException();
+
     /// <inheritdoc/>
     public void NotifyForEvent(ScopeId scope, StreamId stream, StreamPosition position)
     {

--- a/Source/EventHorizon/Consumer/Processing/EventsFromEventHorizonFetcher.cs
+++ b/Source/EventHorizon/Consumer/Processing/EventsFromEventHorizonFetcher.cs
@@ -49,7 +49,7 @@ public class EventsFromEventHorizonFetcher : ICanFetchEventsFromStream, IStreamE
 
     /// <inheritdoc />
     public async Task<Try<StreamPosition>> GetNextStreamPosition(CancellationToken cancellationToken)
-        => new NotImplementedException();
+        => new NotImplementedException("GetNextStreamPosition should never be used on this specific fetcher");
 
     /// <inheritdoc/>
     public void NotifyForEvent(ScopeId scope, StreamId stream, StreamPosition position)

--- a/Source/EventHorizon/Producer/EventHorizon.cs
+++ b/Source/EventHorizon/Producer/EventHorizon.cs
@@ -149,9 +149,14 @@ public class EventHorizon : IDisposable
                         _cancellationTokenSource.Token).ConfigureAwait(false);
                     if (!tryGetStreamEvent.Success)
                     {
+                        var nextPosition = await publicEvents.GetNextStreamPosition(_cancellationTokenSource.Token).ConfigureAwait(false);
+                        if (!nextPosition.Success)
+                        {
+                            throw nextPosition.Exception;
+                        }
                         await eventWaiter.WaitForEvent(
                             Id.PublicStream,
-                            CurrentPosition,
+                            nextPosition,
                             TimeSpan.FromMinutes(1),
                             _cancellationTokenSource.Token).ConfigureAwait(false);
                         continue;

--- a/Source/EventHorizon/Producer/EventHorizon.cs
+++ b/Source/EventHorizon/Producer/EventHorizon.cs
@@ -149,14 +149,14 @@ public class EventHorizon : IDisposable
                         _cancellationTokenSource.Token).ConfigureAwait(false);
                     if (!tryGetStreamEvent.Success)
                     {
-                        var nextPosition = await publicEvents.GetNextStreamPosition(_cancellationTokenSource.Token).ConfigureAwait(false);
-                        if (!nextPosition.Success)
+                        var nextEventPositionInAnyPartition = await publicEvents.GetNextStreamPosition(_cancellationTokenSource.Token).ConfigureAwait(false);
+                        if (!nextEventPositionInAnyPartition.Success)
                         {
-                            throw nextPosition.Exception;
+                            throw nextEventPositionInAnyPartition.Exception;
                         }
                         await eventWaiter.WaitForEvent(
                             Id.PublicStream,
-                            nextPosition,
+                            nextEventPositionInAnyPartition,
                             TimeSpan.FromMinutes(1),
                             _cancellationTokenSource.Token).ConfigureAwait(false);
                         continue;

--- a/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
@@ -111,6 +111,20 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
         }
     }
 
+    /// <inheritdoc />
+    public async Task<Try<StreamPosition>> GetNextStreamPosition(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var numEvents = await _collection.CountDocumentsAsync(_filter.Empty, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return Try<StreamPosition>.Succeeded((ulong)numEvents);
+        }
+        catch (MongoWaitQueueFullException ex)
+        {
+            throw new EventStoreUnavailable("Mongo wait queue is full", ex);
+        }
+    }
+
     /// <inheritdoc/>
     public async Task<Try<IEnumerable<StreamEvent>>> FetchInPartition(PartitionId partitionId, StreamPosition streamPosition, CancellationToken cancellationToken)
     {

--- a/Source/Events.Store/Streams/ICanFetchEventsFromStream.cs
+++ b/Source/Events.Store/Streams/ICanFetchEventsFromStream.cs
@@ -22,7 +22,7 @@ public interface ICanFetchEventsFromStream
     Task<Try<IEnumerable<StreamEvent>>> Fetch(StreamPosition streamPosition, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets the current <see cref="StreamPosition"/> offset. 
+    /// Gets the <see cref="StreamPosition"/> that will be used for the next event written to the stream. 
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
     /// <returns>The <see cref="StreamPosition"/> offset.</returns>

--- a/Source/Events.Store/Streams/ICanFetchEventsFromStream.cs
+++ b/Source/Events.Store/Streams/ICanFetchEventsFromStream.cs
@@ -20,4 +20,11 @@ public interface ICanFetchEventsFromStream
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns>The <see cref="StreamEvent" />.</returns>
     Task<Try<IEnumerable<StreamEvent>>> Fetch(StreamPosition streamPosition, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the current <see cref="StreamPosition"/> offset. 
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns>The <see cref="StreamPosition"/> offset.</returns>
+    Task<Try<StreamPosition>> GetNextStreamPosition(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary

Fixes an issue introduced many versions ago related to event horizon producer non-stop polling the event store for an event that isn't there