### PR TITLE
Throw a friendlier exception when failing to resolve tenant specific …

### DIFF
--- a/Source/DependencyInversion/Tenancy/FailedToResolveServiceForTenant.cs
+++ b/Source/DependencyInversion/Tenancy/FailedToResolveServiceForTenant.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Runtime.Domain.Tenancy;
+
+namespace Dolittle.Runtime.DependencyInversion.Tenancy;
+
+/// <summary>
+/// Exception that gets thrown when autofac fails to resolve a tenant specific service.
+/// </summary>
+public class FailedToResolveServiceForTenant : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FailedToResolveServiceForTenant"/> class.
+    /// </summary>
+    /// <param name="tenant">The tenant id it fails to resolve service for.</param>
+    /// <param name="service">The service it fails to resolve.</param>
+    /// <param name="resolutionException">The inner autofac resolution exception.</param>
+    public FailedToResolveServiceForTenant(TenantId tenant, Type service, Exception resolutionException)
+        : base($"Failed to resolve tenant specific service {service} for tenant {tenant}", resolutionException)
+    {
+    }
+}

--- a/Source/DependencyInversion/Tenancy/GeneratedTenantFactoryRegistrationSource.cs
+++ b/Source/DependencyInversion/Tenancy/GeneratedTenantFactoryRegistrationSource.cs
@@ -39,7 +39,14 @@ public class GeneratedTenantFactoryRegistrationSource : IRegistrationSource
             {
                 var provider = providers.ForTenant(tenant);
                 var resolver = provider.GetRequiredService(tenantDelegateToResolve) as Delegate;
-                return resolver?.DynamicInvoke(arguments); //TODO: Null check?
+                try
+                {
+                    return resolver?.DynamicInvoke(arguments); //TODO: Null check?
+                }
+                catch (Exception e)
+                {
+                    throw new FailedToResolveServiceForTenant(tenant, resolvedType, e);
+                }
             };
 
         var generatedDelegateParameters = parameters.Select(_ => Expression.Parameter(_.ParameterType, _.Name)).ToList();


### PR DESCRIPTION
## Summary

When a service for a specific tenant failed to be resolved the exception wasn't particularly helpful.

### Changed

- A more helpful exception is thrown when failing to resolve a tenant specific service