### PR TITLE
Cron update table

### DIFF
--- a/.github/workflows/compatibility-table-update.yml
+++ b/.github/workflows/compatibility-table-update.yml
@@ -1,0 +1,30 @@
+name: Update Runtime <-> SDK compatibility table for Documentation
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    name: Recalculate and commit new table
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BUILD_PAT }}
+      - name: Run dolittle/contracts-compatibility tool
+        run: docker run --pull=always dolittle/contracts-compatibility | tee generated-compatibility-table.md
+      - name: Merge generated table with template
+        id: update
+        run: ./Documentation/merge-compatibility-table-template.sh generated-compatibility-table.md
+      - name: Commit and push changes
+        if: ${{ steps.update.outputs.changed == 'true' }}
+        run: |
+          git config user.name dolittle-build
+          git config user.email build@dolittle.com
+          git add Documentation/References/compatibility.md
+          git commit -m "Automatic update of compatibility table"
+          git push

--- a/Documentation/References/compatibility.md
+++ b/Documentation/References/compatibility.md
@@ -4,6 +4,7 @@ description: Runtime compatibility table
 weight: 1
 ---
 
+<!-- BEGIN TABLE -->
 ## By Runtime version:
 |    Runtime    |   DotNET SDK    | JavaScript SDK  |
 |---------------|-----------------|-----------------|
@@ -59,3 +60,5 @@ weight: 1
 | 18.0.0          | 7.0.0 - 7.8.1 |
 | 15.0.0 - 17.0.3 | 6.1.0 - 6.2.2 |
 | 14.3.0 - 14.4.0 | 5.5.0 - 5.6.0 |
+
+<!-- END TABLE -->

--- a/Documentation/merge-compatibility-table-template.sh
+++ b/Documentation/merge-compatibility-table-template.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+TEMPLATE="Documentation/References/compatibility.md"
+GENERATED="$1"
+
+if [ ! -f "$GENERATED" ]; then
+    echo "The provided generated file '$GENERATED', is not valid!"
+    exit 1
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "The template file '$TEMPLATE', is not valid!"
+    exit 1
+fi
+
+echo "Merging '$GENERATED' into '$TEMPLATE' ..."
+
+HEAD=$(sed -ne '1,/<!-- BEGIN TABLE -->/p' <"$TEMPLATE")
+TAIL=$(sed -ne '/<!-- END TABLE -->/,$p' <"$TEMPLATE")
+
+echo "$HEAD" > "$TEMPLATE"
+cat "$GENERATED" >> "$TEMPLATE"
+echo "$TAIL" >> "$TEMPLATE"
+
+git diff --quiet "$TEMPLATE"
+CHANGED=$?
+
+function set_github_output {
+    if [ "$CI" == "true" ]; then
+      echo "::set-output name=$1::$2"
+    fi
+}
+
+if [ "$CHANGED" ]; then 
+    echo "The update has changed the compatibility table"
+    set_github_output "changed" "true"
+else
+    echo "The update has not changed the compatibility table"
+    set_github_output "changed" "false"
+fi


### PR DESCRIPTION
## Summary

Adds a workflow and a script that is used together to run the `dolittle/contracts-compatibility' tool recalculate a fresh Runtime <-> SDK compatibility table and merge it into the existing one. If there is an update to the file, this will be committed and pushed to the default branch.

The workflow is setup to run every morning, and can be triggered manually on GitHub.
