### PR TITLE
Remove platform configuration from production image

### DIFF
--- a/Docker/Production/.dolittle/platform.yml
+++ b/Docker/Production/.dolittle/platform.yml
@@ -1,1 +1,0 @@
-environment: Production

--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -23,7 +23,6 @@ ENV Logging__Console__FormatterName=""
 WORKDIR /app
 COPY --from=dotnet-build /app/Source/Server/out ./
 COPY --from=dotnet-build /app/Source/Server/.dolittle ./.dolittle
-COPY Docker/Production/.dolittle ./.dolittle
 
 EXPOSE 9700 50052 50053 51052
 


### PR DESCRIPTION
## Summary

Don't include a platform config with Production environment in production docker image.It ended up overwriting the environment for all Runtimes