### PR TITLE
Graceful disconnect

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,7 +18,6 @@ jobs:
           - 'Events.Store.Streams.StreamProcessorStateRepository'
           - 'Events.Processing.EventHandlers.EventHandler'
           - 'Events.Processing.EventHandlers.FastEventHandler'
-#          - 'Events.Processing.EventHandlers.FastEventHandlerWithImplicitFilter'
           - 'Events.Processing.EventHandlers.Filter'
           - 'Events.Processing.Projections.Projection'
     env:

--- a/Integration/Tests/Events.Processing/given/a_clean_event_store.cs
+++ b/Integration/Tests/Events.Processing/given/a_clean_event_store.cs
@@ -25,8 +25,6 @@ class a_clean_event_store : a_runtime_with_a_single_tenant
     protected static IStreamDefinitionRepository stream_definition_repository;
     protected static IStreamEventSubscriber stream_event_subscriber;
 
-
-
     Establish context = () =>
     {
         event_store = runtime.Host.Services.GetRequiredService<Func<TenantId, IEventStore>>()(execution_context.Tenant);

--- a/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
@@ -208,6 +208,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
             var composedFilter = _filter.EqStringOrGuid(_partitionIdExpression, partitionId.Value)
                                  & _filter.Gte(_sequenceNumberExpression, from.Value)
                                  & _filter.Lt(_sequenceNumberExpression, to.Value);
+            
             if (artifactIds.Any())
             {
                 composedFilter &= _filter.In(_eventToArtifactId, artifactIds);

--- a/Source/Events/Processing/EventHandlers/Actors/ConcurrentPartitionedProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/ConcurrentPartitionedProcessor.cs
@@ -74,17 +74,18 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
 
         public async ValueTask<Task<ReceiveResult>> GetNextCompleted(CancellationToken cancellationToken)
         {
-            var result = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-            if (result.partition != PartitionId.None)
+            var (partition, callback) = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (partition != PartitionId.None)
             {
-                _currentPartitions.Remove(result.partition);
+                _currentPartitions.Remove(partition);
             }
 
-            return result.callback;
+            return callback;
         }
 
         public bool IsEmpty => _currentPartitions.Count == 0;
         public bool IsFull => _currentPartitions.Count == _concurrency;
+        public int Count => _currentPartitions.Count;
     }
 
     internal record State(StreamProcessorState ProcessorState, ActiveRequests ActiveRequests)
@@ -119,7 +120,6 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
             this with { ProcessorState = ProcessorState.WithResult(SkippedProcessing.Instance, streamEvent, DateTimeOffset.UtcNow) };
     }
 
-    bool _catchingUp = true;
     readonly ImmutableHashSet<Guid> _handledTypes;
     readonly int _concurrency;
 
@@ -145,7 +145,8 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
         _handledTypes = handledEventTypes.Select(_ => _.Value).ToImmutableHashSet();
     }
 
-    public async Task Process(ChannelReader<StreamEvent> messages, IStreamProcessorState state, CancellationToken cancellationToken)
+    public async Task Process(ChannelReader<StreamEvent> messages, IStreamProcessorState state, CancellationToken cancellationToken,
+        CancellationToken deadlineToken)
     {
         var currentState = new State(AsPartitioned(state), new ActiveRequests(_concurrency));
         try
@@ -158,15 +159,15 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
                     switch (nextAction)
                     {
                         case NextAction.ReceiveResult:
-                            currentState = await ProcessReceiveResult(currentState, cancellationToken);
+                            currentState = await ProcessReceiveResult(currentState, cancellationToken, deadlineToken);
                             break;
 
                         case NextAction.ProcessNextEvent:
-                            currentState = await ProcessNextEvent(messages, currentState, cancellationToken);
+                            currentState = await ProcessNextEvent(messages, currentState, cancellationToken, deadlineToken);
 
                             break;
                         case NextAction.ProcessFailedEvent:
-                            currentState = await CatchUpForPartition(currentState, partitionId!, cancellationToken);
+                            currentState = await CatchUpForPartition(currentState, partitionId!, cancellationToken, deadlineToken);
 
                             break;
                         case NextAction.Completed:
@@ -175,7 +176,7 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
                 }
                 finally
                 {
-                    await PersistNewState(currentState.ProcessorState, CancellationToken.None);
+                    await PersistNewState(currentState.ProcessorState, deadlineToken);
                 }
             }
         }
@@ -190,44 +191,55 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
         finally
         {
             // If there are requests in-flight, let's try to wait for them to complete
-            await WaitForCompletions(currentState);
+
+            await WaitForCompletions(currentState, deadlineToken);
         }
     }
 
-    async Task WaitForCompletions(State currentState)
+    async Task WaitForCompletions(State currentState, CancellationToken deadlineToken)
     {
         if (currentState.ActiveRequests.IsEmpty)
             return;
 
-        var timeout = CancellationTokens.FromSeconds(10);
-        while (!currentState.ActiveRequests.IsEmpty)
+        Logger.WaitingForCompletions(Identifier.EventProcessorId, Identifier.ScopeId, currentState.ActiveRequests.Count);
+
+        try
         {
-            currentState = await ProcessReceiveResult(currentState, timeout);
+            var timeout = CancellationTokens.FromSeconds(10);
+            while (!currentState.ActiveRequests.IsEmpty && !deadlineToken.IsCancellationRequested)
+            {
+                currentState = await ProcessReceiveResult(currentState, timeout, deadlineToken);
+            }
+            Logger.FinishedWaitingForCompletions(Identifier.EventProcessorId, Identifier.ScopeId);
+        }
+        catch (Exception e)
+        {
+            Logger.FailedWaitingForCompletions(e, Identifier.EventProcessorId, Identifier.ScopeId, currentState.ActiveRequests.Count);
         }
     }
 
-    async Task<State> ProcessNextEvent(ChannelReader<StreamEvent> messages, State currentState, CancellationToken cancellationToken)
+    async Task<State> ProcessNextEvent(ChannelReader<StreamEvent> messages, State currentState, CancellationToken stoppingToken, CancellationToken deadlineToken)
     {
-        var evt = await messages.ReadAsync(cancellationToken);
+        var evt = await messages.ReadAsync(stoppingToken);
         if (currentState.ProcessorState.FailingPartitions.TryGetValue(evt.Partition, out _))
         {
             await currentState.ActiveRequests.AddSkipped(Task.FromResult(AsSkippedEvent(evt)));
             return currentState;
         }
 
-        var newTask = ProcessEventAndReturnStateUpdateCallback(evt, cancellationToken);
+        var newTask = ProcessEventAndReturnStateUpdateCallback(evt, deadlineToken);
         await currentState.ActiveRequests.Add(evt.Partition, newTask);
         return currentState;
     }
 
     ReceiveResult AsSkippedEvent(StreamEvent evt) => current => current.WithSkippedEvent(evt);
 
-    async Task<State> ProcessReceiveResult(State currentState, CancellationToken cancellationToken)
+    async Task<State> ProcessReceiveResult(State currentState, CancellationToken cancellationToken, CancellationToken deadlineToken)
     {
         var readAsync = await currentState.ActiveRequests.GetNextCompleted(cancellationToken);
         var receive = await readAsync;
         currentState = receive(currentState);
-        await PersistNewState(currentState.ProcessorState, CancellationToken.None);
+        await PersistNewState(currentState.ProcessorState, deadlineToken);
         return currentState;
     }
 
@@ -243,18 +255,18 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
         };
     }
 
-    async Task<ReceiveResult> ProcessEventRetryAndReturnStateUpdateCallback(StreamEvent evt, FailingPartitionState partitionState,
-        CancellationToken cancellationToken)
-    {
-        var (processingResult, elapsed) = await RetryProcessingEvent(evt, partitionState.Reason, partitionState.ProcessingAttempts, cancellationToken);
-
-        return state =>
-        {
-            var updatedState = HandleProcessingResult(processingResult, evt, elapsed, state.ProcessorState);
-
-            return state with { ProcessorState = updatedState };
-        };
-    }
+    // async Task<ReceiveResult> ProcessEventRetryAndReturnStateUpdateCallback(StreamEvent evt, FailingPartitionState partitionState,
+    //     CancellationToken cancellationToken)
+    // {
+    //     var (processingResult, elapsed) = await RetryProcessingEvent(evt, partitionState.Reason, partitionState.ProcessingAttempts, cancellationToken);
+    //
+    //     return state =>
+    //     {
+    //         var updatedState = HandleProcessingResult(processingResult, evt, elapsed, state.ProcessorState);
+    //
+    //         return state with { ProcessorState = updatedState };
+    //     };
+    // }
 
     internal enum NextAction
     {
@@ -396,10 +408,9 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
         }
     }
 
-    async Task<State> CatchUpForPartition(
-        State state,
+    async Task<State> CatchUpForPartition(State state,
         PartitionId partition,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken, CancellationToken deadlineToken)
     {
         var failingPartitionState = state.ProcessorState.FailingPartitions[partition];
         if (!ShouldRetryProcessing(failingPartitionState)) return state; // Should not really happen, since we explicitly wait for each partition
@@ -413,11 +424,11 @@ public class ConcurrentPartitionedProcessor : ProcessorBase<StreamProcessorState
         {
             // No more events before the high water mark for this partition, remove it
             state = state with { ProcessorState = state.ProcessorState.WithoutFailingPartition(partition) };
-            await PersistNewState(state.ProcessorState, CancellationToken.None);
+            await PersistNewState(state.ProcessorState, deadlineToken);
             return state;
         }
 
-        var newTask = ProcessEventAndReturnStateUpdateCallback(evt, cancellationToken);
+        var newTask = ProcessEventAndReturnStateUpdateCallback(evt, deadlineToken);
         await state.ActiveRequests.Add(evt.Partition, newTask);
         return state;
     }

--- a/Source/Events/Processing/EventHandlers/Actors/EventHandlerProcessorActor.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/EventHandlerProcessorActor.cs
@@ -164,7 +164,7 @@ public class EventHandlerProcessorActor : IDisposable, IActor
             {
                 await context.StopAsync(pid);
                 await _getStreamProcessorStates(reprocess.TenantId).Persist(_identifier,
-                    CreateProcessorState(reprocess.ProcessingPosition, _filter.Partitioned), context.CancellationToken);
+                    CreateProcessorState(reprocess.ProcessingPosition, _filter.Partitioned), CancellationToken.None);
                 InitTenant(reprocess.TenantId, context);
             }
             else

--- a/Source/Events/Processing/EventHandlers/Actors/ProcessorBase.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/ProcessorBase.cs
@@ -149,21 +149,21 @@ public abstract class ProcessorBase<T> where T : IStreamProcessorState<T>
     /// <param name="failureReason">The reason for why processing failed the last time.</param>
     /// <param name="processingAttempts">The number of times that this event has been processed before.</param>
     /// <param name="currentState">The current <see cref="IStreamProcessorState" />.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
+    /// <param name="deadlineToken">The <see cref="CancellationToken" />.</param>
     /// <returns>A <see cref="Task"/> that, when returned, returns the new <see cref="IStreamProcessorState" />.</returns>
     protected async Task<(T, IProcessingResult)> RetryProcessingEventAndHandleResult(StreamEvent evt, T currentState,
         string failureReason,
         uint processingAttempts,
-        CancellationToken cancellationToken)
+        CancellationToken deadlineToken)
     {
         Logger.LogTrace("ReProcessing event at position {ProcessingPosition}", evt.CurrentProcessingPosition);
-        var (processingResult, elapsed) = await RetryProcessingEvent(evt, failureReason, processingAttempts, cancellationToken);
+        var (processingResult, elapsed) = await RetryProcessingEvent(evt, failureReason, processingAttempts, deadlineToken);
         return (HandleProcessingResult(processingResult, evt, elapsed, currentState), processingResult);
     }
 
-    protected Task PersistNewState(T newState, CancellationToken cancellationToken)
+    protected Task PersistNewState(T newState, CancellationToken deadlineToken)
     {
-        return _streamProcessorStates.Persist(Identifier, newState, cancellationToken);
+        return _streamProcessorStates.Persist(Identifier, newState, deadlineToken);
     }
 
     /// <summary>

--- a/Source/Events/Processing/EventHandlers/EventHandlerFactory.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlerFactory.cs
@@ -65,8 +65,6 @@ public class EventHandlerFactory : IEventHandlerFactory
     /// <inheritdoc />
     public IEventHandler Create(EventHandlerRegistrationArguments arguments, ReverseCallDispatcher dispatcher, CancellationToken cancellationToken)
     {
-        using var linkedShutdownTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dispatcher.ShutdownToken);
-        
         EventProcessor Converter(TenantId _) => new(arguments.Scope, arguments.EventHandler, dispatcher, _loggerFactory.CreateLogger<EventProcessor>());
         return new ActorEventHandler(_streamDefinitions,
             arguments,
@@ -79,7 +77,7 @@ public class EventHandlerFactory : IEventHandlerFactory
             _actorSystem,
             _tenants,
             _createStreamProcessorActorProps,
-            linkedShutdownTokenSource.Token
+            cancellationToken
         );
     }
 

--- a/Source/Events/Processing/EventHandlers/EventHandlerFactory.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlerFactory.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Dolittle.Runtime.Domain.Tenancy;
 using Dolittle.Runtime.Events.Processing.Contracts;
 using Dolittle.Runtime.Events.Processing.EventHandlers.Actors;
-using Dolittle.Runtime.Events.Processing.Streams;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Protobuf;
 using Dolittle.Runtime.Tenancy;
@@ -29,7 +28,6 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers;
 public class EventHandlerFactory : IEventHandlerFactory
 {
     readonly CreateStreamProcessorActorProps _createStreamProcessorActorProps;
-    readonly IStreamProcessors _streamProcessors;
     readonly IStreamDefinitions _streamDefinitions;
     readonly IMetricsCollector _metrics;
     readonly ILoggerFactory _loggerFactory;
@@ -39,21 +37,19 @@ public class EventHandlerFactory : IEventHandlerFactory
     /// <summary>
     /// Initializes a new instance of the <see cref="EventHandlerFactory"/> class.
     /// </summary>
-    /// <param name="streamProcessors">The <see cref="IStreamProcessors"/>.</param>
     /// <param name="streamDefinitions">The <see cref="IStreamDefinitions"/>.</param>
     /// <param name="metrics">The collector to use for metrics.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
     /// <param name="tenants">The <see cref="ITenants"/>.</param>
     /// <param name="actorSystem"></param>
+    /// <param name="createStreamProcessorActorProps">Create Actor props for </param>
     public EventHandlerFactory(
-        IStreamProcessors streamProcessors,
         IStreamDefinitions streamDefinitions,
         IMetricsCollector metrics,
         ILoggerFactory loggerFactory,
         ITenants tenants,
         ActorSystem actorSystem, CreateStreamProcessorActorProps createStreamProcessorActorProps)
     {
-        _streamProcessors = streamProcessors;
         _streamDefinitions = streamDefinitions;
         _metrics = metrics;
         _loggerFactory = loggerFactory;

--- a/Source/Events/Processing/EventHandlers/EventHandlerFactory.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlerFactory.cs
@@ -65,7 +65,9 @@ public class EventHandlerFactory : IEventHandlerFactory
     /// <inheritdoc />
     public IEventHandler Create(EventHandlerRegistrationArguments arguments, ReverseCallDispatcher dispatcher, CancellationToken cancellationToken)
     {
-        EventProcessor Converter(TenantId _) => new EventProcessor(arguments.Scope, arguments.EventHandler, dispatcher, _loggerFactory.CreateLogger<EventProcessor>());
+        using var linkedShutdownTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dispatcher.ShutdownToken);
+        
+        EventProcessor Converter(TenantId _) => new(arguments.Scope, arguments.EventHandler, dispatcher, _loggerFactory.CreateLogger<EventProcessor>());
         return new ActorEventHandler(_streamDefinitions,
             arguments,
             Converter,
@@ -77,7 +79,7 @@ public class EventHandlerFactory : IEventHandlerFactory
             _actorSystem,
             _tenants,
             _createStreamProcessorActorProps,
-            cancellationToken
+            linkedShutdownTokenSource.Token
         );
     }
 

--- a/Source/Events/Processing/EventHandlers/EventHandlersProtocol.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlersProtocol.cs
@@ -7,6 +7,7 @@ using Dolittle.Runtime.Events.Processing.Contracts;
 using Dolittle.Runtime.Protobuf;
 using Dolittle.Runtime.Services;
 using Dolittle.Services.Contracts;
+using InitiateDisconnect = Dolittle.Runtime.Services.InitiateDisconnect;
 
 namespace Dolittle.Runtime.Events.Processing.EventHandlers;
 
@@ -38,7 +39,11 @@ public class EventHandlersProtocol : IEventHandlersProtocol
 
     /// <inheritdoc/>
     public EventHandlerRegistrationResponse CreateFailedConnectResponse(FailureReason failureMessage)
-        => new() { Failure = new Dolittle.Protobuf.Contracts.Failure { Id = EventHandlersFailures.FailedToRegisterEventHandler.Value.ToProtobuf(), Reason = failureMessage } };
+        => new()
+        {
+            Failure = new Dolittle.Protobuf.Contracts.Failure
+                { Id = EventHandlersFailures.FailedToRegisterEventHandler.Value.ToProtobuf(), Reason = failureMessage }
+        };
 
     /// <inheritdoc/>
     public ReverseCallArgumentsContext GetArgumentsContext(EventHandlerRegistrationRequest message)
@@ -75,6 +80,21 @@ public class EventHandlersProtocol : IEventHandlersProtocol
     /// <inheritdoc/>
     public void SetRequestContext(ReverseCallRequestContext context, HandleEventRequest request)
         => request.CallContext = context;
+
+    public InitiateDisconnect? GetInitiateDisconnect(EventHandlerClientToRuntimeMessage message)
+    {
+        if (message.MessageCase != EventHandlerClientToRuntimeMessage.MessageOneofCase.InitiateDisconnect)
+        {
+            return null;
+        }
+
+        var gracePeriod = message.InitiateDisconnect.GracePeriod?.ToTimeSpan();
+
+        return new InitiateDisconnect
+        {
+            GracePeriod = gracePeriod
+        };
+    }
 
     /// <inheritdoc/>
     public ConnectArgumentsValidationResult ValidateConnectArguments(EventHandlerRegistrationArguments arguments)

--- a/Source/Events/Processing/EventHandlers/EventHandlersProtocol.cs
+++ b/Source/Events/Processing/EventHandlers/EventHandlersProtocol.cs
@@ -81,6 +81,8 @@ public class EventHandlersProtocol : IEventHandlersProtocol
     public void SetRequestContext(ReverseCallRequestContext context, HandleEventRequest request)
         => request.CallContext = context;
 
+    public bool SupportsGracefulShutdown => true;
+
     public InitiateDisconnect? GetInitiateDisconnect(EventHandlerClientToRuntimeMessage message)
     {
         if (message.MessageCase != EventHandlerClientToRuntimeMessage.MessageOneofCase.InitiateDisconnect)

--- a/Source/Events/Processing/EventHandlers/EventProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/EventProcessor.cs
@@ -49,7 +49,9 @@ public class EventProcessor : IEventProcessor
     /// <inheritdoc />
     public EventProcessorId Identifier { get; }
 
-    public CancellationToken ShutdownToken => _dispatcher.ShutdownToken;
+    public CancellationToken? ShutdownToken => _dispatcher.ShutdownToken;
+
+    public CancellationToken? DeadlineToken => _dispatcher.DeadlineToken;
 
     /// <inheritdoc />
     public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, ExecutionContext executionContext, CancellationToken cancellationToken)

--- a/Source/Events/Processing/EventHandlers/EventProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/EventProcessor.cs
@@ -49,6 +49,8 @@ public class EventProcessor : IEventProcessor
     /// <inheritdoc />
     public EventProcessorId Identifier { get; }
 
+    public CancellationToken ShutdownToken => _dispatcher.ShutdownToken;
+
     /// <inheritdoc />
     public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, ExecutionContext executionContext, CancellationToken cancellationToken)
     {

--- a/Source/Events/Processing/EventHandlers/LoggerExtensions.cs
+++ b/Source/Events/Processing/EventHandlers/LoggerExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dolittle.Runtime.Artifacts;
+using Dolittle.Runtime.Domain.Tenancy;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Microsoft.Extensions.Logging;
@@ -66,8 +67,8 @@ static partial class LoggerExtensions
 
     static readonly Action<ILogger, Guid, Guid, Exception> _eventHandlerDisconnected = LoggerMessage
         .Define<Guid, Guid>(
-            LogLevel.Debug,
-            new EventId(414482081, nameof(EventHandlerDisconnected)),
+            LogLevel.Information,
+            new EventId(414482081, nameof(EventHandlerDisconnectedForTenant)),
             "Event handler: {EventHandler} in scope: {Scope} disconnected");
 
     static readonly Action<ILogger, Guid, Exception> _startingEventHandler = LoggerMessage
@@ -159,6 +160,9 @@ static partial class LoggerExtensions
     [LoggerMessage(0, LogLevel.Information, "Failing eventHandler was cancelled, no retries scheduled: {EventHandler} in scope: {Scope}. Error: {Reason}")]
     internal static partial void StoppedFailingEventHandler(this ILogger logger, EventProcessorId eventHandler, ScopeId scope, string reason);
 
+    [LoggerMessage(0, LogLevel.Debug, "Event handler: {EventHandler} in scope: {Scope} disconnected for tenant {TenantId}")]
+    internal static partial void EventHandlerDisconnectedForTenant(this ILogger logger, EventProcessorId eventHandler, ScopeId scope, TenantId tenantId);
+    
     internal static void EventHandlerDisconnected(this ILogger logger, EventProcessorId handlerId, ScopeId scopeId)
         => _eventHandlerDisconnected(logger, handlerId, scopeId, null);
 

--- a/Source/Events/Processing/EventHandlers/LoggerExtensions.cs
+++ b/Source/Events/Processing/EventHandlers/LoggerExtensions.cs
@@ -112,7 +112,8 @@ static partial class LoggerExtensions
             new EventId(250914604, nameof(EventProcessorIsProcessingAgain)),
             "Event processor: {EventProcessor} is processing event type: {EventTypeId} for partition: {PartitionId} again for the {RetryCount} time, because of: {FailureReason}");
 
-    internal static void ReceivedEventHandler(this ILogger logger, StreamId sourceStream, EventProcessorId handler, ScopeId scope, IEnumerable<ArtifactId> types, bool partitioned)
+    internal static void ReceivedEventHandler(this ILogger logger, StreamId sourceStream, EventProcessorId handler, ScopeId scope,
+        IEnumerable<ArtifactId> types, bool partitioned)
         => _receivedEventHandler(logger, sourceStream, handler, scope, string.Join(", ", types.Select(_ => $"'{_.Value}'")), partitioned, null);
 
     internal static void EventHandlerIsInvalid(this ILogger logger, EventProcessorId handler)
@@ -139,16 +140,25 @@ static partial class LoggerExtensions
     internal static void CouldNotStartEventHandler(this ILogger logger, EventProcessorId handlerId, ScopeId scopeId)
         => _couldNotStartEventHandler(logger, handlerId, scopeId, null);
 
-    
-    [LoggerMessage(0,LogLevel.Warning, "An error occurred while running event handler: {EventHandler} in scope: {Scope}")]
+
+    [LoggerMessage(0, LogLevel.Warning, "An error occurred while running event handler: {EventHandler} in scope: {Scope}")]
     internal static partial void ErrorWhileRunningEventHandler(this ILogger logger, Exception ex, EventProcessorId eventHandler, ScopeId scope);
+
+    [LoggerMessage(0, LogLevel.Information, "Waiting for completions: {EventHandler} in scope: {Scope}, {RequestsInFlight} requests in flight")]
+    internal static partial void WaitingForCompletions(this ILogger logger, EventProcessorId eventHandler, ScopeId scope, int requestsInFlight);
     
-    [LoggerMessage(0,LogLevel.Information, "EventHandler was cancelled: {EventHandler} in scope: {Scope}")]
+    [LoggerMessage(0, LogLevel.Information, "All handlers complete: {EventHandler} in scope: {Scope}")]
+    internal static partial void FinishedWaitingForCompletions(this ILogger logger, EventProcessorId eventHandler, ScopeId scope);
+
+    [LoggerMessage(0, LogLevel.Error, "Failed while waiting for completions: {EventHandler} in scope: {Scope}")]
+    internal static partial void FailedWaitingForCompletions(this ILogger logger, Exception ex, EventProcessorId eventHandler, ScopeId scope, int requestsInFlight);
+
+    [LoggerMessage(0, LogLevel.Information, "EventHandler was cancelled: {EventHandler} in scope: {Scope}")]
     internal static partial void CancelledRunningEventHandler(this ILogger logger, Exception ex, EventProcessorId eventHandler, ScopeId scope);
-    
-    [LoggerMessage(0,LogLevel.Information, "Failing eventHandler was cancelled, no retries scheduled: {EventHandler} in scope: {Scope}. Error: {Reason}")]
+
+    [LoggerMessage(0, LogLevel.Information, "Failing eventHandler was cancelled, no retries scheduled: {EventHandler} in scope: {Scope}. Error: {Reason}")]
     internal static partial void StoppedFailingEventHandler(this ILogger logger, EventProcessorId eventHandler, ScopeId scope, string reason);
-    
+
     internal static void EventHandlerDisconnected(this ILogger logger, EventProcessorId handlerId, ScopeId scopeId)
         => _eventHandlerDisconnected(logger, handlerId, scopeId, null);
 
@@ -170,6 +180,7 @@ static partial class LoggerExtensions
     internal static void EventProcessorIsProcessing(this ILogger logger, EventProcessorId handlerId, ArtifactId eventType, PartitionId partition)
         => _eventProcessorIsProcessing(logger, handlerId, eventType, partition, null);
 
-    internal static void EventProcessorIsProcessingAgain(this ILogger logger, EventProcessorId handlerId, ArtifactId eventType, PartitionId partition, uint retryCount, string failureReason)
+    internal static void EventProcessorIsProcessingAgain(this ILogger logger, EventProcessorId handlerId, ArtifactId eventType, PartitionId partition,
+        uint retryCount, string failureReason)
         => _eventProcessorIsProcessingAgain(logger, handlerId, eventType, partition, retryCount, failureReason, null);
 }

--- a/Source/Events/Processing/Filters/AbstractFilterProcessor.cs
+++ b/Source/Events/Processing/Filters/AbstractFilterProcessor.cs
@@ -50,6 +50,9 @@ public abstract class AbstractFilterProcessor<TDefinition> : IFilterProcessor<TD
     /// <inheritdoc />
     public EventProcessorId Identifier => Definition.TargetStream.Value;
 
+    public CancellationToken? ShutdownToken { get; } = null;
+    public CancellationToken? DeadlineToken { get; } = null;
+
     /// <inheritdoc/>
     public abstract Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, ExecutionContext executionContext, CancellationToken cancellationToken);
 

--- a/Source/Events/Processing/IEventProcessor.cs
+++ b/Source/Events/Processing/IEventProcessor.cs
@@ -25,6 +25,16 @@ public interface IEventProcessor
     EventProcessorId Identifier { get; }
 
     /// <summary>
+    /// Let the processor know that it should shut down.
+    /// </summary>
+    CancellationToken ShutdownToken => CancellationToken.None;
+    
+    /// <summary>
+    /// Do not wait for graceful shutdown after this has been cancelled
+    /// </summary>
+    CancellationToken DeadlineToken => CancellationToken.None;
+
+    /// <summary>
     /// Processes an <see cref="CommittedEvent" /> for a <see cref="PartitionId"> partition </see>.
     /// </summary>
     /// <param name="event">The <see cref="CommittedEvent" />.</param>
@@ -44,5 +54,6 @@ public interface IEventProcessor
     /// <param name="executionContext">The execution context to process the event in.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns><see cref="IProcessingResult" />.</returns>
-    Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken);
+    Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, ExecutionContext executionContext,
+        CancellationToken cancellationToken);
 }

--- a/Source/Events/Processing/IEventProcessor.cs
+++ b/Source/Events/Processing/IEventProcessor.cs
@@ -27,12 +27,12 @@ public interface IEventProcessor
     /// <summary>
     /// Let the processor know that it should shut down.
     /// </summary>
-    CancellationToken ShutdownToken => CancellationToken.None;
-    
+    CancellationToken? ShutdownToken => null;
+
     /// <summary>
     /// Do not wait for graceful shutdown after this has been cancelled
     /// </summary>
-    CancellationToken DeadlineToken => CancellationToken.None;
+    CancellationToken? DeadlineToken => null;
 
     /// <summary>
     /// Processes an <see cref="CommittedEvent" /> for a <see cref="PartitionId"> partition </see>.

--- a/Source/Events/Store/Actors/StreamSubscriptionActor.cs
+++ b/Source/Events/Store/Actors/StreamSubscriptionActor.cs
@@ -108,6 +108,10 @@ public class StreamSubscriptionActor : IActor
                 context.Stop(context.Self);
                 return;
             }
+            catch (TimeoutException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                // Stopping, no need to log
+            }
             catch (Exception e)
             {
                 _logger.ErrorPublishingSubscribedEvents(e, _subscriptionName);

--- a/Source/Events/Store/Log.cs
+++ b/Source/Events/Store/Log.cs
@@ -62,7 +62,7 @@ static partial class Log
     
     static readonly Action<ILogger, Exception> _subscriptionReturnedDeadLetter = LoggerMessage
         .Define(
-            LogLevel.Warning,
+            LogLevel.Debug,
             new EventId(0, nameof(SubscriptionReturnedDeadLetter)),
             "Subscription target returned dead letter response");
 

--- a/Source/Events/Store/Streams/StreamEventSubscriber.cs
+++ b/Source/Events/Store/Streams/StreamEventSubscriber.cs
@@ -74,7 +74,8 @@ public class StreamEventSubscriber : IStreamEventSubscriber
                         if (include(evt))
                         {
                             var streamEvent = new StreamEvent(evt.FromProtobuf(), current, StreamId.EventLog, evt.EventSourceId, partitioned);
-                            await writer.WriteAsync(streamEvent, cancellationToken);
+                            // ReSharper disable once MethodSupportsCancellation
+                            await writer.WriteAsync(streamEvent);
                             current = current.Increment();
                         }
                     }

--- a/Source/Services/Actors/ReverseCallDispatcherActor.cs
+++ b/Source/Services/Actors/ReverseCallDispatcherActor.cs
@@ -38,13 +38,18 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
 
         public record Call(TRequest Request, ExecutionContext ExecutionContext);
 
+        public record Send(TServerMessage Request);
+
         public record CallResponse(TResponse Response, ReverseCallId CallId);
+
+        public record InitDisconnect(InitiateDisconnect InitiateDisconnect);
     }
 
     public class Wrapper : IReverseCallDispatcher<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>
     {
         readonly ActorSystem _actorSystem;
         readonly PID _actor;
+        readonly CancellationTokenSource _shutdownTokenSource = new();
 
         public Wrapper(
             ActorSystem actorSystem,
@@ -57,11 +62,14 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
             _actor = actorSystem.Root.SpawnNamed(
                 propsCreator.PropsFor<ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>>(
                     connection,
-                    messageConverter),
+                    messageConverter,
+                    _shutdownTokenSource),
                 $"reverse-call-dispatcher-{requestId.Value}");
         }
 
         public void Dispose() => _actor.Stop(_actorSystem);
+
+        public CancellationToken ShutdownToken => _shutdownTokenSource.Token;
 
         public TConnectArguments? Arguments { get; private set; }
 
@@ -115,6 +123,16 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
 
             return getResult.Result;
         }
+
+        public async Task WriteMessage(TServerMessage message, CancellationToken cancellationToken)
+        {
+            var getResult = await _actorSystem.Root.RequestAsync<Try>(_actor, new Messages.Send(message), CancellationToken.None)
+                .ConfigureAwait(false);
+            if (!getResult.Success)
+            {
+                ExceptionDispatchInfo.Capture(getResult.Exception).Throw();
+            }
+        }
     }
 
     readonly IPingedConnection<TClientMessage, TServerMessage> _reverseCallConnection;
@@ -122,6 +140,7 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
     readonly ICreateExecutionContexts _executionContextFactory;
     readonly IMetricsCollector _metricsCollector;
     readonly ILogger<ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>> _logger;
+    readonly CancellationTokenSource _shutdownTokenSource;
     readonly Dictionary<ReverseCallId, TaskCompletionSource<TResponse>> _calls = new();
 
     bool _disposed;
@@ -134,13 +153,15 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
         IConvertReverseCallMessages<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse> messageConverter,
         ICreateExecutionContexts executionContextFactory,
         IMetricsCollector metricsCollector,
-        ILogger<ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>> logger)
+        ILogger<ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnectArguments, TConnectResponse, TRequest, TResponse>> logger,
+        CancellationTokenSource _shutdownTokenSource)
     {
         _reverseCallConnection = reverseCallConnection;
         _messageConverter = messageConverter;
         _executionContextFactory = executionContextFactory;
         _metricsCollector = metricsCollector;
         _logger = logger;
+        this._shutdownTokenSource = _shutdownTokenSource;
     }
 
     public Task ReceiveAsync(IContext context)
@@ -151,9 +172,18 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
             Messages.Reject reject => OnReject(reject, context.Respond),
             Messages.Call message => OnCall(context, message, context.Respond),
             Messages.CallResponse response => OnCallResponse(response),
+            Messages.Send response => OnSend(response, context.Respond),
+            Messages.InitDisconnect initDisconnect => OnInitDisconnect(initDisconnect),
             Stopped => DisposeAsync().AsTask(),
             _ => Task.CompletedTask
         };
+
+    Task OnInitDisconnect(Messages.InitDisconnect msg)
+    {
+        _shutdownTokenSource.Cancel();
+        // TODO: deadline for graceful shutdown
+        return Task.CompletedTask;
+    }
 
 
     Task OnCallResponse(Messages.CallResponse msg)
@@ -298,6 +328,38 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
         }
     }
 
+    async Task OnSend(Messages.Send command, Action<Try> respond)
+    {
+        if (_disposed)
+        {
+            RespondError(new CannotPerformCallOnCompletedReverseCallConnection());
+            return;
+        }
+
+        if (_rejected)
+        {
+            RespondError(new ReverseCallDispatcherAlreadyRejected());
+            return;
+        }
+
+        try
+        {
+            await _reverseCallConnection.ClientStream.WriteAsync(command.Request).ConfigureAwait(false);
+            respond(Try.Succeeded);
+        }
+        catch (Exception e)
+        {
+            RespondError(e);
+        }
+
+
+        void RespondError(Exception ex)
+        {
+            respond(Try.Failed(ex));
+        }
+    }
+
+
     Task OnCall(IContext context, Messages.Call msg, Action<Try<TResponse>> respond)
     {
         if (_disposed)
@@ -400,6 +462,14 @@ public class ReverseCallDispatcherActor<TClientMessage, TServerMessage, TConnect
             while (!cts.Token.IsCancellationRequested && await reader.MoveNext(cts.Token).ConfigureAwait(false))
             {
                 var message = reader.Current;
+                var initiateDisconnect = _messageConverter.GetInitiateDisconnect(message);
+                if (initiateDisconnect is not null)
+                {
+                    _logger.ReceivedInitiateDisconnect();
+                    context.Send(context.Self, new Messages.InitDisconnect(initiateDisconnect));
+                    continue;
+                }
+                
                 var response = _messageConverter.GetResponse(message);
                 if (response != null)
                 {

--- a/Source/Services/IConvertReverseCallMessages.cs
+++ b/Source/Services/IConvertReverseCallMessages.cs
@@ -87,13 +87,15 @@ public interface IConvertReverseCallMessages<TClientMessage, TServerMessage, TCo
     /// <returns>The <see cref="Pong"/> in the message.</returns>
     Pong? GetPong(TClientMessage message);
 
+    bool SupportsGracefulShutdown => false;
+    
     /// <summary>
     /// If the protocol supports it, and it is of the correct type, get <see cref="InitiateDisconnect" /> from the <typeparamref name="TClientMessage"/>.
     /// </summary>
     /// <param name="message"></param>
     /// <returns></returns>
     InitiateDisconnect? GetInitiateDisconnect(TClientMessage message) => null;
-
+    
     /// <summary>
     /// Creates a <typeparamref name="TConnectResponse"/> signifying a failed connection.
     /// </summary>

--- a/Source/Services/IConvertReverseCallMessages.cs
+++ b/Source/Services/IConvertReverseCallMessages.cs
@@ -88,6 +88,13 @@ public interface IConvertReverseCallMessages<TClientMessage, TServerMessage, TCo
     Pong? GetPong(TClientMessage message);
 
     /// <summary>
+    /// If the protocol supports it, and it is of the correct type, get <see cref="InitiateDisconnect" /> from the <typeparamref name="TClientMessage"/>.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <returns></returns>
+    InitiateDisconnect? GetInitiateDisconnect(TClientMessage message) => null;
+
+    /// <summary>
     /// Creates a <typeparamref name="TConnectResponse"/> signifying a failed connection.
     /// </summary>
     /// <param name="failureMessage">The reason for failure.</param>

--- a/Source/Services/IReverseCallDispatcher.cs
+++ b/Source/Services/IReverseCallDispatcher.cs
@@ -35,6 +35,8 @@ public interface IReverseCallDispatcher<TClientMessage, TServerMessage, TConnect
     /// Gets the <see cref="ExecutionContext"/> received from the initial Connect call from the client.
     /// </summary>
     ExecutionContext ExecutionContext { get; }
+    
+    CancellationToken ShutdownToken { get; }
 
     /// <summary>
     /// Waits for the initial Connect call arguments from the client.
@@ -68,4 +70,12 @@ public interface IReverseCallDispatcher<TClientMessage, TServerMessage, TConnect
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns>A <see cref="Task"/> that, when resolved, returns the <typeparamref name="TResponse"/> from the client.</returns>
     Task<TResponse> Call(TRequest request, ExecutionContext executionContext, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Write a message to the client without waiting for a response.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task WriteMessage(TServerMessage message, CancellationToken cancellationToken);
 }

--- a/Source/Services/IReverseCallDispatcher.cs
+++ b/Source/Services/IReverseCallDispatcher.cs
@@ -36,7 +36,15 @@ public interface IReverseCallDispatcher<TClientMessage, TServerMessage, TConnect
     /// </summary>
     ExecutionContext ExecutionContext { get; }
     
-    CancellationToken ShutdownToken { get; }
+    /// <summary>
+    /// I
+    /// </summary>
+    CancellationToken? ShutdownToken { get; }
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    CancellationToken? DeadlineToken { get; }
 
     /// <summary>
     /// Waits for the initial Connect call arguments from the client.

--- a/Source/Services/InitiateDisconnect.cs
+++ b/Source/Services/InitiateDisconnect.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Dolittle.Runtime.Events.Processing.EventHandlers;
+using System;
 
-public class EventHandlerManagerActor
+namespace Dolittle.Runtime.Services;
+
+public record InitiateDisconnect
 {
-    
+    public required TimeSpan? GracePeriod { get; init; }
 }

--- a/Source/Services/Log.cs
+++ b/Source/Services/Log.cs
@@ -23,6 +23,9 @@ static partial class Log
     [LoggerMessage(0, LogLevel.Trace, "Received response.")]
     internal static partial void ReceivedResponse(this ILogger logger);
     
+    [LoggerMessage(0, LogLevel.Debug, "Received InitiateDisconnect.")]
+    internal static partial void ReceivedInitiateDisconnect(this ILogger logger);
+    
     [LoggerMessage(0, LogLevel.Warning, "Could not find the call id from the received response from the client. The message will be ignored.")]
     internal static partial void CouldNotFindCallId(this ILogger logger);
 

--- a/Specifications/Events.Processing/Mappings/streamprocessorstate/partitioned/failing/mapping_is_correct.cs
+++ b/Specifications/Events.Processing/Mappings/streamprocessorstate/partitioned/failing/mapping_is_correct.cs
@@ -21,7 +21,6 @@ public class mapping_a_failing_partitioned_state : given.a_failing_partitioned_s
         before = stream_processor_state;
         as_protobuf = stream_processor_state.ToProtobuf();
         after = (StreamProcessorState)as_protobuf.FromProtobuf();
-        Console.WriteLine(after);
     };
 
     It should_not_be_lossy = () => after.Should().BeEquivalentTo(before);

--- a/versions.props
+++ b/versions.props
@@ -4,7 +4,7 @@
         <AutofacExtensionsVersion>7.2.0</AutofacExtensionsVersion>
         <BaselineTypeDiscoveryVersion>1.1.2</BaselineTypeDiscoveryVersion>
         <ConsoleTablesVersion>2.4.2</ConsoleTablesVersion>
-        <ContractsVersion>7.7.0</ContractsVersion>
+        <ContractsVersion>7.8.0</ContractsVersion>
         <CoverletVersion>3.1.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>


### PR DESCRIPTION
## Summary
Adds graceful disconnects for event handlers. This ensures that the system waits for the current handlers to complete before completing shutdowns / disconnects.

Also adresses some minor internal fixes.

### Changed
- Updated projections to accommodate newer MongoDB drivers.
- Rewritten event handlers to support graceful disconnects from the client.

### Fixed
- Resolved an issue in eventlogstream-subscriptions, ensuring correct subscription cancellation.
