### PR TITLE
Stream Processor retry-rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# [8.9.3] - 2023-6-2 [PR: #738](https://github.com/dolittle/Runtime/pull/738)
+## Summary
+
+This pull request includes various enhancements, bug fixes, and code updates. Please find below the details of the changes:
+
+### Added
+
+- Implemented filtering to MongoDB traces, removing unnecessary noise.
+- Introduced Proto.Actor healthchecks for improved monitoring and diagnostics.
+
+### Changed
+
+- Upgraded the Proto.Actor dependency and transitioned to a single node provider/lookup. This change reduces overhead when running as a single server.
+- Upgraded OTEL libraries
+
+### Fixed
+
+- Fixed an edge case in the catch-up logic that could cause processing to stall.
+- Addressed test assertion issues.
+
+
 # [8.9.2] - 2023-5-10 [PR: #736](https://github.com/dolittle/Runtime/pull/736)
 ## Summary
 

--- a/Source/Actors/GrainAndActor.cs
+++ b/Source/Actors/GrainAndActor.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Reflection;
 using Proto;
-using Proto.Cluster;
 
 namespace Dolittle.Runtime.Actors;
 
@@ -15,23 +12,6 @@ namespace Dolittle.Runtime.Actors;
 /// <param name="Grain">The type of the grain.</param>
 /// <param name="Actor">The type of the grain actor.</param>
 /// <param name="IsPerTenant">Whether the grain is per tenant.</param>
-public record GrainAndActor(Type Grain, Type Actor, bool IsPerTenant)
+public record GrainAndActor(Type Grain, Type Actor, string Kind, bool IsPerTenant)
 {
-    /// <summary>
-    /// The <see cref="ClusterKind.Name"/> of the grain.
-    /// </summary>
-    public string Kind
-    {
-        get
-        {
-            var kind = GetKind(Actor);
-            return kind ?? Grain.Name;
-        }
-    }
-    static string? GetKind(Type type)
-    {
-        var fieldInfos = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-
-        return fieldInfos.FirstOrDefault(fi => fi is { IsLiteral: true, IsInitOnly: false, Name:"Kind" })?.GetRawConstantValue()?.ToString();
-    }
 }

--- a/Source/Actors/GrainAttribute.cs
+++ b/Source/Actors/GrainAttribute.cs
@@ -16,19 +16,26 @@ public class GrainAttribute : Attribute
     /// </summary>
     /// <param name="actorType">The <see cref="Type"/> of the grain actor.</param>
     /// <param name="clientType">The <see cref="Type"/> of the grain client.</param>
-    public GrainAttribute(Type actorType, Type clientType)
+    /// <param name="kind">The kind (type address) of the grain.</param>
+    public GrainAttribute(Type actorType, Type clientType, string kind)
     {
         ActorType = actorType;
         ClientType = clientType;
+        Kind = kind;
     }
-    
+
     /// <summary>
     /// Gets the <see cref="Type"/> of the grain actor.
     /// </summary>
     public Type ActorType { get; }
-    
+
     /// <summary>
     /// Gets the <see cref="Type"/> of the grain client.
     /// </summary>
     public Type ClientType { get; }
+
+    /// <summary>
+    /// Gets the kind (type address) of the grain.
+    /// </summary>
+    public string Kind { get; }
 }

--- a/Source/Actors/Grains.cs
+++ b/Source/Actors/Grains.cs
@@ -24,6 +24,6 @@ public class Grains : ICanAddServicesForTypesWith<GrainAttribute>
                     provider.GetRequiredService<Cluster>(),
                     "Groot"))
             .AddTransient(type)
-            .AddSingleton(new GrainAndActor(type, attribute.ActorType, false));
+            .AddSingleton(new GrainAndActor(type, attribute.ActorType, attribute.Kind, false));
     }
 }

--- a/Source/Actors/TenantGrainAttribute.cs
+++ b/Source/Actors/TenantGrainAttribute.cs
@@ -16,10 +16,12 @@ public class TenantGrainAttribute : Attribute
     /// </summary>
     /// <param name="actorType">The <see cref="Type"/> of the grain actor.</param>
     /// <param name="clientType">The <see cref="Type"/> of the grain client.</param>
-    public TenantGrainAttribute(Type actorType, Type clientType)
+    /// <param name="kind">The kind (type address) of the grain.</param>
+    public TenantGrainAttribute(Type actorType, Type clientType, string kind)
     {
         ActorType = actorType;
         ClientType = clientType;
+        Kind = kind;
     }
     
     /// <summary>
@@ -31,4 +33,9 @@ public class TenantGrainAttribute : Attribute
     /// Gets the <see cref="Type"/> of the grain client.
     /// </summary>
     public Type ClientType { get; }
+    
+    /// <summary>
+    /// Gets the kind (type address) of the grain.
+    /// </summary>
+    public string Kind { get; }
 }

--- a/Source/Actors/TenantGrains.cs
+++ b/Source/Actors/TenantGrains.cs
@@ -36,7 +36,6 @@ public class TenantGrainsServices : ICanAddServicesForTypesWith<TenantGrainAttri
     /// <inheritdoc />
     public void AddServiceFor(Type type, TenantGrainAttribute attribute, IServiceCollection services)
     {
-        services
-            .AddSingleton(new GrainAndActor(type, attribute.ActorType, true));
+        services.AddSingleton(new GrainAndActor(type, attribute.ActorType, attribute.Kind, true));
     }
 }

--- a/Source/Diagnostics/Diagnostics.csproj
+++ b/Source/Diagnostics/Diagnostics.csproj
@@ -15,12 +15,12 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
         <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.3.0-rc.2" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.4" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.4" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-rc.4" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.14" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
         <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
     </ItemGroup>
 

--- a/Source/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/Source/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -73,15 +73,16 @@ public static class OpenTelemetryConfigurationExtensions
     static void AddOpenTelemetryTracing(this IHostBuilder builder, ResourceBuilder resourceBuilder, Uri otlpEndpoint)
     {
         builder.ConfigureServices(services =>
-            services.AddOpenTelemetryTracing(builder =>
-            {
-                builder.SetResourceBuilder(resourceBuilder)
-                    .AddHttpClientInstrumentation()
-                    .AddAspNetCoreInstrumentation()
-                    .AddMongoDBInstrumentation()
-                    .AddGrpcClientInstrumentation()
-                    .AddProtoActorInstrumentation()
-                    .AddOtlpExporter(options => { options.Endpoint = otlpEndpoint; });
-            }));
+            services.AddOpenTelemetry()
+                .WithTracing(_ =>
+                {
+                    _.SetResourceBuilder(resourceBuilder)
+                        .AddHttpClientInstrumentation()
+                        .AddAspNetCoreInstrumentation()
+                        .AddMongoDBInstrumentation()
+                        .AddGrpcClientInstrumentation()
+                        .AddProtoActorInstrumentation()
+                        .AddOtlpExporter(options => { options.Endpoint = otlpEndpoint; });
+                }));
     }
 }

--- a/Source/Events.Store.MongoDB/DatabaseConnection.cs
+++ b/Source/Events.Store.MongoDB/DatabaseConnection.cs
@@ -7,7 +7,7 @@ using Dolittle.Runtime.DependencyInversion.Scoping;
 using Dolittle.Runtime.Events.Store.MongoDB.Legacy;
 using Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams;
 using Dolittle.Runtime.Events.Store.MongoDB.Streams.Filters;
-
+using Dolittle.Runtime.MongoDB;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -44,7 +44,7 @@ public class DatabaseConnection : IDatabaseConnection
             Servers = config.Servers.Select(MongoServerAddress.Parse),
             GuidRepresentation = GuidRepresentation.Standard,
             MaxConnectionPoolSize = config.MaxConnectionPoolSize,
-            ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber())
+            ClusterConfigurator = cb => cb.AddTelemetry()
         };
 
         MongoClient = new MongoClient(settings.Freeze());

--- a/Source/Events.Store.MongoDB/Events/EventConverter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventConverter.cs
@@ -53,6 +53,15 @@ public class EventConverter : IEventConverter
             StreamId.EventLog,
             PartitionId.None,
             false);
+    
+    /// <inheritdoc/>
+    public runtime.Streams.StreamEvent ToPartitionedRuntimeStreamEvent(mongoDB.Event @event) =>
+        new(
+            ToRuntimeCommittedEvent(@event),
+            @event.EventLogSequenceNumber,
+            StreamId.EventLog,
+            @event.Metadata.EventSource,
+            true);
 
     /// <inheritdoc/>
     public runtime.Streams.StreamEvent ToRuntimeStreamEvent(mongoDB.StreamEvent @event, StreamId stream, bool partitioned) =>

--- a/Source/Events.Store.MongoDB/Events/IEventConverter.cs
+++ b/Source/Events.Store.MongoDB/Events/IEventConverter.cs
@@ -50,4 +50,7 @@ public interface IEventConverter
     /// <param name="event">The <see cref="mongoDB.Event" /> to be converted.</param>
     /// <returns>The converted <see cref="runtime.CommittedEvent" />.</returns>
     runtime.CommittedEvent ToRuntimeCommittedEvent(mongoDB.Event @event);
+
+    /// <inheritdoc/>
+    runtime.Streams.StreamEvent ToPartitionedRuntimeStreamEvent(mongoDB.Event @event);
 }

--- a/Source/Events.Store.MongoDB/Legacy/StringOrGuidFilterDefinition.cs
+++ b/Source/Events.Store.MongoDB/Legacy/StringOrGuidFilterDefinition.cs
@@ -6,6 +6,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB.Legacy;
 
@@ -44,6 +45,8 @@ public class StringOrGuidFilterDefinition<TDocument> : FilterDefinition<TDocumen
         writer.WriteEndDocument();
         return document;
     }
+
+    public override BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry, LinqProvider linqProvider) => Render(documentSerializer, serializerRegistry);
 
     void RenderEqualityQuery(IBsonWriter writer)
     {

--- a/Source/Events.Store.MongoDB/Streams/Filters/FilterDefinitionDiscriminatorConvention.cs
+++ b/Source/Events.Store.MongoDB/Streams/Filters/FilterDefinitionDiscriminatorConvention.cs
@@ -18,7 +18,7 @@ public class FilterDefinitionDiscriminatorConvention : IDiscriminatorConvention
     const string Type = "Type";
 
     /// <summary>
-    /// Represents the differnet kinds of FilterDefinitions we have.
+    /// Represents the different kinds of FilterDefinitions we have.
     /// </summary>
     public enum FilterType
     {

--- a/Source/Events.Store.MongoDB/Streams/StreamFetcherWasNotConstructedWithPartitionIdExpression.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcherWasNotConstructedWithPartitionIdExpression.cs
@@ -11,7 +11,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams;
 public class StreamFetcherWasNotConstructedWithPartitionIdExpression : Exception
 {
     public StreamFetcherWasNotConstructedWithPartitionIdExpression()
-        : base($"The StreamFetcher was constructed without a ParitionId expression. It cannot be used for fetching events or types in a specific partition")
+        : base($"The StreamFetcher was constructed without a PartitionId expression. It cannot be used for fetching events or types in a specific partition")
     {
     }
 }

--- a/Source/Events/Processing/Streams/Partitioned/FailingPartitions.cs
+++ b/Source/Events/Processing/Streams/Partitioned/FailingPartitions.cs
@@ -74,108 +74,104 @@ public class FailingPartitions : IFailingPartitions
         StreamProcessorState streamProcessorState,
         CancellationToken cancellationToken)
     {
-        if (streamProcessorState.FailingPartitions.Count > 0)
-        {
-            streamProcessorState = (await _streamProcessorStates.TryGetFor(streamProcessorId, cancellationToken)
-                .ConfigureAwait(false)).Result as StreamProcessorState;
-        }
-
         var failingPartitionsList = streamProcessorState.FailingPartitions.ToList();
 
-        // TODO: Failing partitions should be actorified
         foreach (var kvp in failingPartitionsList)
         {
-            var partition = kvp.Key;
-            var failingPartitionState = kvp.Value;
-            while (IsBeforeCurrentHighWatermark(failingPartitionState.Position.StreamPosition, streamProcessorState.Position.StreamPosition) &&
-                   ShouldRetryProcessing(failingPartitionState))
+            streamProcessorState = await ProcessPartition(streamProcessorId, streamProcessorState, kvp, cancellationToken);
+        }
+
+        return streamProcessorState;
+    }
+
+    async Task<StreamProcessorState> ProcessPartition(IStreamProcessorId streamProcessorId, StreamProcessorState streamProcessorState, KeyValuePair<PartitionId, FailingPartitionState> kvp,
+        CancellationToken cancellationToken)
+    {
+        var partition = kvp.Key;
+        var failingPartitionState = kvp.Value;
+        while (IsBeforeCurrentHighWatermark(failingPartitionState.Position.StreamPosition, streamProcessorState.Position.StreamPosition) &&
+               ShouldRetryProcessing(failingPartitionState))
+        {
+            var tryGetEvents = await _eventsFromStreamsFetcher.FetchInPartition(partition, failingPartitionState.Position.StreamPosition, cancellationToken);
+            if (!tryGetEvents.Success)
             {
-                var tryGetEvents = await _eventsFromStreamsFetcher.FetchInPartition(partition, failingPartitionState.Position.StreamPosition, cancellationToken);
-                
-                // var tryGetEvents = await _eventFetcherPolicies.Fetching.ExecuteAsync(
-                //     _ => _eventsFromStreamsFetcher.FetchInPartition(partition, failingPartitionState.Position.StreamPosition, _),
-                //     cancellationToken).ConfigureAwait(false);
-                if (!tryGetEvents.Success)
+                break;
+            }
+
+            foreach (var streamEvent in tryGetEvents.Result)
+            {
+                if (streamEvent.Partition != partition)
+                {
+                    throw new StreamEventInWrongPartition(streamEvent, partition);
+                }
+
+                if (!IsBeforeCurrentHighWatermark(streamEvent.Position, streamProcessorState.Position.StreamPosition))
+                {
+                    // We have caught up to the current high watermark
+                    // Remove the failing state for this partition
+                    streamProcessorState = await RemoveFailingPartition(streamProcessorId, streamProcessorState, partition, cancellationToken)
+                        .ConfigureAwait(false);
+                    return streamProcessorState;
+                }
+
+                if (!ShouldRetryProcessing(failingPartitionState))
                 {
                     break;
                 }
 
-                foreach (var streamEvent in tryGetEvents.Result)
+                var processingResult = await RetryProcessingEvent(
+                    failingPartitionState,
+                    streamEvent.Event,
+                    partition,
+                    _createExecutionContextForEvent(streamEvent),
+                    cancellationToken).ConfigureAwait(false);
+
+                if (processingResult.Succeeded)
                 {
-                    if (streamEvent.Partition != partition)
-                    {
-                        throw new StreamEventInWrongPartition(streamEvent, partition);
-                    }
-                    if (!IsBeforeCurrentHighWatermark(streamEvent.Position, streamProcessorState.Position.StreamPosition))
-                    {
-                        // We have caught up to the current high watermark
-                        // Remove the failing state for this partition
-                        streamProcessorState = await RemoveFailingPartition(streamProcessorId, streamProcessorState, partition, cancellationToken)
-                            .ConfigureAwait(false);
-                        // Return
-                        break;
-                    }
-
-                    if (!ShouldRetryProcessing(failingPartitionState))
-                    {
-                        break;
-                    }
-
-                    var processingResult = await RetryProcessingEvent(
-                        failingPartitionState,
-                        streamEvent.Event,
+                    (streamProcessorState, failingPartitionState) = await ChangePositionInFailingPartition(
+                        streamProcessorId,
+                        streamProcessorState,
                         partition,
-                        _createExecutionContextForEvent(streamEvent),
+                        streamEvent.Position + 1,
+                        failingPartitionState.LastFailed,
                         cancellationToken).ConfigureAwait(false);
-
-                    if (processingResult.Succeeded)
-                    {
-                        (streamProcessorState, failingPartitionState) = await ChangePositionInFailingPartition(
-                            streamProcessorId,
-                            streamProcessorState,
-                            partition,
-                            streamEvent.Position + 1,
-                            failingPartitionState.LastFailed,
-                            cancellationToken).ConfigureAwait(false);
-                    }
-                    else if (processingResult.Retry)
-                    {
-                        (streamProcessorState, failingPartitionState) = await SetFailingPartitionState(
-                            streamProcessorId,
-                            streamProcessorState,
-                            partition,
-                            failingPartitionState.ProcessingAttempts + 1,
-                            processingResult.RetryTimeout,
-                            processingResult.FailureReason,
-                            streamEvent.Position,
-                            DateTimeOffset.UtcNow,
-                            cancellationToken).ConfigureAwait(false);
-                        // Important to not process the next events if this failed
-                        break;
-                    }
-                    else
-                    {
-                        (streamProcessorState, failingPartitionState) = await SetFailingPartitionState(
-                            streamProcessorId,
-                            streamProcessorState,
-                            partition,
-                            failingPartitionState.ProcessingAttempts + 1,
-                            DateTimeOffset.MaxValue,
-                            processingResult.FailureReason,
-                            streamEvent.Position,
-                            DateTimeOffset.UtcNow,
-                            cancellationToken).ConfigureAwait(false);
-                        // Important to not process the next events if this failed
-                        break;
-                    }
+                }
+                else if (processingResult.Retry)
+                {
+                    (streamProcessorState, failingPartitionState) = await SetFailingPartitionState(
+                        streamProcessorId,
+                        streamProcessorState,
+                        partition,
+                        failingPartitionState.ProcessingAttempts + 1,
+                        processingResult.RetryTimeout,
+                        processingResult.FailureReason,
+                        streamEvent.Position,
+                        DateTimeOffset.UtcNow,
+                        cancellationToken).ConfigureAwait(false);
+                    // Important to not process the next events if this failed
+                    break;
+                }
+                else
+                {
+                    (streamProcessorState, failingPartitionState) = await SetFailingPartitionState(
+                        streamProcessorId,
+                        streamProcessorState,
+                        partition,
+                        failingPartitionState.ProcessingAttempts + 1,
+                        DateTimeOffset.MaxValue,
+                        processingResult.FailureReason,
+                        streamEvent.Position,
+                        DateTimeOffset.UtcNow,
+                        cancellationToken).ConfigureAwait(false);
+                    // Important to not process the next events if this failed
+                    break;
                 }
             }
+        }
 
-            if (ShouldRetryProcessing(failingPartitionState))
-            {
-                streamProcessorState =
-                    await RemoveFailingPartition(streamProcessorId, streamProcessorState, partition, cancellationToken).ConfigureAwait(false);
-            }
+        if (ShouldRetryProcessing(failingPartitionState))
+        {
+            streamProcessorState = await RemoveFailingPartition(streamProcessorId, streamProcessorState, partition, cancellationToken).ConfigureAwait(false);
         }
 
         return streamProcessorState;

--- a/Source/Events/Processing/Streams/StreamProcessorState.cs
+++ b/Source/Events/Processing/Streams/StreamProcessorState.cs
@@ -144,6 +144,8 @@ public record StreamProcessorState(ProcessingPosition Position, string FailureRe
 
     void VerifyEventHasValidProcessingPosition(StreamEvent processedEvent)
     {
+        
+        
         if (processedEvent.CurrentProcessingPosition.StreamPosition != Position.StreamPosition)
         {
             throw new ArgumentException($"The processed event does not match the current position of the stream processor. Expected {Position}, got {processedEvent.CurrentProcessingPosition}", nameof(processedEvent));

--- a/Source/Events/Store/Actors/EventStore.cs
+++ b/Source/Events/Store/Actors/EventStore.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Store.Actors;
 /// <summary>
 /// Represents the event store grain. 
 /// </summary>
-[TenantGrain(typeof(EventStoreActor), typeof(EventStoreClient))]
+[TenantGrain(typeof(EventStoreActor), typeof(EventStoreClient), "dolittle.runtime.events.actors.EventStore")]
 // ReSharper disable once UnusedType.Global
 public class EventStore : EventStoreBase
 {

--- a/Source/Events/Store/Actors/StreamProcessorStateManager.cs
+++ b/Source/Events/Store/Actors/StreamProcessorStateManager.cs
@@ -14,7 +14,7 @@ using Proto;
 
 namespace Dolittle.Runtime.Events.Store.Actors;
 
-[TenantGrain(typeof(StreamProcessorStateActor), typeof(StreamProcessorStateClient))]
+[TenantGrain(typeof(StreamProcessorStateActor), typeof(StreamProcessorStateClient),"dolittle.runtime.events.actors.StreamProcessorState")]
 public class StreamProcessorStateManager : StreamProcessorStateBase
 {
     readonly IStreamProcessorStateRepository _repository;
@@ -226,6 +226,7 @@ public class StreamProcessorStateManager : StreamProcessorStateBase
         if (!_changedSubscriptionStates.TryGetValue(scope, out var changedScopedSubscriptionStates))
         {
             _changedSubscriptionStates.Add(scope, changedScopedSubscriptionStates = new());
+            
         }
 
         changedScopedSubscriptionStates[id] = state;

--- a/Source/Events/Store/Actors/StreamSubscriptionStateManager.cs
+++ b/Source/Events/Store/Actors/StreamSubscriptionStateManager.cs
@@ -15,7 +15,7 @@ using Proto;
 
 namespace Dolittle.Runtime.Events.Store.Actors;
 
-[TenantGrain(typeof(StreamSubscriptionStateActor), typeof(StreamSubscriptionStateClient))]
+[TenantGrain(typeof(StreamSubscriptionStateActor), typeof(StreamSubscriptionStateClient), "dolittle.runtime.events.actors.StreamSubscriptionState")]
 public class StreamSubscriptionStateManager : StreamSubscriptionStateBase
 {
     readonly ISubscriptionStateRepository _repository;
@@ -115,10 +115,11 @@ public class StreamSubscriptionStateManager : StreamSubscriptionStateBase
                     SubscriptionId = subscriptionId
                 },
             };
-            if(bucket is not null)
+            if (bucket is not null)
             {
                 streamProcessorStateResponse.Bucket.Add(bucket);
             }
+
             respond(streamProcessorStateResponse);
         }
     }
@@ -149,7 +150,8 @@ public class StreamSubscriptionStateManager : StreamSubscriptionStateBase
                     }
                     else
                     {
-                        _logger.LogWarning("Got unexpected stream processor key type {StreamProcessorKeyType} for scope {ScopeId}", streamProcessorKey.IdCase, scopeId);
+                        _logger.LogWarning("Got unexpected stream processor key type {StreamProcessorKeyType} for scope {ScopeId}", streamProcessorKey.IdCase,
+                            scopeId);
                     }
                 }
 

--- a/Source/Events/Store/Streams/ICanFetchEventsFromPartitionedStream.cs
+++ b/Source/Events/Store/Streams/ICanFetchEventsFromPartitionedStream.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,14 +12,26 @@ namespace Dolittle.Runtime.Events.Store.Streams;
 /// <summary>
 /// Defines a system that can fetch <see cref="StreamEvent">events</see> from <see cref="StreamId">streams</see>.
 /// </summary>
-public interface ICanFetchEventsFromPartitionedStream: ICanFetchEventsFromStream
+public interface ICanFetchEventsFromPartitionedStream : ICanFetchEventsFromStream
 {
     /// <summary>
-    /// Fetch the first event in the given partition from a given <see cref="StreamPosition" />.
+    /// Fetch events in the given partition from a given <see cref="StreamPosition" />.
     /// </summary>
     /// <param name="partitionId">The <see cref="PartitionId" />.</param>
     /// <param name="position"><see cref="StreamPosition">the position in the stream</see>.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns>The <see cref="Try{TResult}" /> with <see cref="StreamEvent" /> result.</returns>
     Task<Try<IEnumerable<StreamEvent>>> FetchInPartition(PartitionId partitionId, StreamPosition position, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch events in the given partition from a given <see cref="StreamPosition" />.
+    /// </summary>
+    /// <param name="partitionId">The <see cref="PartitionId" />.</param>
+    /// <param name="from"><see cref="StreamPosition">the from (inclusive) position in the stream</see>.</param>
+    /// <param name="to"><see cref="StreamPosition">the to(exclusive position in the stream</see>.</param>
+    /// <param name="artifactIds"></param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+    /// <returns>The <see cref="Try{TResult}" /> with <see cref="StreamEvent" /> result.</returns>
+    Task<(IList<StreamEvent> events, bool hasMoreEvents)> FetchInPartition(PartitionId partitionId, StreamPosition from, StreamPosition to, ISet<Guid> artifactIds,
+        CancellationToken cancellationToken);
 }

--- a/Source/Events/Store/Streams/IEventFetchers.cs
+++ b/Source/Events/Store/Streams/IEventFetchers.cs
@@ -17,7 +17,7 @@ public interface IEventFetchers
     /// <param name="scopeId">The <see cref="ScopeId" />.</param>
     /// <param name="streamDefinition">The <see cref="IStreamDefinition" />.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-    /// <returns>A <see cref="Task" /> that, whn resolved, returns the <see cref="ICanFetchEventsFromStream" />.</returns>
+    /// <returns>A <see cref="Task" /> that, when resolved, returns the <see cref="ICanFetchEventsFromStream" />.</returns>
     Task<ICanFetchEventsFromStream> GetFetcherFor(ScopeId scopeId, IStreamDefinition streamDefinition, CancellationToken cancellationToken);
 
     /// <summary>
@@ -26,7 +26,7 @@ public interface IEventFetchers
     /// <param name="scopeId">The <see cref="ScopeId" />.</param>
     /// <param name="streamDefinition">The <see cref="IStreamDefinition" />.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-    /// <returns>A <see cref="Task" /> that, whn resolved, returns the <see cref="ICanFetchEventsFromPartitionedStream" />.</returns>
+    /// <returns>A <see cref="Task" /> that, when resolved, returns the <see cref="ICanFetchEventsFromPartitionedStream" />.</returns>
     Task<ICanFetchEventsFromPartitionedStream> GetPartitionedFetcherFor(ScopeId scopeId, IStreamDefinition streamDefinition, CancellationToken cancellationToken);
 
     /// <summary>
@@ -35,7 +35,7 @@ public interface IEventFetchers
     /// <param name="scopeId">The <see cref="ScopeId" />.</param>
     /// <param name="streamDefinition">The <see cref="IStreamDefinition" />.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-    /// <returns>A <see cref="Task" /> that, whn resolved, returns the <see cref="ICanFetchRangeOfEventsFromStream" />.</returns>
+    /// <returns>A <see cref="Task" /> that, when resolved, returns the <see cref="ICanFetchRangeOfEventsFromStream" />.</returns>
     Task<ICanFetchRangeOfEventsFromStream> GetRangeFetcherFor(ScopeId scopeId, IStreamDefinition streamDefinition, CancellationToken cancellationToken);
 
     /// <summary>
@@ -44,7 +44,7 @@ public interface IEventFetchers
     /// <param name="scopeId">The <see cref="ScopeId" />.</param>
     /// <param name="streamDefinition">The <see cref="IStreamDefinition" />.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-    /// <returns>A <see cref="Task" /> that, whn resolved, returns the <see cref="ICanFetchEventTypesFromStream" />.</returns>
+    /// <returns>A <see cref="Task" /> that, when resolved, returns the <see cref="ICanFetchEventTypesFromStream" />.</returns>
     Task<ICanFetchEventTypesFromStream> GetTypeFetcherFor(ScopeId scopeId, IStreamDefinition streamDefinition, CancellationToken cancellationToken);
 
     /// <summary>
@@ -53,6 +53,6 @@ public interface IEventFetchers
     /// <param name="scopeId">The <see cref="ScopeId" />.</param>
     /// <param name="streamDefinition">The <see cref="IStreamDefinition" />.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-    /// <returns>A <see cref="Task" /> that, whn resolved, returns the <see cref="ICanFetchEventTypesFromPartitionedStream" />.</returns>
+    /// <returns>A <see cref="Task" /> that, when resolved, returns the <see cref="ICanFetchEventTypesFromPartitionedStream" />.</returns>
     Task<ICanFetchEventTypesFromPartitionedStream> GetPartitionedTypeFetcherFor(ScopeId scopeId, IStreamDefinition streamDefinition, CancellationToken cancellationToken);
 }

--- a/Source/MongoDB/MongoClientSettingsExtensions.cs
+++ b/Source/MongoDB/MongoClientSettingsExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Core.Extensions.DiagnosticSources;
+
+namespace Dolittle.Runtime.MongoDB;
+
+public static class MongoClientSettingsExtensions
+{
+    static readonly HashSet<string> _commandsToFilter = new(new[] { "ping", "isMaster", "buildInfo", "saslStart", "saslContinue" },
+        StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initializes <see cref="DiagnosticsActivityEventSubscriber"/>, which creates traces based on MongoDB events, and adds it as subscriber to <see cref="ClusterBuilder"/>.
+    /// </summary>
+    /// <param name="builder">The MongoDB ClusterBuilder.</param>
+    public static void AddTelemetry(this ClusterBuilder builder)
+    {
+        builder.Subscribe(
+            new DiagnosticsActivityEventSubscriber(
+                new InstrumentationOptions
+                {
+                    ShouldStartActivity = commandStartedEvent => !_commandsToFilter.Contains(
+                        commandStartedEvent.CommandName)
+                }));
+    }
+}

--- a/Source/MongoDB/MongoDB.csproj
+++ b/Source/MongoDB/MongoDB.csproj
@@ -8,5 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
     </ItemGroup>
 </Project>

--- a/Source/Projections.Store.MongoDB/DatabaseConnection.cs
+++ b/Source/Projections.Store.MongoDB/DatabaseConnection.cs
@@ -4,11 +4,11 @@
 using System.Linq;
 using Dolittle.Runtime.DependencyInversion.Lifecycle;
 using Dolittle.Runtime.DependencyInversion.Scoping;
+using Dolittle.Runtime.MongoDB;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 
 namespace Dolittle.Runtime.Projections.Store.MongoDB;
 
@@ -38,7 +38,7 @@ public class DatabaseConnection : IDatabaseConnection
             Servers = config.Servers.Select(MongoServerAddress.Parse),
             GuidRepresentation = GuidRepresentation.Standard,
             MaxConnectionPoolSize = config.MaxConnectionPoolSize,
-            ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber())
+            ClusterConfigurator = cb => cb.AddTelemetry()
         };
 
         MongoClient = new MongoClient(settings.Freeze());

--- a/Source/Projections.Store.MongoDB/Projections.Store.MongoDB.csproj
+++ b/Source/Projections.Store.MongoDB/Projections.Store.MongoDB.csproj
@@ -14,6 +14,5 @@
     <ItemGroup>
         <ProjectReference Include="../Events/Events.csproj" />
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="$(MongoDBOpenTelemetryVersion)" />
     </ItemGroup>
 </Project>

--- a/Source/Server/Web/HostBuilderExtensions.cs
+++ b/Source/Server/Web/HostBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Proto.Cluster;
 
 namespace Dolittle.Runtime.Server.Web;
 
@@ -23,7 +24,8 @@ public static class HostBuilderExtensions
                 {
                     services.AddKestrelConfiguration();
                     services.AddControllers();
-                    services.AddHealthChecks();
+                    services.AddHealthChecks()
+                        .AddCheck<ClusterHealthCheck>("ProtoClusterHealthCheck");
                     services.AddRouting();
                     services.AddEndpointsApiExplorer();
                     services.AddSwaggerGen(options =>
@@ -35,15 +37,12 @@ public static class HostBuilderExtensions
                 webHost.Configure(app =>
                 {
                     app.UseHealthChecks("/healthz");
-                    
+
                     app.UseSwagger();
                     app.UseSwaggerUI();
-                   
+
                     app.UseRouting();
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.MapControllers();
-                    });
+                    app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
                 });
             }));
 }

--- a/Specifications/Events.Processing/EventHandlers/for_EventHandler/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventHandler/given/all_dependencies.cs
@@ -115,7 +115,7 @@ public class all_dependencies
 
         var eventSubscriber = new Mock<IStreamEventSubscriber>();
         var eventLogPositionEnricher = new Mock<IMapStreamPositionToEventLogPosition>().Object;
-        
+
         create_scoped_processor_props = (StreamProcessorId streamProcessorId,
             TypeFilterWithEventSourcePartitionDefinition filterDefinition,
             IEventProcessor processor,
@@ -124,17 +124,18 @@ public class all_dependencies
             ScopedStreamProcessorFailedToProcessEvent onFailedToProcess,
             TenantId tenantId) => Props.FromProducer(() => new TenantScopedStreamProcessorActor(
             streamProcessorId,
-        filterDefinition,
+            filterDefinition,
             processor,
             eventSubscriber.Object,
             stream_processor_states,
-        executionContext,
+            executionContext,
             eventLogPositionEnricher,
-        NullLogger<TenantScopedStreamProcessorActor>.Instance, 
+            NullLogger<TenantScopedStreamProcessorActor>.Instance,
             onProcessed,
-        onFailedToProcess,
+            onFailedToProcess,
+            Mock.Of<IEventFetchers>(),
             tenantId
-            ));
+        ));
 
 
         create_processor_props = (

--- a/versions.props
+++ b/versions.props
@@ -18,7 +18,7 @@
         <MicrosoftDotNetVersion>3.1.6</MicrosoftDotNetVersion>
         <MicrosoftDotNetTestVersion>16.4.0</MicrosoftDotNetTestVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
-        <MongoDBDriverVersion>2.10.1</MongoDBDriverVersion>
+        <MongoDBDriverVersion>2.19.2</MongoDBDriverVersion>
         <MongoDBOpenTelemetryVersion>1.0.0</MongoDBOpenTelemetryVersion>
         <MoqVersion>4.18.*</MoqVersion>
         <FluentAssertionsVersion>6.10.0</FluentAssertionsVersion>

--- a/versions.props
+++ b/versions.props
@@ -28,7 +28,7 @@
         <PollyVersion>7.2.3</PollyVersion>
         <PrometheusVersion>6.0.0</PrometheusVersion>
         <PrometheusNetDotNetRuntimeVersion>4.2.4</PrometheusNetDotNetRuntimeVersion>
-        <ProtoActorVersion>1.1.1-alpha.0.48</ProtoActorVersion>
+        <ProtoActorVersion>1.2.0</ProtoActorVersion>
         <ProtobufVersion>3.23.0</ProtobufVersion>
         <SwashbuckleVersion>6.3.0</SwashbuckleVersion>
         <SystemDataHashFunctionVersion>2.0.0</SystemDataHashFunctionVersion>


### PR DESCRIPTION
## Summary

Pulled in upstream changes
Added support for partitioned events directly from event log.
Rewritten how retries are done in the actor based event handler processing. Optimizing for lower potential memory footprint, failed events are read from DB when retrying instead of optimizing for IO by keeping them in memory.
