### PR TITLE
Add gRPC-web Management service endpoint

### DIFF
--- a/Source/Aggregates.Management/AggregateRootsService.cs
+++ b/Source/Aggregates.Management/AggregateRootsService.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Aggregates.Management;
 /// <summary>
 /// Represents an implementation of <see cref="AggregateRootsBase"/>.
 /// </summary>
-[ManagementService]
+[ManagementService, ManagementWebService]
 public class AggregateRootsService : AggregateRootsBase
 {
     readonly IGetTenantScopedAggregateRoot _tenantScopedAggregateRoot;

--- a/Source/DependencyInversion/Types/TypeAttributeExtensions.cs
+++ b/Source/DependencyInversion/Types/TypeAttributeExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Dolittle.Runtime.DependencyInversion.Types;
 
@@ -11,22 +13,11 @@ namespace Dolittle.Runtime.DependencyInversion.Types;
 public static class TypeAttributeExtensions
 {
     /// <summary>
-    /// Tries to get a attribute on a <see cref="Type"/>.
+    /// Gets the defined attributes of a specific type, on a <see cref="Type"/>.
     /// </summary>
     /// <param name="type">The <see cref="Type"/>.</param>
-    /// <param name="attribute">The outputted attribute.</param>
-    /// <typeparam name="TAttribute">The <see cref="Type"/> of the attribute.</typeparam>
-    /// <returns>True if <see cref="Type"/> has the attribute, false if not.</returns>
-    public static bool TryGetAttribute<TAttribute>(this Type type, out TAttribute attribute)
+    /// <returns>The found attributes of the specified type.</returns>
+    public static IEnumerable<TAttribute> GetAttributes<TAttribute>(this Type type)
         where TAttribute : Attribute
-    {
-        if (!Attribute.IsDefined(type, typeof(TAttribute)))
-        {
-            attribute = default;
-            return false;
-        }
-
-        attribute = Attribute.GetCustomAttribute(type, typeof(TAttribute)) as TAttribute;
-        return attribute != default;
-    }
+        => Attribute.GetCustomAttributes(type, typeof(TAttribute)).Cast<TAttribute>();
 }

--- a/Source/Events.Management/EventTypesService.cs
+++ b/Source/Events.Management/EventTypesService.cs
@@ -17,7 +17,7 @@ namespace Dolittle.Runtime.Events.Management;
 /// <summary>
 /// Represents an implementation of <see cref="EventTypesBase"/>.
 /// </summary>
-[ManagementService]
+[ManagementService, ManagementWebService]
 public class EventTypesService : EventTypesBase
 {
     readonly IEventTypes _eventTypes;

--- a/Source/Events.Processing.Management/EventHandlers/EventHandlersService.cs
+++ b/Source/Events.Processing.Management/EventHandlers/EventHandlersService.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.Events.Processing.Management.EventHandlers;
 /// <summary>
 /// Represents an implementation of <see cref="EventHandlersBase"/>.
 /// </summary>
-[ManagementService]
+[ManagementService, ManagementWebService]
 public class EventHandlersService : EventHandlersBase
 {
     readonly IEventHandlers _eventHandlers;

--- a/Source/Events.Processing.Management/Projections/ProjectionsService.cs
+++ b/Source/Events.Processing.Management/Projections/ProjectionsService.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.Events.Processing.Management.Projections;
 /// <summary>
 /// Represents an implementation of <see cref="ProjectionsBase"/>.
 /// </summary>
-[ManagementService]
+[ManagementService, ManagementWebService]
 public class ProjectionsService : ProjectionsBase
 {
     readonly IProjections _projections;

--- a/Source/Server/Program.cs
+++ b/Source/Server/Program.cs
@@ -8,12 +8,15 @@ using Dolittle.Runtime.Bootstrap.Hosting;
 using Dolittle.Runtime.Configuration;
 using Dolittle.Runtime.DependencyInversion.Building;
 using Dolittle.Runtime.Diagnostics.OpenTelemetry;
+using Dolittle.Runtime.Events.Management;
+using Dolittle.Runtime.Events.Processing.Management.EventHandlers;
 using Dolittle.Runtime.Events.Store.MongoDB.Legacy;
 using Dolittle.Runtime.Metrics.Hosting;
 using Dolittle.Runtime.Server.Web;
 using Dolittle.Runtime.Services;
 using Dolittle.Runtime.Services.Hosting;
 using Dolittle.Runtime.Tenancy;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -36,6 +39,11 @@ var host = Host.CreateDefaultBuilder(args)
     .AddGrpcHost(EndpointVisibility.Private)
     .AddGrpcHost(EndpointVisibility.Public)
     .AddGrpcHost(EndpointVisibility.Management)
+    .AddGrpcWebHost(endpoints =>
+    {
+        endpoints.MapGrpcService<EventTypesService>();
+        endpoints.MapGrpcService<EventHandlersService>();
+    })
     .AddMetricsHost()
     .AddWebHost()
     .Build();

--- a/Source/Server/Program.cs
+++ b/Source/Server/Program.cs
@@ -8,8 +8,6 @@ using Dolittle.Runtime.Bootstrap.Hosting;
 using Dolittle.Runtime.Configuration;
 using Dolittle.Runtime.DependencyInversion.Building;
 using Dolittle.Runtime.Diagnostics.OpenTelemetry;
-using Dolittle.Runtime.Events.Management;
-using Dolittle.Runtime.Events.Processing.Management.EventHandlers;
 using Dolittle.Runtime.Events.Store.MongoDB.Legacy;
 using Dolittle.Runtime.Metrics.Hosting;
 using Dolittle.Runtime.Server.Web;
@@ -39,11 +37,7 @@ var host = Host.CreateDefaultBuilder(args)
     .AddGrpcHost(EndpointVisibility.Private)
     .AddGrpcHost(EndpointVisibility.Public)
     .AddGrpcHost(EndpointVisibility.Management)
-    .AddGrpcWebHost(endpoints =>
-    {
-        endpoints.MapGrpcService<EventTypesService>();
-        endpoints.MapGrpcService<EventHandlersService>();
-    })
+    .AddGrpcWebHost(EndpointVisibility.ManagementWeb)
     .AddMetricsHost()
     .AddWebHost()
     .Build();

--- a/Source/Services/Configuration/EndpointsConfiguration.cs
+++ b/Source/Services/Configuration/EndpointsConfiguration.cs
@@ -25,6 +25,11 @@ public record EndpointsConfiguration
     /// Gets the configuration for the management endpoint.
     /// </summary>
     public EndpointConfiguration Management { get; init; } = new() {Port = 51052};
+    
+    /// <summary>
+    /// Gets the configuration for the management web endpoint.
+    /// </summary>
+    public EndpointConfiguration ManagementWeb {get; init; } = new() {Port = 51152};
 
     /// <summary>
     /// Gets the configuration for an endpoint by its <see cref="EndpointVisibility"/>.
@@ -37,6 +42,7 @@ public record EndpointsConfiguration
             EndpointVisibility.Public => Public,
             EndpointVisibility.Private => Private,
             EndpointVisibility.Management => Management,
+            EndpointVisibility.ManagementWeb => ManagementWeb,
             _ => throw new UnknownEndpointVisibility(visibility)
         };
 }

--- a/Source/Services/EndpointVisibility.cs
+++ b/Source/Services/EndpointVisibility.cs
@@ -17,9 +17,14 @@ public enum EndpointVisibility
     /// Represents private endpoints.
     /// </summary>
     Private = 2,
-        
+
     /// <summary>
     /// Represents management endpoints.
     /// </summary>
     Management = 3,
+
+    /// <summary>
+    /// Represents management endpoints exposed through gRPC web.
+    /// </summary>
+    ManagementWeb = 4,
 }

--- a/Source/Services/Hosting/HostBuilderExtensions.cs
+++ b/Source/Services/Hosting/HostBuilderExtensions.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Dolittle.Runtime.Hosting;
 using Dolittle.Runtime.Services.HealthChecks;
 using Dolittle.Runtime.Services.Hosting.Endpoints;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -34,7 +31,7 @@ public static class HostBuilderExtensions
 
                 grpcHost.ConfigureServices(services =>
                 {
-                    services.AddKestrelConfigurationFor(visibility);
+                    services.AddKestrelConfigurationForGrpc(visibility);
                     services.AddGrpc();
                     services.AddGrpcReflection();
                 });
@@ -52,21 +49,23 @@ public static class HostBuilderExtensions
                 });
             }));
 
-    public static IHostBuilder AddGrpcWebHost(this IHostBuilder builder, Action<IEndpointRouteBuilder> services)
+    /// <summary>
+    /// Configures a scoped host that serves gRPC-web endpoints of the specified <see cref="EndpointVisibility"/> using Kestrel.
+    /// </summary>
+    /// <param name="builder">The host builder to add a scoped host to.</param>
+    /// <param name="visibility">The endpoint visibility to serve endpoints for.</param>
+    /// <returns>The builder for continuation.</returns>
+    public static IHostBuilder AddGrpcWebHost(this IHostBuilder builder, EndpointVisibility visibility)
         => builder
             .AddScopedHost(_ => _.ConfigureWebHost(grpcWebHost =>
             {
-                grpcWebHost.UseKestrel().ConfigureKestrel(_ =>
-                {
-                    _.ListenAnyIP(61052, _ =>
-                    {
-                        _.Protocols = HttpProtocols.Http1;
-                    });
-                });
+                grpcWebHost.UseKestrel();
 
                 grpcWebHost.ConfigureServices(services =>
                 {
+                    services.AddKestrelConfigurationForGrpcWeb(visibility);
                     services.AddGrpc();
+                    services.AddGrpcReflection();
                 });
 
                 grpcWebHost.Configure(app =>
@@ -77,7 +76,9 @@ public static class HostBuilderExtensions
 
                     app.UseEndpoints(endpoints =>
                     {
-                        services(endpoints);
+                        endpoints.MapDiscoveredGrpcServicesOf(visibility);
+                        endpoints.MapGrpcReflectionService();
+                        endpoints.MapGrpcService<HealthService>();
                     });
                 });
             }));

--- a/Source/Services/Hosting/KestrelConfiguration.cs
+++ b/Source/Services/Hosting/KestrelConfiguration.cs
@@ -12,10 +12,12 @@ namespace Dolittle.Runtime.Services.Hosting;
 public class KestrelConfiguration : IConfigureOptions<KestrelServerOptions>
 {
     readonly EndpointConfiguration _configuration;
-    
-    public KestrelConfiguration(IOptions<EndpointsConfiguration> configuration, EndpointVisibility visibility)
+    readonly HttpProtocols _protocols;
+
+    public KestrelConfiguration(IOptions<EndpointsConfiguration> configuration, EndpointVisibility visibility, HttpProtocols protocols)
     {
         _configuration = configuration.Value.GetConfigurationFor(visibility);
+        _protocols = protocols;
     }
 
     /// <inheritdoc />
@@ -25,7 +27,7 @@ public class KestrelConfiguration : IConfigureOptions<KestrelServerOptions>
             _configuration.Port,
             _ =>
             {
-                _.Protocols = HttpProtocols.Http2;
+                _.Protocols = _protocols;
             });
     }
 }

--- a/Source/Services/Hosting/ManagementWebServiceAttribute.cs
+++ b/Source/Services/Hosting/ManagementWebServiceAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Dolittle.Runtime.Services.Hosting;
+
+/// <summary>
+/// Indicates that the class should be registered as a management gRPC-web service in a DI container.
+/// </summary>
+public class ManagementWebServiceAttribute : ServiceAttribute 
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ManagementWebServiceAttribute"/> class.
+    /// </summary>
+    public ManagementWebServiceAttribute()
+        : base(EndpointVisibility.ManagementWeb)
+    {
+    }
+}

--- a/Source/Services/Hosting/ServiceCollectionExtensions.cs
+++ b/Source/Services/Hosting/ServiceCollectionExtensions.cs
@@ -11,11 +11,21 @@ namespace Dolittle.Runtime.Services.Hosting;
 public static class ServiceCollectionExtensions
 {
 
-    public static void AddKestrelConfigurationFor(this IServiceCollection services, EndpointVisibility visibility)
+    public static void AddKestrelConfigurationForGrpc(this IServiceCollection services, EndpointVisibility visibility)
     {
         services.AddSingleton<IConfigureOptions<KestrelServerOptions>>(_ => 
             new KestrelConfiguration(
                 _.GetRequiredService<IOptions<EndpointsConfiguration>>(),
-                visibility));
+                visibility,
+                HttpProtocols.Http2));
+    }
+
+    public static void AddKestrelConfigurationForGrpcWeb(this IServiceCollection services, EndpointVisibility visibility)
+    {
+        services.AddSingleton<IConfigureOptions<KestrelServerOptions>>(_ => 
+            new KestrelConfiguration(
+                _.GetRequiredService<IOptions<EndpointsConfiguration>>(),
+                visibility,
+                HttpProtocols.Http1));
     }
 }

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
         <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
         <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcVersion)" />
+        <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcVersion)" />
         <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="$(GrpcVersion)" />
         <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="$(GrpcVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />

--- a/versions.props
+++ b/versions.props
@@ -4,7 +4,7 @@
         <AutofacExtensionsVersion>7.2.0</AutofacExtensionsVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>7.4.0</ContractsVersion>
+        <ContractsVersion>7.4.1</ContractsVersion>
         <CoverletVersion>3.1.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary

Exposing management services on a new, configurable, grpc-web port so that we can make calls to the management services from a web browser

### Added

- Endpoint configuration for managementWeb with default port 51152
- Exposing management services through grpc-web
