### PR TITLE
Concurrent processing support for event handlers

### DIFF
--- a/Integration/Benchmarks/Events.Processing/EventHandlers/EventHandler.cs
+++ b/Integration/Benchmarks/Events.Processing/EventHandlers/EventHandler.cs
@@ -86,7 +86,7 @@ public class EventHandler : JobBase
 
         var eventHandlers = new List<IEventHandler>();
         eventHandlers.AddRange(Enumerable.Range(0, EventHandlers).Select(_ => _eventHandlerFactory.Create(
-            new EventHandlerRegistrationArguments(Runtime.CreateExecutionContextFor("d9fd643f-ce74-4ae5-b706-b76859fd8827"), Guid.NewGuid(), _eventTypes, Partitioned, ScopeId.Default),
+            new EventHandlerRegistrationArguments(Runtime.CreateExecutionContextFor("d9fd643f-ce74-4ae5-b706-b76859fd8827"), Guid.NewGuid(), _eventTypes, Partitioned, ScopeId.Default, Concurrency),
             _dispatcher.Object,
             CancellationToken.None)));
         _eventHandlersToRun = eventHandlers;
@@ -122,6 +122,10 @@ public class EventHandler : JobBase
     /// </summary>
     // [Params(1, 10)] TODO: We can maybe enable this in the future, but as of now it seems that the performance depends on the amount of events processed.
     public int EventTypes { get; set; } = 1;
+    
+    
+    [Params(1, 20)]
+    public int Concurrency { get; set; } = 1;
     
     /// <summary>
     /// Gets the number of events committed per configured event type.

--- a/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
+++ b/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
@@ -54,6 +54,8 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
     protected static Dictionary<ScopeId, CommittedEvents> scoped_committed_events = default!;
     protected static IWriteEventHorizonEvents event_horizon_events_writer = default!;
     protected static EventLogSequenceNumber external_event_sequence_number = default!;
+    protected static int concurrency = 1;
+
 
     static ICommitExternalEvents external_event_committer = default!;
     static int number_of_events_handled;
@@ -120,7 +122,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
         {
             while (!cts.IsCancellationRequested)
             {
-                var evt = Task.Run(async () => await reader.ReadAsync(CancellationToken.None),cts.Token).GetAwaiter().GetResult();
+                var evt = Task.Run(async () => await reader.ReadAsync(CancellationToken.None), cts.Token).GetAwaiter().GetResult();
                 events.Add(evt);
             }
         }
@@ -215,7 +217,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
         {
             var (partitioned, max_event_types_to_filter, scope, fast, implicitFilter) = _;
             var registration_arguments = new EventHandlerRegistrationArguments(
-                Runtime.CreateExecutionContextFor(tenant), Guid.NewGuid(), event_types.Take(max_event_types_to_filter), partitioned, scope);
+                Runtime.CreateExecutionContextFor(tenant), Guid.NewGuid(), event_types.Take(max_event_types_to_filter), partitioned, scope, concurrency);
             return event_handler_factory.Create(registration_arguments, dispatcher.Object, CancellationToken.None);
         }).ToArray();
     }

--- a/Source/Events/ActorPropsAdder.cs
+++ b/Source/Events/ActorPropsAdder.cs
@@ -14,7 +14,7 @@ public class ActorPropsAdder : ICanAddServices
 {
     public void AddTo(IServiceCollection services)
     {
-        services.AddSingleton<CreateStreamProcessorActorProps>(sp => StreamProcessorActor.CreateFactory(new CreateProps(sp)));
+        services.AddSingleton<CreateStreamProcessorActorProps>(sp => EventHandlerProcessorActor.CreateFactory(new CreateProps(sp)));
         services.AddScoped<Func<TenantId, CreateTenantScopedStreamProcessorProps>>(globalServiceProvider =>
             tenant =>
             {

--- a/Source/Events/InternalsVisibleTo.cs
+++ b/Source/Events/InternalsVisibleTo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Events.Processing.Tests")]

--- a/Source/Events/Processing/EventHandlers/Actors/ConcurrentPartitionedProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/ConcurrentPartitionedProcessor.cs
@@ -1,0 +1,426 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Artifacts;
+using Dolittle.Runtime.Domain.Tenancy;
+using Dolittle.Runtime.Events.Processing.Streams;
+using Dolittle.Runtime.Events.Processing.Streams.Partitioned;
+using Dolittle.Runtime.Events.Store.Streams;
+using Microsoft.Extensions.Logging;
+using Proto;
+using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
+using StreamProcessorState = Dolittle.Runtime.Events.Processing.Streams.Partitioned.StreamProcessorState;
+
+namespace Dolittle.Runtime.Events.Processing.EventHandlers.Actors;
+
+public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState>
+{
+    readonly ICanFetchEventsFromPartitionedStream _fetcher;
+
+    internal delegate State ReceiveResult(State current);
+
+    internal class ActiveRequests
+    {
+        readonly int _concurrency;
+        readonly HashSet<PartitionId> _currentPartitions = new();
+        readonly Channel<(PartitionId partition, Task<ReceiveResult> callback)> _currentlyProcessing;
+        readonly ChannelReader<(PartitionId partition, Task<ReceiveResult> callback)> _reader;
+
+        public IReadOnlySet<PartitionId> PartitionsBeingProcessed => _currentPartitions;
+
+        public ActiveRequests(int concurrency)
+        {
+            _concurrency = concurrency;
+            _currentlyProcessing = Channel.CreateBounded<(PartitionId, Task<ReceiveResult>)>(new BoundedChannelOptions(concurrency)
+            {
+                SingleReader = true,
+                SingleWriter = true
+            });
+            _reader = _currentlyProcessing.Reader;
+        }
+
+        public bool IsProcessing(PartitionId partitionId) => _currentPartitions.Contains(partitionId);
+
+        public ValueTask Add(PartitionId partitionId, Task<ReceiveResult> callBack)
+        {
+            if (!_currentPartitions.Add(partitionId)) throw new ArgumentException($"Partition {partitionId} is already being processed");
+            return _currentlyProcessing.Writer.WriteAsync((partitionId, callBack));
+        }
+
+        public ValueTask AddSkipped(Task<ReceiveResult> callBack)
+        {
+            return _currentlyProcessing.Writer.WriteAsync((PartitionId.None, callBack));
+        }
+
+        public bool HasCompletedRequests()
+        {
+            return _reader.TryPeek(out var next) && next.callback.IsCompleted;
+        }
+
+        public async Task WaitForNextCompleted(CancellationToken cancellationToken)
+        {
+            await _reader.WaitToReadAsync(cancellationToken);
+            _reader.TryPeek(out var next);
+            await next.callback;
+        }
+
+        public async ValueTask<Task<ReceiveResult>> GetNextCompleted(CancellationToken cancellationToken)
+        {
+            var result = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (result.partition != PartitionId.None)
+            {
+                _currentPartitions.Remove(result.partition);
+            }
+
+            return result.callback;
+        }
+
+        public bool IsEmpty => _currentPartitions.Count == 0;
+        public bool IsFull => _currentPartitions.Count == _concurrency;
+    }
+
+    internal record State(StreamProcessorState ProcessorState, ActiveRequests ActiveRequests)
+    {
+        public bool NoFailingEvents => ProcessorState.FailingPartitions.IsEmpty;
+
+        public bool TryGetTimeToRetry(ActiveRequests activeRequests, out TimeSpan timeToRetry, [NotNullWhen(true)] out PartitionId? selectedPartitionId)
+        {
+            timeToRetry = TimeSpan.MaxValue;
+            selectedPartitionId = default;
+            if (NoFailingEvents) return false;
+            var processing = activeRequests.PartitionsBeingProcessed;
+            foreach (var (partitionId, failingPartitionState) in ProcessorState.FailingPartitions)
+            {
+                if (processing.Contains(partitionId)) continue;
+                if (failingPartitionState.TryGetTimespanToRetry(out var partitionTimeToRetry) && partitionTimeToRetry < timeToRetry)
+                {
+                    timeToRetry = partitionTimeToRetry;
+                    selectedPartitionId = partitionId;
+                }
+            }
+
+            return timeToRetry < TimeSpan.MaxValue;
+        }
+
+        /// <summary>
+        /// Mark the event as skipped. Used when the event partition is failing, and the event should be retried out of band
+        /// </summary>
+        /// <param name="streamEvent"></param>
+        /// <returns></returns>
+        public State WithSkippedEvent(StreamEvent streamEvent) =>
+            this with { ProcessorState = ProcessorState.WithResult(SkippedProcessing.Instance, streamEvent, DateTimeOffset.UtcNow) };
+    }
+
+    bool _catchingUp = true;
+    readonly ImmutableHashSet<Guid> _handledTypes;
+    readonly int _concurrency;
+
+
+    public ConcurrentPartitionedProcessor(
+        StreamProcessorId streamProcessorId,
+        IEnumerable<ArtifactId> handledEventTypes,
+        IEventProcessor processor,
+        IStreamProcessorStates streamProcessorStates,
+        ExecutionContext executionContext,
+        ScopedStreamProcessorProcessedEvent onProcessed,
+        ScopedStreamProcessorFailedToProcessEvent onFailedToProcess,
+        TenantId tenantId,
+        ICanFetchEventsFromPartitionedStream fetcher,
+        int concurrency,
+        ILogger logger)
+        :
+        base(
+            streamProcessorId, processor, streamProcessorStates, executionContext, onProcessed, onFailedToProcess, tenantId, logger)
+    {
+        _fetcher = fetcher;
+        _concurrency = concurrency;
+        _handledTypes = handledEventTypes.Select(_ => _.Value).ToImmutableHashSet();
+    }
+
+    public async Task Process(ChannelReader<StreamEvent> messages, IStreamProcessorState state, CancellationToken cancellationToken)
+    {
+        var currentState = new State(AsPartitioned(state), new ActiveRequests(_concurrency));
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var (nextAction, partitionId) = await WaitForNextAction(messages, currentState, cancellationToken);
+                try
+                {
+                    switch (nextAction)
+                    {
+                        case NextAction.ReceiveResult:
+                            currentState = await ProcessReceiveResult(currentState, cancellationToken);
+                            break;
+
+                        case NextAction.ProcessNextEvent:
+                            currentState = await ProcessNextEvent(messages, currentState, cancellationToken);
+
+                            break;
+                        case NextAction.ProcessFailedEvent:
+                            currentState = await CatchUpForPartition(currentState, partitionId!, cancellationToken);
+
+                            break;
+                        case NextAction.Completed:
+                            return;
+                    }
+                }
+                finally
+                {
+                    await PersistNewState(currentState.ProcessorState, CancellationToken.None);
+                }
+            }
+        }
+        catch (OperationCanceledException e)
+        {
+            Logger.CancelledRunningEventHandler(e, Identifier.EventProcessorId, Identifier.ScopeId);
+        }
+        catch (Exception e)
+        {
+            Logger.ErrorWhileRunningEventHandler(e, Identifier.EventProcessorId, Identifier.ScopeId);
+        }
+        finally
+        {
+            // If there are requests in-flight, let's try to wait for them to complete
+            await WaitForCompletions(currentState);
+        }
+    }
+
+    async Task WaitForCompletions(State currentState)
+    {
+        if (currentState.ActiveRequests.IsEmpty)
+            return;
+
+        var timeout = CancellationTokens.FromSeconds(10);
+        while (!currentState.ActiveRequests.IsEmpty)
+        {
+            currentState = await ProcessReceiveResult(currentState, timeout);
+        }
+    }
+
+    async Task<State> ProcessNextEvent(ChannelReader<StreamEvent> messages, State currentState, CancellationToken cancellationToken)
+    {
+        var evt = await messages.ReadAsync(cancellationToken);
+        if (currentState.ProcessorState.FailingPartitions.TryGetValue(evt.Partition, out _))
+        {
+            await currentState.ActiveRequests.AddSkipped(Task.FromResult(AsSkippedEvent(evt)));
+            return currentState;
+        }
+
+        var newTask = ProcessEventAndReturnStateUpdateCallback(evt, cancellationToken);
+        await currentState.ActiveRequests.Add(evt.Partition, newTask);
+        return currentState;
+    }
+
+    ReceiveResult AsSkippedEvent(StreamEvent evt) => current => current.WithSkippedEvent(evt);
+
+    async Task<State> ProcessReceiveResult(State currentState, CancellationToken cancellationToken)
+    {
+        var readAsync = await currentState.ActiveRequests.GetNextCompleted(cancellationToken);
+        var receive = await readAsync;
+        currentState = receive(currentState);
+        await PersistNewState(currentState.ProcessorState, CancellationToken.None);
+        return currentState;
+    }
+
+    async Task<ReceiveResult> ProcessEventAndReturnStateUpdateCallback(StreamEvent evt, CancellationToken cancellationToken)
+    {
+        var (processingResult, elapsed) = await ProcessEvent(evt, cancellationToken);
+
+        return state =>
+        {
+            var updatedState = HandleProcessingResult(processingResult, evt, elapsed, state.ProcessorState);
+
+            return state with { ProcessorState = updatedState };
+        };
+    }
+
+    async Task<ReceiveResult> ProcessEventRetryAndReturnStateUpdateCallback(StreamEvent evt, FailingPartitionState partitionState,
+        CancellationToken cancellationToken)
+    {
+        var (processingResult, elapsed) = await RetryProcessingEvent(evt, partitionState.Reason, partitionState.ProcessingAttempts, cancellationToken);
+
+        return state =>
+        {
+            var updatedState = HandleProcessingResult(processingResult, evt, elapsed, state.ProcessorState);
+
+            return state with { ProcessorState = updatedState };
+        };
+    }
+
+    internal enum NextAction
+    {
+        /// <summary>
+        /// Process the next event in the event stream.
+        /// </summary>
+        ProcessNextEvent,
+
+        /// <summary>
+        /// Receive the result of the current event being processed
+        /// </summary>
+        ReceiveResult,
+
+        /// <summary>
+        /// Process an event from before the current position in the event stream.
+        /// Skips events in non failing partitions
+        /// </summary>
+        ProcessCatchUpEvent,
+
+        /// <summary>
+        /// Retry processing of failed events.
+        /// </summary>
+        ProcessFailedEvent,
+
+        /// <summary>
+        /// Processing is complete.
+        /// </summary>
+        Completed
+    }
+
+    /// <summary>
+    /// Determines which action to take next.
+    /// If the current processing is complete, it will return <see cref="NextAction.ReceiveResult"/>.
+    /// Else it will wait for new data to become available or for the retry delay to expire.
+    /// </summary>
+    /// <param name="messages"></param>
+    /// <param name="state"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    internal static async ValueTask<(NextAction, PartitionId?)> WaitForNextAction(
+        ChannelReader<StreamEvent> messages,
+        State state,
+        CancellationToken cancellationToken)
+    {
+        Task? resultReady = null;
+
+        if (state.ActiveRequests.IsFull || state.ActiveRequests.HasCompletedRequests())
+        {
+            return (NextAction.ReceiveResult, default);
+        }
+
+        if (!state.ActiveRequests.IsEmpty)
+        {
+            resultReady = state.ActiveRequests.WaitForNextCompleted(cancellationToken);
+        }
+
+        Task? retryAfter = null;
+
+        if (state.TryGetTimeToRetry(state.ActiveRequests, out var timeToRetry, out var partitionId))
+        {
+            if (timeToRetry <= TimeSpan.Zero)
+            {
+                return (NextAction.ProcessFailedEvent, partitionId);
+            }
+
+            // Not ready to retry yet
+            retryAfter = Task.Delay(timeToRetry, cancellationToken);
+        }
+
+        var tasks = new List<Task>(3);
+        if (resultReady != null)
+        {
+            tasks.Add(resultReady);
+        }
+
+        if (retryAfter != null)
+        {
+            tasks.Add(retryAfter);
+        }
+
+        var readyToRead = messages.WaitToReadAsync(cancellationToken).AsTask();
+        tasks.Add(readyToRead);
+
+        await Task.WhenAny(tasks);
+
+        // Prioritize processing of results over retrying
+        if (resultReady is not null && resultReady.IsCompleted)
+        {
+            return (NextAction.ReceiveResult, partitionId);
+        }
+
+        // If a partition is ready to retry, do that
+        if (retryAfter is not null && retryAfter.IsCompletedSuccessfully)
+        {
+            return (NextAction.ProcessFailedEvent, partitionId);
+        }
+
+        // Else check if there are more events to process
+        var hasMoreEvents = readyToRead.IsCompleted && readyToRead.Result;
+
+        // Channel has closed, processor is terminating
+        if (!hasMoreEvents)
+        {
+            if (state.ActiveRequests.IsEmpty)
+            {
+                return (NextAction.Completed, default);
+            }
+
+            return (NextAction.ReceiveResult, default);
+        }
+
+        if (messages.TryPeek(out var streamEvent) && state.ActiveRequests.IsProcessing(streamEvent.Partition))
+        {
+            return (NextAction.ReceiveResult, streamEvent.Partition);
+        }
+
+        return (NextAction.ProcessNextEvent, default);
+    }
+
+    StreamProcessorState AsPartitioned(IStreamProcessorState state)
+    {
+        switch (state)
+        {
+            case StreamProcessorState partitionedState:
+                return partitionedState;
+
+            case Dolittle.Runtime.Events.Processing.Streams.StreamProcessorState nonPartitionedState:
+                if (!nonPartitionedState.IsFailing)
+                {
+                    Logger.LogInformation("Converting non-partitioned state to partitioned for {StreamProcessorId}", Identifier);
+                    return new StreamProcessorState(nonPartitionedState.Position, nonPartitionedState.LastSuccessfullyProcessed);
+                }
+
+                throw new ArgumentException("State is not convertible to partitioned");
+
+            default:
+                throw new ArgumentException("State is of invalid type");
+        }
+    }
+
+    async Task<State> CatchUpForPartition(
+        State state,
+        PartitionId partition,
+        CancellationToken cancellationToken)
+    {
+        var failingPartitionState = state.ProcessorState.FailingPartitions[partition];
+        if (!ShouldRetryProcessing(failingPartitionState)) return state; // Should not really happen, since we explicitly wait for each partition
+
+        var startPosition = new StreamPosition(failingPartitionState.Position.EventLogPosition.Value);
+        var highWatermark = new StreamPosition(state.ProcessorState.Position.EventLogPosition.Value);
+
+        var (evt, _) = await _fetcher.FetchNextEventInPartition(partition, startPosition, highWatermark, _handledTypes, cancellationToken);
+
+        if (evt is null)
+        {
+            // No more events before the high water mark for this partition, remove it
+            state = state with { ProcessorState = state.ProcessorState.WithoutFailingPartition(partition) };
+            await PersistNewState(state.ProcessorState, CancellationToken.None);
+            return state;
+        }
+
+        var newTask = ProcessEventAndReturnStateUpdateCallback(evt, cancellationToken);
+        await state.ActiveRequests.Add(evt.Partition, newTask);
+        return state;
+    }
+
+    static bool ShouldRetryProcessing(FailingPartitionState state) => DateTimeOffset.UtcNow.CompareTo(state.RetryTime) >= 0;
+}

--- a/Source/Events/Processing/EventHandlers/Actors/NonPartitionedProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/NonPartitionedProcessor.cs
@@ -45,7 +45,7 @@ public class NonPartitionedProcessor : ProcessorBase<StreamProcessorState>
                 {
                     var evt = await messages.ReadAsync(cancellationToken);
 
-                    (currentState, var processingResult) = await ProcessEvent(evt, currentState, GetExecutionContextForEvent(evt), cancellationToken);
+                    (currentState, var processingResult) = await ProcessEventAndHandleResult(evt, currentState, cancellationToken);
                     await PersistNewState(currentState, cancellationToken);
 
                     while (processingResult is { Succeeded: false, Retry: true })
@@ -60,9 +60,8 @@ public class NonPartitionedProcessor : ProcessorBase<StreamProcessorState>
                             Logger.LogInformation("Will retry processing event {evt.Position} directly", evt);
                         }
 
-                        (currentState, processingResult) = await RetryProcessingEvent(evt, currentState, processingResult.FailureReason,
-                            currentState.ProcessingAttempts + 1,
-                            GetExecutionContextForEvent(evt), cancellationToken);
+                        (currentState, processingResult) = await RetryProcessingEventAndHandleResult(evt, currentState, processingResult.FailureReason,
+                            currentState.ProcessingAttempts + 1, cancellationToken);
                     }
 
                     if (!processingResult.Succeeded)

--- a/Source/Events/Processing/EventHandlers/Actors/PartitionedProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/PartitionedProcessor.cs
@@ -198,7 +198,7 @@ public class PartitionedProcessor : ProcessorBase<StreamProcessorState>
             };
         }
 
-        var (processorState, _) = await ProcessEvent(evt, state.ProcessorState, GetExecutionContextForEvent(evt), cancellationToken);
+        var (processorState, _) = await ProcessEventAndHandleResult(evt, state.ProcessorState, cancellationToken);
         state = state with
         {
             ProcessorState = processorState
@@ -243,12 +243,11 @@ public class PartitionedProcessor : ProcessorBase<StreamProcessorState>
         var (events, hasMoreEvents) = await _fetcher.FetchInPartition(partition, startPosition, highWatermark, _handledTypes, cancellationToken);
         foreach (var streamEvent in events)
         {
-            var (newState, processingResult) = await RetryProcessingEvent(
+            var (newState, processingResult) = await RetryProcessingEventAndHandleResult(
                 streamEvent,
                 state.ProcessorState,
                 failingPartitionState.Reason,
                 failingPartitionState.ProcessingAttempts,
-                GetExecutionContextForEvent(streamEvent),
                 cancellationToken).ConfigureAwait(false);
             await PersistNewState(newState, CancellationToken.None);
 

--- a/Source/Events/Processing/EventHandlers/EventHandlerInfo.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlerInfo.cs
@@ -14,4 +14,5 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers;
 /// <param name="Alias">The alias of the Event Handler.</param>
 /// <param name="EventTypes">The Event types that the Event Handler handles..</param>
 /// <param name="Partitioned">Whether the Event Handler is partitioned.</param>
-public record EventHandlerInfo(EventHandlerId Id, bool HasAlias, EventHandlerAlias Alias, IEnumerable<ArtifactId> EventTypes, bool Partitioned);
+/// <param name="Concurrency">How many events the handler can process simultaneously.</param>
+public record EventHandlerInfo(EventHandlerId Id, bool HasAlias, EventHandlerAlias Alias, IEnumerable<ArtifactId> EventTypes, bool Partitioned, int Concurrency);

--- a/Source/Events/Processing/EventHandlers/EventHandlerRegistrationArguments.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlerRegistrationArguments.cs
@@ -21,7 +21,9 @@ public record EventHandlerRegistrationArguments
     /// <param name="eventTypes">The Event types that the Event Handler handles.</param>
     /// <param name="partitioned">Whether the Event Handler is partitioned or unpartitioned.</param>
     /// <param name="scope">The Scope the Event Handler will be handling events in.</param>
-    public EventHandlerRegistrationArguments(ExecutionContext executionContext, EventProcessorId eventHandler, IEnumerable<ArtifactId> eventTypes, bool partitioned, ScopeId scope)
+    /// <param name="concurrency">How many concurrent calls the Event Handler can process simultaneously</param>
+    public EventHandlerRegistrationArguments(ExecutionContext executionContext, EventProcessorId eventHandler, IEnumerable<ArtifactId> eventTypes,
+        bool partitioned, ScopeId scope, int concurrency)
     {
         ExecutionContext = executionContext;
         EventHandler = eventHandler;
@@ -30,6 +32,7 @@ public record EventHandlerRegistrationArguments
         Scope = scope;
         Alias = EventHandlerAlias.NotSet;
         HasAlias = false;
+        Concurrency = concurrency > 0 ? concurrency : 1;
     }
 
     /// <summary>
@@ -41,7 +44,9 @@ public record EventHandlerRegistrationArguments
     /// <param name="partitioned">Whether the Event Handler is partitioned or unpartitioned.</param>
     /// <param name="scope">The Scope the Event Handler will be handling events in.</param>
     /// <param name="alias">The alias of the Event Handler.</param>
-    public EventHandlerRegistrationArguments(ExecutionContext executionContext, EventProcessorId eventHandler, IEnumerable<ArtifactId> eventTypes, bool partitioned, ScopeId scope, EventHandlerAlias alias)
+    /// <param name="concurrency">How many concurrent calls the Event Handler can process simultaneously</param>
+    public EventHandlerRegistrationArguments(ExecutionContext executionContext, EventProcessorId eventHandler, IEnumerable<ArtifactId> eventTypes,
+        bool partitioned, ScopeId scope, EventHandlerAlias alias, int concurrency = 1)
     {
         ExecutionContext = executionContext;
         EventHandler = eventHandler;
@@ -49,39 +54,45 @@ public record EventHandlerRegistrationArguments
         Partitioned = partitioned;
         Scope = scope;
         Alias = alias;
+        Concurrency = concurrency > 0 ? concurrency : 1;
         HasAlias = true;
     }
+
+    /// <summary>
+    /// How many concurrent calls the Event Handler can process simultaneously.
+    /// </summary>
+    public int Concurrency { get; set; }
 
     /// <summary>
     /// Gets the ExecutionContext of the Client while registering.
     /// </summary>
     public ExecutionContext ExecutionContext { get; }
-        
+
     /// <summary>
     /// Gets the identifier of the Event Handler.
     /// </summary>
     public EventProcessorId EventHandler { get; }
-        
+
     /// <summary>
     /// Gets the Event types that the Event Handler handles.
     /// </summary>
     public IEnumerable<ArtifactId> EventTypes { get; }
-        
+
     /// <summary>
     /// Gets a value indicating whether the Event Handler is partitioned or unpartitioned.
     /// </summary>
     public bool Partitioned { get; }
-        
+
     /// <summary>
     /// Gets the Scope the Event Handler will be handling events in.
     /// </summary>
     public ScopeId Scope { get; }
-        
+
     /// <summary>
     /// Gets the alias of the Event Handler if set, or <see cref="EventHandlerAlias.NotSet"/> if not passed from the Client.
     /// </summary>
     public EventHandlerAlias Alias { get; }
-        
+
     /// <summary>
     /// Gets a value indicating whether or not the Client passed along an alias for the Event Handler.
     /// </summary>

--- a/Source/Events/Processing/EventHandlers/EventHandlersProtocol.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlersProtocol.cs
@@ -25,13 +25,15 @@ public class EventHandlersProtocol : IEventHandlersProtocol
                 arguments.EventTypes.Select(_ => new ArtifactId(_.Id.ToGuid())),
                 arguments.Partitioned,
                 arguments.ScopeId.ToGuid(),
-                arguments.Alias),
+                arguments.Alias,
+                arguments.Concurrency),
             false => new EventHandlerRegistrationArguments(
                 arguments.CallContext.ExecutionContext.ToExecutionContext(),
                 arguments.EventHandlerId.ToGuid(),
                 arguments.EventTypes.Select(_ => new ArtifactId(_.Id.ToGuid())),
                 arguments.Partitioned,
-                arguments.ScopeId.ToGuid()),
+                arguments.ScopeId.ToGuid(),
+                arguments.Concurrency),
         };
 
     /// <inheritdoc/>

--- a/Source/Events/Processing/Streams/Partitioned/StreamProcessorState.cs
+++ b/Source/Events/Processing/Streams/Partitioned/StreamProcessorState.cs
@@ -34,9 +34,6 @@ public record StreamProcessorState(ProcessingPosition Position, ImmutableDiction
     {
     }
 
-    // public StreamProcessorState(ProcessingPosition position, IDictionary<PartitionId, FailingPartitionState> failingPartitions, DateTimeOffset lastSuccessfullyProcessed)
-    //     : this(position.StreamPosition, position.EventLogPosition, failingPartitions, lastSuccessfullyProcessed){}
-
     /// <summary>
     /// Gets a new, initial, <see cref="StreamProcessorState" />.
     /// </summary>

--- a/Source/Events/Store/Streams/ICanFetchEventsFromPartitionedStream.cs
+++ b/Source/Events/Store/Streams/ICanFetchEventsFromPartitionedStream.cs
@@ -34,4 +34,8 @@ public interface ICanFetchEventsFromPartitionedStream : ICanFetchEventsFromStrea
     /// <returns>The <see cref="Try{TResult}" /> with <see cref="StreamEvent" /> result.</returns>
     Task<(IList<StreamEvent> events, bool hasMoreEvents)> FetchInPartition(PartitionId partitionId, StreamPosition from, StreamPosition to, ISet<Guid> artifactIds,
         CancellationToken cancellationToken);
+
+    Task<(StreamEvent? events, bool hasMoreEvents)> FetchNextEventInPartition(PartitionId partitionId, StreamPosition from, StreamPosition to,
+        ISet<Guid> artifactIds,
+        CancellationToken cancellationToken);
 }

--- a/Specifications/Events.Processing.Tests/concurrent/ConcurrentPartitionedProcessorTests.cs
+++ b/Specifications/Events.Processing.Tests/concurrent/ConcurrentPartitionedProcessorTests.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading.Channels;
+using Dolittle.Runtime.Domain.Platform;
+using Dolittle.Runtime.Domain.Tenancy;
+using Dolittle.Runtime.Events.Processing.Streams.Partitioned;
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
+using Dolittle.Runtime.Execution;
+using FluentAssertions;
+using Proto;
+using static Dolittle.Runtime.Events.Processing.EventHandlers.Actors.ConcurrentPartitionedProcessor;
+using Artifact = Dolittle.Runtime.Artifacts.Artifact;
+using Environment = Dolittle.Runtime.Domain.Platform.Environment;
+using Version = Dolittle.Runtime.Domain.Platform.Version;
+
+namespace Events.Processing.Tests.concurrent;
+
+public class ConcurrentPartitionedProcessorTests
+{
+    private static readonly Dolittle.Runtime.Execution.ExecutionContext ExecutionContext = new(MicroserviceId.New(), TenantId.Development, Version.NotSet,
+        Environment.Development, CorrelationId.Empty, ActivitySpanId.CreateRandom(), Claims.Empty, CultureInfo.CurrentCulture);
+
+    private static readonly CommittedEvent SomeEvent = new(
+        EventLogSequenceNumber.Initial,
+        DateTimeOffset.Now,
+        "some-partition",
+        ExecutionContext,
+        Artifact.New(), false, "{}");
+
+    private static readonly StreamEvent FirstStreamEvent = new(SomeEvent, StreamPosition.Start, StreamId.EventLog, new PartitionId("some-partition"), true);
+
+    [Fact]
+    public async Task ShouldReturnNoActionWhenNoInput()
+    {
+        var state = new State(StreamProcessorState.New, NoWaitingReceipts());
+
+        using var cancellationTokenSource = new CancellationTokenSource(100);
+        await state.Invoking(async _ => { await WaitForNextAction(ChannelWithoutEvents(), state, cancellationTokenSource.Token); }).Should()
+            .ThrowAsync<OperationCanceledException>();
+    }
+
+    private static Channel<StreamEvent> ChannelWithoutEvents() => Channel.CreateBounded<StreamEvent>(100);
+
+    [Fact]
+    public async Task ShouldReturnProcessNextEventWhenMessageAvailable()
+    {
+        var state = new State(StreamProcessorState.New, NoWaitingReceipts());
+
+        var (nextAction, _) = await WaitForNextAction(ChannelWithEvent(), state, CancellationTokens.FromSeconds(1));
+
+        nextAction.Should().Be(NextAction.ProcessNextEvent);
+    }
+
+    [Fact]
+    public async Task ShouldReturnRetryFailedActionWhenRetryAvailable()
+    {
+        var state = new State(FailingProcessorStateWithRetryIn(TimeSpan.Zero, "failing-partition"),
+            NoWaitingReceipts());
+
+        var (nextAction, _) = await WaitForNextAction(ChannelWithEvent(), state, CancellationTokens.FromSeconds(1));
+
+        nextAction.Should().Be(NextAction.ProcessFailedEvent);
+    }
+
+    [Fact]
+    public async Task ShouldReturnProcessNextWhenRetryNotAvailableYet()
+    {
+        var state = new State(FailingProcessorStateWithRetryIn(TimeSpan.FromSeconds(1), "failing-partition"),
+            NoWaitingReceipts());
+
+        var (nextAction, _) = await WaitForNextAction(ChannelWithEvent(), state, CancellationTokens.FromSeconds(1));
+
+        nextAction.Should().Be(NextAction.ProcessNextEvent);
+    }
+
+    [Fact]
+    public async Task ShouldReturnProcessNextWhenWaitingForReceipt()
+    {
+        var state = new State(FailingProcessorStateWithRetryIn(TimeSpan.FromSeconds(1), "failing-partition"),
+            NoWaitingReceipts());
+
+        var (nextAction, _) = await WaitForNextAction(ChannelWithEvent(), state, CancellationTokens.FromSeconds(1));
+
+        nextAction.Should().Be(NextAction.ProcessNextEvent);
+    }
+
+    [Fact]
+    public async Task ShouldReturnReceiveResultWhenReceiptReady()
+    {
+        var state = new State(FailingProcessorStateWithRetryIn(TimeSpan.FromSeconds(1), "failing-partition"),
+            WithWaitingReceipt());
+
+        var (nextAction, _) = await WaitForNextAction(ChannelWithEvent(), state, CancellationTokens.FromSeconds(1));
+
+        nextAction.Should().Be(NextAction.ReceiveResult);
+    }
+
+    private static ActiveRequests NoWaitingReceipts() => new(5);
+
+    private static ActiveRequests WithWaitingReceipt()
+    {
+        var activeRequests = new ActiveRequests(5);
+        var completedResult = Task.FromResult<ReceiveResult>(current => current);
+        activeRequests.Add("waiting-partition", completedResult);
+        return activeRequests;
+    }
+
+    private static StreamProcessorState FailingProcessorStateWithRetryIn(TimeSpan timeSpan, PartitionId partitionId)
+    {
+        var processingPosition = new ProcessingPosition(5, 5);
+        var failingPosition = new ProcessingPosition(3, 3);
+
+        var retryTime = DateTimeOffset.UtcNow.Add(timeSpan);
+
+        var failingPartition = new FailingPartitionState(failingPosition, retryTime, "#reasons", 1, DateTimeOffset.Now - TimeSpan.FromSeconds(10));
+
+        return new StreamProcessorState(processingPosition, new Dictionary<PartitionId, FailingPartitionState>()
+        {
+            { partitionId, failingPartition }
+        }.ToImmutableDictionary(), DateTimeOffset.UtcNow);
+    }
+
+    private static Channel<StreamEvent> ChannelWithEvent()
+    {
+        var events = Channel.CreateBounded<StreamEvent>(100);
+        events.Writer.WriteAsync(FirstStreamEvent).GetAwaiter().GetResult();
+        return events;
+    }
+}

--- a/Specifications/Events.Processing/EventHandlers/for_EventHandler/given/all_dependencies.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventHandler/given/all_dependencies.cs
@@ -122,6 +122,7 @@ public class all_dependencies
             ExecutionContext executionContext,
             ScopedStreamProcessorProcessedEvent onProcessed,
             ScopedStreamProcessorFailedToProcessEvent onFailedToProcess,
+            EventHandlerInfo EventHandlerInfo,
             TenantId tenantId) => Props.FromProducer(() => new TenantScopedStreamProcessorActor(
             streamProcessorId,
             filterDefinition,
@@ -134,9 +135,9 @@ public class all_dependencies
             onProcessed,
             onFailedToProcess,
             Mock.Of<IEventFetchers>(),
+            EventHandlerInfo,
             tenantId
         ));
-
 
         create_processor_props = (
             StreamProcessorId streamProcessorId,
@@ -145,18 +146,23 @@ public class all_dependencies
             StreamProcessorProcessedEvent processedEvent,
             StreamProcessorFailedToProcessEvent failedToProcessEvent,
             ExecutionContext executionContext,
-            CancellationTokenSource cancellationTokenSource) => Props.FromProducer(() => new StreamProcessorActor(streamProcessorId,
-            streamDefinition,
-            createEventProcessorFor,
-            executionContext,
-            new Mock<Streams.IMetricsCollector>().Object,
-            processedEvent,
-            failedToProcessEvent,
-            NullLogger<StreamProcessorActor>.Instance,
-            tenant => create_scoped_processor_props,
-            tenants,
-            tenant => stream_processor_states,
-            cancellationTokenSource));
+            EventHandlerInfo eventHandlerInfo,
+            CancellationTokenSource cancellationTokenSource) => Props.FromProducer(() =>
+        {
+            return new EventHandlerProcessorActor(streamProcessorId,
+                streamDefinition,
+                createEventProcessorFor,
+                executionContext,
+                new Mock<Streams.IMetricsCollector>().Object,
+                processedEvent,
+                failedToProcessEvent,
+                NullLogger<EventHandlerProcessorActor>.Instance,
+                tenant => create_scoped_processor_props,
+                tenants,
+                tenant => stream_processor_states,
+                eventHandlerInfo,
+                cancellationTokenSource);
+        });
     };
 
     private Cleanup cleanup = () => { _ = actor_system.ShutdownAsync(); };

--- a/versions.props
+++ b/versions.props
@@ -4,7 +4,7 @@
         <AutofacExtensionsVersion>7.2.0</AutofacExtensionsVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>7.6.0</ContractsVersion>
+        <ContractsVersion>7.7.0</ContractsVersion>
         <CoverletVersion>3.1.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary

Adds support for a new mode to run partitioned event handlers in. With concurrency > 1, event handlers are able to process each partition (eventsourceId) in parallel. This greatly improves throughput, but requires the handlers to be thread safe and not require global ordering of events. Each partition still has full ordering guarantees and will be processed sequentially.
