### PR TITLE
Fixes OutOfMemoryException during public filter validation

### DIFF
--- a/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
+++ b/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
@@ -128,10 +128,12 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
                 event_handler.Info.Id.EventHandler.Value,
                 event_handler.Info.EventTypes,
                 event_handler.Info.Partitioned)), CancellationToken.None).Result;
-
+        
         return rangeFetcher
             .FetchRange(new StreamPositionRange(StreamPosition.Start, ulong.MaxValue), CancellationToken.None)
-            .Result
+            .ToListAsync()
+            .GetAwaiter()
+            .GetResult()
             .Where(_ => _.Event.EventSource.Value == partition_id.Value);
     }
 

--- a/Source/Events.Store.MongoDB/Events.Store.MongoDB.csproj
+++ b/Source/Events.Store.MongoDB/Events.Store.MongoDB.csproj
@@ -15,6 +15,7 @@
         <ProjectReference Include="../Artifacts/Artifacts.csproj" />
         <ProjectReference Include="../EventHorizon/EventHorizon.csproj" />
         <ProjectReference Include="../Events.Processing/Events.Processing.csproj" />
+        <ProjectReference Include="../MongoDB/MongoDB.csproj" />
         <ProjectReference Include="../Events.Store/Events.Store.csproj" />
         <ProjectReference Include="../Aggregates/Aggregates.csproj" />
     </ItemGroup>

--- a/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
@@ -155,11 +155,11 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
     {
         try
         {
-            var maxNumEvents = range.Length;
             return _collection.Find(
                     _filter.Gte(_sequenceNumberExpression, range.From.Value)
                     & _filter.Lt(_sequenceNumberExpression, range.From.Value + range.Length))
-                .Project(_eventToStreamEvent).ToAsyncEnumerable(cancellationToken);
+                .Project(_eventToStreamEvent)
+                .ToAsyncEnumerable(cancellationToken);
         }
         catch (MongoWaitQueueFullException ex)
         {

--- a/Source/Events.Store/Streams/ICanFetchRangeOfEventsFromStream.cs
+++ b/Source/Events.Store/Streams/ICanFetchRangeOfEventsFromStream.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Dolittle.Runtime.Events.Store.Streams;
 
@@ -13,10 +12,10 @@ namespace Dolittle.Runtime.Events.Store.Streams;
 public interface ICanFetchRangeOfEventsFromStream
 {
     /// <summary>
-    /// Fetch a range of events in an incluse <see cref="StreamPositionRange" /> in a <see cref="StreamId">stream</see>.
+    /// Fetch a range of events in an include <see cref="StreamPositionRange" /> in a <see cref="StreamId">stream</see>.
     /// </summary>
     /// <param name="range">The <see cref="StreamPositionRange" />.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-    /// <returns>The <see cref="IEnumerable{T}" /> of <see cref="StreamEvent" />.</returns>
-    Task<IEnumerable<StreamEvent>> FetchRange(StreamPositionRange range, CancellationToken cancellationToken);
+    /// <returns>The <see cref="IAsyncEnumerable{T}" /> of <see cref="StreamEvent" />.</returns>
+    IAsyncEnumerable<StreamEvent> FetchRange(StreamPositionRange range, CancellationToken cancellationToken);
 }

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/given/all_dependencies.cs
@@ -55,10 +55,10 @@ public class all_dependencies
 
         events_from_event_log_fetcher
             .Setup(_ => _.FetchRange(Moq.It.IsAny<StreamPositionRange>(), cancellation_token))
-            .Returns<StreamPositionRange, CancellationToken>((range, _) => Task.FromResult(events_in_event_log.Where(_ => _.Position >= range.From && _.Position < range.From + range.Length)));
+            .Returns<StreamPositionRange, CancellationToken>((range, _) => events_in_event_log.Where(_ => _.Position >= range.From && _.Position < range.From + range.Length).ToAsyncEnumerable());
         events_from_filtered_stream_fetcher
             .Setup(_ => _.FetchRange(Moq.It.IsAny<StreamPositionRange>(), cancellation_token))
-            .Returns<StreamPositionRange, CancellationToken>((range, _) => Task.FromResult(events_in_filtered_stream.Where(_ => _.Position >= range.From && _.Position < range.From + range.Length)));
+            .Returns<StreamPositionRange, CancellationToken>((range, _) => events_in_filtered_stream.Where(_ => _.Position >= range.From && _.Position < range.From + range.Length).ToAsyncEnumerable());
 
         events_fetchers
             .Setup(_ => _.GetRangeFetcherFor(scope_id, new EventLogStreamDefinition(), cancellation_token))

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_fetching_the_old_stream_events_fails.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_fetching_the_old_stream_events_fails.cs
@@ -16,7 +16,7 @@ public class and_fetching_the_old_stream_events_fails : given.all_dependencies
     {
         events_from_filtered_stream_fetcher
             .Setup(_ => _.FetchRange(new StreamPositionRange(StreamPosition.Start, ulong.MaxValue), cancellation_token))
-            .Returns(Task.FromException<IEnumerable<StreamEvent>>(new Exception()));
+            .Throws(new Exception());
     };
 
     static FilterValidationResult result;

--- a/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_fetching_the_source_stream_events_fails.cs
+++ b/Specifications/Events.Processing/Filters/for_ValidateFilterByComparingStreams/when_validating/and_fetching_the_source_stream_events_fails.cs
@@ -16,7 +16,7 @@ public class and_fetching_the_source_stream_events_fails : given.all_dependencie
     {
         events_from_event_log_fetcher
             .Setup(_ => _.FetchRange(new StreamPositionRange(StreamPosition.Start, 10), cancellation_token))
-            .Returns(Task.FromException<IEnumerable<StreamEvent>>(new Exception()));
+            .Throws(new Exception());
     };
 
     static FilterValidationResult result;


### PR DESCRIPTION
## Summary

The filter validator for public filters would take the whole event log into memory and compare filtered streams in memory. This could cause OutOfMemoryException if the event log is big enough

### Fixed

- Fixes `OutOfMemoryException` caused by filter validator for public filters.
