### PR TITLE
Eventhorizon error handling

### DIFF
--- a/Integration/Shared/Runtime.cs
+++ b/Integration/Shared/Runtime.cs
@@ -49,26 +49,26 @@ public static class Runtime
             .AddEnvironmentVariables()
             .Build();
 
-        var configuration = new Dictionary<string, string>();
+        var configuration = new Dictionary<string, string?>();
         var (databases, tenants) = CreateRuntimeConfiguration(configuration, numberOfTenants);
 
         var runtimeHost = Host.CreateDefaultBuilder()
             .UseDolittleServices()
             .ConfigureOpenTelemetry(cfg)
-            .ConfigureHostConfiguration(_ =>
+            .ConfigureHostConfiguration(builder =>
             {
-                _.Sources.Clear();
-                _.AddInMemoryCollection(configuration);
+                builder.Sources.Clear();
+                builder.AddInMemoryCollection(configuration);
             })
-            .ConfigureAppConfiguration(_ =>
+            .ConfigureAppConfiguration(builder =>
             {
-                _.Sources.Clear();
-                _.AddInMemoryCollection(configuration);
+                builder.Sources.Clear();
+                builder.AddInMemoryCollection(configuration);
             })
-            .ConfigureServices(_ =>
+            .ConfigureServices(coll =>
             {
-                _.AddLogging(_ => _.ClearProviders());
-                _.AddOptions<EndpointsConfiguration>().Configure(builder =>
+                coll.AddLogging(builder => builder.ClearProviders());
+                coll.AddOptions<EndpointsConfiguration>().Configure(builder =>
                 {
                     builder.Management = new EndpointConfiguration { Port = 0 };
                     // builder.Private = new EndpointConfiguration { Port = 0 };
@@ -106,7 +106,7 @@ public static class Runtime
     public static Dolittle.Runtime.Execution.ExecutionContext CreateExecutionContextFor(TenantId tenant)
         => new(_microserviceId, tenant, Version.NotSet, _environment, Guid.NewGuid(), null, Claims.Empty, CultureInfo.InvariantCulture);
 
-    static (IEnumerable<string> databases, IEnumerable<TenantId> tenants) CreateRuntimeConfiguration(Dictionary<string, string> configuration,
+    static (IEnumerable<string> databases, IEnumerable<TenantId> tenants) CreateRuntimeConfiguration(Dictionary<string, string?> configuration,
         int numberOfTenants)
     {
         configuration["dolittle:runtime:eventstore:backwardscompatibility:version"] = "V7";

--- a/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
+++ b/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
@@ -204,7 +204,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
             (_, _) => dispatcher.Object.Reject(new EventHandlerRegistrationResponse(), CancellationToken.None),
             CancellationToken.None)));
         tasks.Add(post_start_task ?? Task.CompletedTask);
-        reset_timeout_after_action(TimeSpan.FromSeconds(5));
+        reset_timeout_after_action(TimeSpan.FromSeconds(6));
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
@@ -296,7 +296,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
         });
     }
 
-    static async Task commit_after_delay(IEnumerable<(int number_of_events, EventSourceId event_source, ScopeId scope)> commit)
+    static async Task commit_after_delay((int number_of_events, EventSourceId event_source, ScopeId scope)[] commit)
     {
         if (commit.Any())
         {

--- a/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
+++ b/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
@@ -204,7 +204,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
             (_, _) => dispatcher.Object.Reject(new EventHandlerRegistrationResponse(), CancellationToken.None),
             CancellationToken.None)));
         tasks.Add(post_start_task ?? Task.CompletedTask);
-        reset_timeout_after_action(TimeSpan.FromSeconds(4));
+        reset_timeout_after_action(TimeSpan.FromSeconds(5));
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 

--- a/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
+++ b/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
@@ -204,7 +204,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
             (_, _) => dispatcher.Object.Reject(new EventHandlerRegistrationResponse(), CancellationToken.None),
             CancellationToken.None)));
         tasks.Add(post_start_task ?? Task.CompletedTask);
-        reset_timeout_after_action(TimeSpan.FromSeconds(2));
+        reset_timeout_after_action(TimeSpan.FromSeconds(4));
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 

--- a/Source/EventHorizon/Consumer/Processing/EventProcessor.cs
+++ b/Source/EventHorizon/Consumer/Processing/EventProcessor.cs
@@ -64,19 +64,20 @@ public class EventProcessor : IEventProcessor
         return Process(@event, cancellationToken);
     }
 
-    async Task<IProcessingResult> Process(CommittedEvent @event, CancellationToken cancellationToken)
+    async Task<IProcessingResult> Process(CommittedEvent @event, CancellationToken _)
     {
         _metrics.IncrementTotalEventHorizonEventsProcessed();
         Log.ProcessEvent(_logger, @event.Type.Id, Scope, _subscriptionId.ProducerMicroserviceId, _subscriptionId.ProducerTenantId);
         try
         {
             await _externalEventsCommitter.Commit(new CommittedEvents(new []{@event}), _consentId, Scope).ConfigureAwait(false);
+            return SuccessfulProcessing.Instance;
         }
         catch (Exception e)
         {
-            _logger.LogWarning(e, "Failed to commit external event");
+            _logger.LogWarning(e, "Failed to commit external event, will retry processing later");
             _metrics.IncrementTotalEventHorizonEventWritesFailed();
+            throw;
         }
-        return SuccessfulProcessing.Instance;
     }
 }

--- a/Source/Events.Store.MongoDB/CommittedEventsFetcher.cs
+++ b/Source/Events.Store.MongoDB/CommittedEventsFetcher.cs
@@ -205,10 +205,10 @@ public class CommittedEventsFetcher : IFetchCommittedEvents
                     new Artifact(
                         evt.Aggregate.TypeId,
                         evt.Aggregate.TypeGeneration),
-                    evt.Aggregate.Version,
-                    evt.EventLogSequenceNumber,
-                    evt.Metadata.Occurred,
-                    evt.Metadata.EventSource,
+                    aggregateRootVersion: evt.Aggregate.Version,
+                    eventLogSequenceNumber: evt.EventLogSequenceNumber,
+                    occurred:evt.Metadata.Occurred,
+                    eventSource:evt.Metadata.EventSource,
                     evt.ExecutionContext.ToExecutionContext(),
                     new Artifact(
                         evt.Metadata.TypeId,

--- a/Source/Events.Store.MongoDB/DatabaseConnection.cs
+++ b/Source/Events.Store.MongoDB/DatabaseConnection.cs
@@ -13,7 +13,6 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB;
 

--- a/Source/Events.Store.MongoDB/Streams/EventsToStreamsWriter.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventsToStreamsWriter.cs
@@ -192,6 +192,7 @@ public class EventsToStreamsWriter : IWriteEventsToStreamCollection, IWriteEvent
             MongoDuplicateKeyException => true,
             MongoWriteException writeException => writeException.Message.Contains("duplicate key error"),
             MongoBulkWriteException bulkWriteException => bulkWriteException.Message.Contains("duplicate key error"),
+            MongoCommandException commandException => commandException.Message.Contains("WriteConflict"),
             _ => false,
         };
 }

--- a/Source/Events/Store/Log.cs
+++ b/Source/Events/Store/Log.cs
@@ -4,7 +4,6 @@
 using System;
 using Dolittle.Runtime.Events.Processing.Streams;
 using Microsoft.Extensions.Logging;
-using Proto;
 
 namespace Dolittle.Runtime.Events.Store;
 

--- a/Source/Events/Store/Streams/Legacy/EventLogSequenceFromStreamPosition.cs
+++ b/Source/Events/Store/Streams/Legacy/EventLogSequenceFromStreamPosition.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.DependencyInversion.Lifecycle;

--- a/Specifications/Events.Processing/Mappings/streamprocessorstate/partitioned/failing/mapping_is_correct.cs
+++ b/Specifications/Events.Processing/Mappings/streamprocessorstate/partitioned/failing/mapping_is_correct.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Dolittle.Runtime.Events.Processing.Streams.Partitioned;
 using Dolittle.Runtime.Events.Store.Actors;
 using FluentAssertions;


### PR DESCRIPTION
## Summary

Fixes issue where an EventHorizon event could be skipped by race condition between tenants. 

### Fixed

- Removed incorrectly ignored exception in EventHorizon.
- Classify write conflict as duplicate key.