### PR TITLE
Add option to not require producer consent when consuming from EventHorizon

### DIFF
--- a/Source/EventHorizon/EventHorizonGlobalSettings.cs
+++ b/Source/EventHorizon/EventHorizonGlobalSettings.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Configuration;
+
+namespace Dolittle.Runtime.EventHorizon;
+
+[Configuration("eventHorizon")]
+public class EventHorizonGlobalSettings
+{
+    public bool RequireConsent { get; set; } = true;
+}

--- a/Source/Events.Store/EventHorizon/ConsentId.cs
+++ b/Source/Events.Store/EventHorizon/ConsentId.cs
@@ -16,4 +16,6 @@ public record ConsentId(Guid Value) : ConceptAs<Guid>(Value)
     /// </summary>
     /// <param name="reason"><see cref="Guid"/> representation.</param>
     public static implicit operator ConsentId(Guid reason) => new(reason);
+    
+    public static readonly ConsentId NoConsent = Guid.Empty;
 }


### PR DESCRIPTION
## Summary

Added the ability to not require producer consent when consuming from event horizon.

To disable required consent, use the following configuration: `DOLITTLE__RUNTIME__EVENTHORIZON__REQUIRECONSENT=false`
This will then pass NoConsent (empty guid) as a valid consent for the consumer, and allow it to consume as normal.
