### PR TITLE
Fix bug in handling of multiple writes of same event to stream.

### DIFF
--- a/Integration/Shared/Runtime.cs
+++ b/Integration/Shared/Runtime.cs
@@ -48,8 +48,16 @@ public static class Runtime
 
         var runtimeHost = Host.CreateDefaultBuilder()
             .UseDolittleServices()
-            .ConfigureHostConfiguration(_ => _
-                .AddInMemoryCollection(configuration))
+            .ConfigureHostConfiguration(_ =>
+            {
+                _.Sources.Clear();
+                _.AddInMemoryCollection(configuration);
+            })
+            .ConfigureAppConfiguration(_ =>
+            {
+                _.Sources.Clear();
+                _.AddInMemoryCollection(configuration);
+            })
             .ConfigureServices(_ => _
                 .AddLogging(_ => _.ClearProviders()))
             .AddActorSystem()

--- a/Integration/Tests/Events.Store/when_writing_to_stream/that_is_not_scoped/when_writing_to_stream.cs
+++ b/Integration/Tests/Events.Store/when_writing_to_stream/that_is_not_scoped/when_writing_to_stream.cs
@@ -86,4 +86,15 @@ class when_writing_to_stream : given.a_clean_event_store
         It should_fail = () => failure.ShouldNotBeNull();
         It should_have_only_3_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(3);
     }
+    
+    [Tags("IntegrationTest")]
+    class and_writing_an_event_twice
+    {
+        Establish context = () => events_to_streams_writer.Write(committed_events.Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult();
+        
+        Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Skip(3).Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
+
+        It should_not_fail = () => failure.ShouldBeNull();
+        It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(4);
+    }
 }

--- a/Integration/Tests/Events.Store/when_writing_to_stream/that_is_scoped/when_writing_to_stream.cs
+++ b/Integration/Tests/Events.Store/when_writing_to_stream/that_is_scoped/when_writing_to_stream.cs
@@ -88,4 +88,15 @@ class when_writing_to_stream : given.a_clean_event_store
         It should_fail = () => failure.ShouldNotBeNull();
         It should_have_only_3_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(3);
     }
+    
+    [Tags("IntegrationTest")]
+    class and_writing_an_event_twice
+    {
+        Establish context = () => events_to_streams_writer.Write(committed_events.Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult();
+        
+        Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Skip(3).Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
+
+        It should_not_fail = () => failure.ShouldBeNull();
+        It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(4);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a bug in the implementation of handling multiple writes of the same events to a stream (https://github.com/dolittle/Runtime/pull/704). The previous fix did not catch the case where a single event was written multiple times - which is the case for most writes, e.g. when using Event Handlers.

### Fixed

- The `EventsToStreamsWriter.WriteOnlyNewEvents` failed when it was given a single event because it throws a `MongoWriteException` instead of a `MongoBulkWriteException`