### PR TITLE
Fixes unregistering eventlogstream, passing scope in request

### DIFF
--- a/Source/Events.Processing/EventHandlers/Fast/CreateScopedFilterStreamProcessors.cs
+++ b/Source/Events.Processing/EventHandlers/Fast/CreateScopedFilterStreamProcessors.cs
@@ -70,7 +70,7 @@ public class CreateScopedFilterStreamProcessors : ICreateScopedFilterStreamProce
                 streamProcessorId.ScopeId,
                 processorState.Position.Value,
                 new ReadOnlyCollection<ArtifactId>(filterDefinition.Types.ToList()),
-                CancellationToken.None),
+                cancellationToken),
             streamProcessorId,
             filterDefinition.Partitioned,
             unpartitionedProcessorState);

--- a/Source/Events.Store/Actors/EventLogStream.cs
+++ b/Source/Events.Store/Actors/EventLogStream.cs
@@ -141,6 +141,7 @@ public class EventLogStreamActor : IActor
         _channelWriter.Complete();
         await _eventStoreClient.CancelSubscription(new CancelEventStoreSubscription
         {
+            ScopeId = _scope,
             SubscriptionId = _subscriptionId
         }, CancellationTokens.FromSeconds(5)).ConfigureAwait(false);
     }


### PR DESCRIPTION
### Fixed

- Fixes correct unregistering of eventlog streams. Was only possible to trigger with fast event handlers enabled, which consumes the stream directly.