### PR TITLE
Change stream position logic to align with eventlog instead of stream.

### DIFF
--- a/Source/EventHorizon/Consumer/Processing/EventsFromEventHorizonFetcher.cs
+++ b/Source/EventHorizon/Consumer/Processing/EventsFromEventHorizonFetcher.cs
@@ -39,13 +39,21 @@ public class EventsFromEventHorizonFetcher : ICanFetchEventsFromStream, IStreamE
             //TODO: This can be improved by taking as many as possible instead of just the first
             var @event = await _events.DequeueAsync(cancellationToken).ConfigureAwait(false);
             _metrics.IncrementTotalEventsFetched();
-            return new [] { @event };
+            return new[] { @event };
         }
         catch (Exception ex)
         {
             return ex;
         }
     }
+
+    /// Unused
+    public Task<Try<StreamEvent>> FetchSingle(StreamPosition _, CancellationToken cancellationToken) =>
+        throw new NotImplementedException("unused for eventhorizon");
+
+    /// Unused
+    public Task<Try<StreamEvent>> FetchLast(CancellationToken cancellationToken) =>
+        throw new NotImplementedException("unused for eventhorizon");
 
     /// <inheritdoc />
     public async Task<Try<StreamPosition>> GetNextStreamPosition(CancellationToken cancellationToken)
@@ -65,7 +73,8 @@ public class EventsFromEventHorizonFetcher : ICanFetchEventsFromStream, IStreamE
     public Task WaitForEvent(ScopeId scope, StreamId stream, StreamPosition position, CancellationToken token) => Task.Delay(60 * 1000, token);
 
     /// <inheritdoc/>
-    public Task WaitForEvent(ScopeId scope, StreamId stream, StreamPosition position, TimeSpan timeout, CancellationToken token) => Task.Delay(60 * 1000, token);
+    public Task WaitForEvent(ScopeId scope, StreamId stream, StreamPosition position, TimeSpan timeout, CancellationToken token) =>
+        Task.Delay(60 * 1000, token);
 
     /// <inheritdoc/>
     public Task WaitForEvent(ScopeId scope, StreamId stream, TimeSpan timeout, CancellationToken token) => Task.Delay(60 * 1000, token);

--- a/Source/Events.Store.MongoDB/Development/MongoDB/README.md
+++ b/Source/Events.Store.MongoDB/Development/MongoDB/README.md
@@ -1,3 +1,4 @@
+
 # Single server MongoDB replica set
 
 This directory contains scripts necessary to build a MongoDB Docker image that starts as a single server replica set.

--- a/Source/Events.Store.MongoDB/Streams/EventFetchers.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventFetchers.cs
@@ -113,6 +113,7 @@ public class EventFetchers : IEventFetchers
                 await _streams.GetEventLog(scopeId, cancellationToken).ConfigureAwait(false),
                 Builders<MongoDB.Events.Event>.Filter,
                 _ => _.EventLogSequenceNumber,
+                _ => _.EventLogSequenceNumber,
                 _ => _eventConverter.ToPartitionedRuntimeStreamEvent(_),
                 _ => _.Metadata.TypeId,
                 _ => _.Metadata.TypeGeneration,
@@ -126,6 +127,7 @@ public class EventFetchers : IEventFetchers
             await _streams.GetEventLog(scopeId, cancellationToken).ConfigureAwait(false),
             Builders<MongoDB.Events.Event>.Filter,
             _ => _.EventLogSequenceNumber,
+            _ => _.EventLogSequenceNumber,
             _ => _eventConverter.ToRuntimeStreamEvent(_),
             _ => _.Metadata.TypeId,
             _ => _.Metadata.TypeGeneration);
@@ -138,6 +140,7 @@ public class EventFetchers : IEventFetchers
             scopeId,
             collection,
             Builders<Events.StreamEvent>.Filter,
+            _ => _.StreamPosition,
             _ => _.StreamPosition,
             _ => _eventConverter.ToRuntimeStreamEvent(_, streamId, partitioned),
             _ => _.Metadata.TypeId,

--- a/Source/Events/Store/IFetchCommittedEvents.cs
+++ b/Source/Events/Store/IFetchCommittedEvents.cs
@@ -69,25 +69,25 @@ public interface IFetchCommittedEvents
     Task<CommittedAggregateEvents> FetchForAggregateAfter(EventSourceId eventSource, ArtifactId aggregateRoot, AggregateRootVersion after,
         CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Get the number of events matching the filter before and including the given <see cref="EventLogSequenceNumber"/>.
-    /// </summary>
-    /// <param name="scope"></param>
-    /// <param name="to"></param>
-    /// <param name="eventTypes"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task<StreamPosition> GetStreamPositionFromArtifactSet(ScopeId scope, EventLogSequenceNumber to, IEnumerable<ArtifactId> eventTypes,
-        CancellationToken cancellationToken);
+    // /// <summary>
+    // /// Get the number of events matching the filter before and including the given <see cref="EventLogSequenceNumber"/>.
+    // /// </summary>
+    // /// <param name="scope"></param>
+    // /// <param name="to"></param>
+    // /// <param name="eventTypes"></param>
+    // /// <param name="cancellationToken"></param>
+    // /// <returns></returns>
+    // Task<StreamPosition> GetStreamPositionFromArtifactSet(ScopeId scope, EventLogSequenceNumber to, IEnumerable<ArtifactId> eventTypes,
+    //     CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Get the number of events matching the filter before and including the given <see cref="EventLogSequenceNumber"/>.
-    /// </summary>
-    /// <param name="scope"></param>
-    /// <param name="nextStreamPosition"></param>
-    /// <param name="eventTypes"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task<Try<EventLogSequenceNumber>> GetEventLogSequenceFromArtifactSet(ScopeId scope, StreamPosition nextStreamPosition, IEnumerable<ArtifactId> eventTypes,
-        CancellationToken cancellationToken);
+    // /// <summary>
+    // /// Get the number of events matching the filter before and including the given <see cref="EventLogSequenceNumber"/>.
+    // /// </summary>
+    // /// <param name="scope"></param>
+    // /// <param name="nextStreamPosition"></param>
+    // /// <param name="eventTypes"></param>
+    // /// <param name="cancellationToken"></param>
+    // /// <returns></returns>
+    // Task<Try<EventLogSequenceNumber>> GetEventLogSequenceFromArtifactSet(ScopeId scope, StreamPosition nextStreamPosition, IEnumerable<ArtifactId> eventTypes,
+    //     CancellationToken cancellationToken);
 }

--- a/Source/Events/Store/Streams/ICanFetchEventsFromStream.cs
+++ b/Source/Events/Store/Streams/ICanFetchEventsFromStream.cs
@@ -20,6 +20,21 @@ public interface ICanFetchEventsFromStream
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns>The <see cref="StreamEvent" />.</returns>
     Task<Try<IEnumerable<StreamEvent>>> Fetch(StreamPosition position, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Fetch the events from a given <see cref="StreamPosition" />.
+    /// </summary>
+    /// <param name="position"><see cref="StreamPosition">the position in the stream</see>.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+    /// <returns>The <see cref="StreamEvent" />.</returns>
+    Task<Try<StreamEvent>> FetchSingle(StreamPosition position, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Fetch the last event written to the stream
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+    /// <returns>The <see cref="StreamEvent" />.</returns>
+    Task<Try<StreamEvent>> FetchLast(CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the <see cref="StreamPosition"/> that will be used for the next event written to the stream. 

--- a/Source/Events/Store/Streams/Legacy/IGetEventLogSequenceFromStreamPosition.cs
+++ b/Source/Events/Store/Streams/Legacy/IGetEventLogSequenceFromStreamPosition.cs
@@ -10,6 +10,6 @@ namespace Dolittle.Runtime.Events.Store.Streams.Legacy;
 
 public interface IGetEventLogSequenceFromStreamPosition
 {
-    Task<Try<EventLogSequenceNumber>> TryGetEventLogPositionForStreamProcessor(StreamProcessorId id, StreamPosition streamPosition,
+    Task<Try<EventLogSequenceNumber>> TryGetEventLogPositionForStreamProcessor(StreamProcessorId id, bool partitioned, StreamPosition streamPosition,
         CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary
Rewritten GetEventLogPosition which maps from legacy stream positions to the event log sequence. Will now retrieve the correct offset from the stream used in V8.
Also changed the logic to get the next stream position to use the last element instead of the count.
Continuing from a specific stream position will now use the eventlog position for the processor instead of the stream position.