### PR TITLE
Properly dispose reverse call dispatcher

### DIFF
--- a/Source/Embeddings.Processing/EmbeddingsService.cs
+++ b/Source/Embeddings.Processing/EmbeddingsService.cs
@@ -94,7 +94,8 @@ public class EmbeddingsService : EmbeddingsBase
         {
             return;
         }
-        var (dispatcher, arguments) = connection.Result;
+        using var dispatcher = connection.Result.dispatcher;
+        var arguments = connection.Result.arguments;
 
         var tryCreateExecutionContext = _executionContextCreator.TryCreateUsing(arguments.ExecutionContext);
         if (!tryCreateExecutionContext.Success)

--- a/Source/EventHorizon/Consumer/Processing/Log.cs
+++ b/Source/EventHorizon/Consumer/Processing/Log.cs
@@ -12,7 +12,7 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Processing;
 
 static partial class Log
 {
-    [LoggerMessage(0, LogLevel.Debug, "Event Store is unavailable")]
+    [LoggerMessage(0, LogLevel.Warning, "Event Store is unavailable")]
     internal static partial void EventStoreIsUnavailable(ILogger logger, EventStoreUnavailable ex);
 
     [LoggerMessage(0, LogLevel.Warning, "Stream Processor not starting because cancellation was requested for subscription {SubscriptionId}")]

--- a/Source/EventHorizon/Producer/EventHorizon.cs
+++ b/Source/EventHorizon/Producer/EventHorizon.cs
@@ -179,8 +179,9 @@ public class EventHorizon : IDisposable
                         CurrentPosition = streamEvent.Position + 1;
                     }
                 }
-                catch (EventStoreUnavailable)
+                catch (EventStoreUnavailable e)
                 {
+                    _logger.LogWarning(e, "Event Store unavailable. Waiting 1 second");
                     await Task.Delay(1000).ConfigureAwait(false);
                 }
             }

--- a/Source/Events.Processing/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing/EventHandlers/EventHandlersService.cs
@@ -74,7 +74,8 @@ public class EventHandlersService : EventHandlersBase
                 return;
             }
             
-            var (dispatcher, arguments) = connectResult.Result;
+            using var dispatcher = connectResult.Result.dispatcher;
+            var arguments = connectResult.Result.arguments;
             using var eventHandler = _configuration.Value.Fast
                 ? _eventHandlerFactory.CreateFast(arguments, _configuration.Value.ImplicitFilter, dispatcher, context.CancellationToken)
                 : _eventHandlerFactory.Create(arguments, dispatcher, context.CancellationToken); 

--- a/Source/Events.Processing/Filters/FiltersService.cs
+++ b/Source/Events.Processing/Filters/FiltersService.cs
@@ -137,7 +137,8 @@ public class FiltersService : FiltersBase
         {
             return;
         }
-        var (dispatcher, arguments) = tryConnect.Result;
+        using var dispatcher = tryConnect.Result.dispatcher;
+        var arguments = tryConnect.Result.arguments;
         var createExecutionContext = await CreateExecutionContextOrReject(dispatcher, arguments.ExecutionContext, cts.Token).ConfigureAwait(false);
         if (!createExecutionContext.Success)
         {
@@ -184,7 +185,8 @@ public class FiltersService : FiltersBase
         {
             return;
         }
-        var (dispatcher, arguments) = tryConnect.Result;
+        using var dispatcher = tryConnect.Result.dispatcher;
+        var arguments = tryConnect.Result.arguments;
         var createExecutionContext = await CreateExecutionContextOrReject(dispatcher, arguments.ExecutionContext, cts.Token).ConfigureAwait(false);
         if (!createExecutionContext.Success)
         {
@@ -232,7 +234,8 @@ public class FiltersService : FiltersBase
         {
             return;
         }
-        var (dispatcher, arguments) = tryConnect.Result;
+        using var dispatcher = tryConnect.Result.dispatcher;
+        var arguments = tryConnect.Result.arguments;
         var createExecutionContext = await CreateExecutionContextOrReject(dispatcher, arguments.ExecutionContext, cts.Token).ConfigureAwait(false);
         if (!createExecutionContext.Success)
         {

--- a/Source/Events.Processing/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing/Projections/ProjectionsService.cs
@@ -70,7 +70,8 @@ public class ProjectionsService : ProjectionsBase
         {
             return;
         }
-        var (dispatcher, arguments) = tryConnect.Result;
+        using var dispatcher = tryConnect.Result.dispatcher;
+        var arguments = tryConnect.Result.arguments;
         var executionContext = arguments.ExecutionContext;
         var definition = arguments.ProjectionDefinition;
 

--- a/Source/Events.Processing/Streams/Log.cs
+++ b/Source/Events.Processing/Streams/Log.cs
@@ -44,7 +44,7 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Warning, "{StreamProcessorId} for tenant {TenantId} failed")]
     internal static partial void StreamProcessingForTenantFailed(ILogger logger, Exception ex, IStreamProcessorId streamProcessorId, TenantId tenantId);
 
-    [LoggerMessage(0, LogLevel.Debug, "Event Store is unavailable")]
+    [LoggerMessage(0, LogLevel.Warning, "Event Store is unavailable")]
     internal static partial void EventStoreUnavailable(ILogger logger, EventStoreUnavailable ex);
     
     [LoggerMessage(0, LogLevel.Warning, "Could not persist stream processor state to the event store, will retry in one second.")]

--- a/Specifications/Embeddings.Processing/for_EmbeddingsService/when_connecting/and_an_embedding_processor_is_already_registered.cs
+++ b/Specifications/Embeddings.Processing/for_EmbeddingsService/when_connecting/and_an_embedding_processor_is_already_registered.cs
@@ -60,7 +60,8 @@ public class and_an_embedding_processor_is_already_registered : given.all_depend
             IsAny<CancellationToken>()),
         Once);
 
-
+    It should_dispose_reverse_call_dispathcer = () => dispatcher.Verify(_ => _.Dispose(), AtLeastOnce);
+    
     It should_not_persist_definition = () => embedding_definition_persister.Verify(_ => _.TryPersist(embedding_definition, IsAny<CancellationToken>()), Never);
     It should_not_do_anything_else_with_dispatcher = () => dispatcher.VerifyNoOtherCalls();
     It should_check_whether_embedding_is_already_registered = () => embedding_processors.Verify(_ => _.HasEmbeddingProcessors(embedding_id), Once);


### PR DESCRIPTION
## Summary

### Changed

- Log warning instead of debug when event store is unavailable

### Fixed

- Dispose correctly of reverse call dispatcher
