### PR TITLE
Add MongoDB Atlas support

### DIFF
--- a/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
+++ b/Integration/Tests/Events.Processing/EventHandlers/given/single_tenant_and_event_handlers.cs
@@ -204,7 +204,7 @@ class single_tenant_and_event_handlers : Processing.given.a_clean_event_store
             (_, _) => dispatcher.Object.Reject(new EventHandlerRegistrationResponse(), CancellationToken.None),
             CancellationToken.None)));
         tasks.Add(post_start_task ?? Task.CompletedTask);
-        reset_timeout_after_action(TimeSpan.FromSeconds(6));
+        reset_timeout_after_action(TimeSpan.FromSeconds(10));
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 

--- a/Source/Actors/Hosting/HostBuilderExtensions.cs
+++ b/Source/Actors/Hosting/HostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,7 +28,11 @@ public static class HostBuilderExtensions
     /// <returns>The builder for continuation.</returns>
     public static IHostBuilder AddActorSystem(this IHostBuilder builder)
         => builder.ConfigureServices(_ => _
-            .AddSingleton(provider => new ActorSystem(ActorSystemConfig.Setup())
+            .AddSingleton(provider => new ActorSystem(new ActorSystemConfig
+                {
+                    ConfigureProps = props => props with { StartDeadline = TimeSpan.Zero },
+                    ConfigureSystemProps = (_, props) => props with { StartDeadline = TimeSpan.Zero },
+                })
                 .WithServiceProvider(provider)
                 .WithRemote(GrpcNetRemoteConfig
                     .BindToLocalhost()

--- a/Source/Configuration/Parsing/ConfigurationParser.cs
+++ b/Source/Configuration/Parsing/ConfigurationParser.cs
@@ -26,15 +26,15 @@ public class ConfigurationParser : IParseConfigurationObjects
         error = default;
         try
         {
-            var stream = new MemoryStream();
-            var writer = new StreamWriter(stream);
+            using var stream = new MemoryStream();
+            using var writer = new StreamWriter(stream);
             WriteSectionToStream(configuration, writer);
             writer.Flush();
 
             stream.Seek(0, SeekOrigin.Begin);
-
-            stream.Seek(0, SeekOrigin.Begin);
-            var reader = new JsonTextReader(new StreamReader(stream));
+            
+            
+            using var reader = new JsonTextReader(new StreamReader(stream));
             var serializer = JsonSerializer.Create();
             parsed = serializer.Deserialize<TOptions>(reader);
             return true;

--- a/Source/Diagnostics/Diagnostics.csproj
+++ b/Source/Diagnostics/Diagnostics.csproj
@@ -15,12 +15,11 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
         <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="$(MongoDBOpenTelemetryVersion)" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-rc.4" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.14" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.5.1-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
         <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
     </ItemGroup>
 

--- a/Source/Events.Store.MongoDB/EventStoreConfiguration.cs
+++ b/Source/Events.Store.MongoDB/EventStoreConfiguration.cs
@@ -17,6 +17,11 @@ public class EventStoreConfiguration
     /// Gets or sets the MongoDB servers.
     /// </summary>
     public IEnumerable<string> Servers { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the connection string.
+    /// </summary>
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// Gets or sets the database name.

--- a/Source/Projections.Store.MongoDB/ProjectionsConfiguration.cs
+++ b/Source/Projections.Store.MongoDB/ProjectionsConfiguration.cs
@@ -17,6 +17,11 @@ public class ProjectionsConfiguration
     /// Gets or sets the MongoDB servers.
     /// </summary>
     public IEnumerable<string> Servers { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the connection string.
+    /// </summary>
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// Gets or sets the database name.

--- a/Source/Resources/MongoDB/ConnectionStringFromResourceConfiguration.cs
+++ b/Source/Resources/MongoDB/ConnectionStringFromResourceConfiguration.cs
@@ -28,9 +28,18 @@ public class ConnectionStringFromResourceConfiguration : IKnowTheConnectionStrin
     public MongoUrl ConnectionString { get; }
 
     static MongoUrl BuildConnectionString(MongoDBConfiguration configuration)
-        => new MongoUrlBuilder(configuration.Host)
+    {
+        if (!string.IsNullOrWhiteSpace(configuration.ConnectionString))
+        {
+            return new MongoUrlBuilder(configuration.ConnectionString)
+            {
+                DatabaseName = configuration.Database
+            }.ToMongoUrl();
+        }
+        return new MongoUrlBuilder(configuration.Host)
         {
             UseTls = configuration.UseSSL,
             DatabaseName = configuration.Database
         }.ToMongoUrl();
+    }
 }

--- a/Source/Resources/MongoDB/MongoDBConfiguration.cs
+++ b/Source/Resources/MongoDB/MongoDBConfiguration.cs
@@ -18,6 +18,11 @@ public class MongoDBConfiguration
     public string? Host { get; set; }
 
     /// <summary>
+    /// Gets or sets the connection string.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+    
+    /// <summary>
     /// Gets or sets the database name.
     /// </summary>
     public string? Database { get; set; }

--- a/Source/Server/.dolittle/runtime.yml
+++ b/Source/Server/.dolittle/runtime.yml
@@ -2,21 +2,13 @@ tenants:
   445f8ea8-1a6f-40d7-b2fc-796dba92dc44:
     resources:
       eventStore:
-        servers:
-        - localhost
+        connectionString: mongodb://localhost:27017
         database: event_store
         maxConnectionPoolSize: 1000
       projections:
-        servers:
-        - localhost
+        connectionString: mongodb://localhost:27017
         database: projections
         maxConnectionPoolSize: 1000
-      embeddings:
-        servers:
-        - localhost
-        database: embeddings
-        maxConnectionPoolSize: 1000
       readModels:
-        host: mongodb://localhost:27017
+        connectionString: mongodb://localhost:27017
         database: readmodels
-        useSSL: false

--- a/versions.props
+++ b/versions.props
@@ -8,9 +8,9 @@
         <CoverletVersion>3.1.0</CoverletVersion>
         <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
         <DockerDotNetVersion>3.125.5</DockerDotNetVersion>
-        <GrpcVersion>2.53.0</GrpcVersion>
+        <GrpcVersion>2.58.0</GrpcVersion>
         <GrpcTestingVersion>2.46.6</GrpcTestingVersion>
-        <GrpcToolsVersion>2.54.0</GrpcToolsVersion>
+        <GrpcToolsVersion>2.58.0</GrpcToolsVersion>
         <MachineSpecificationsRunnerVersion>2.10.2</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>
         <McMasterVersion>3.1.0</McMasterVersion>
@@ -18,26 +18,21 @@
         <MicrosoftDotNetVersion>3.1.6</MicrosoftDotNetVersion>
         <MicrosoftDotNetTestVersion>17.7.2</MicrosoftDotNetTestVersion>
         <MicrosoftExtensionsVersion>6.0.0</MicrosoftExtensionsVersion>
-        <MongoDBDriverVersion>2.19.2</MongoDBDriverVersion>
+        <MongoDBDriverVersion>2.22.0</MongoDBDriverVersion>
         <MongoDBOpenTelemetryVersion>1.0.0</MongoDBOpenTelemetryVersion>
         <MoqVersion>4.18.*</MoqVersion>
         <FluentAssertionsVersion>6.12.0</FluentAssertionsVersion>
         <NetEscapadesYaml>2.2.0</NetEscapadesYaml>
-        <NewtonsoftVersion>13.0.1</NewtonsoftVersion>
+        <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
         <NitoAsyncVersion>5.1.0</NitoAsyncVersion>
         <PollyVersion>7.2.3</PollyVersion>
         <PrometheusVersion>6.0.0</PrometheusVersion>
         <PrometheusNetDotNetRuntimeVersion>4.2.4</PrometheusNetDotNetRuntimeVersion>
-        <ProtoActorVersion>1.2.0</ProtoActorVersion>
-        <ProtobufVersion>3.23.0</ProtobufVersion>
-        <SwashbuckleVersion>6.3.0</SwashbuckleVersion>
-        <SystemDataHashFunctionVersion>2.0.0</SystemDataHashFunctionVersion>
+        <ProtoActorVersion>1.5.0</ProtoActorVersion>
+        <ProtobufVersion>3.24.4</ProtobufVersion>
+        <SwashbuckleVersion>6.5.0</SwashbuckleVersion>
         <SystemLinqAsyncVersion>5.1.0</SystemLinqAsyncVersion>
         <SystemSecurityVersion>4.3.0</SystemSecurityVersion>
-        <SystemReactiveVersion>4.4.1</SystemReactiveVersion>
-        <SystemRuntimeVersion>4.3.0</SystemRuntimeVersion>
-        <SystemDynamicVersion>4.3.0</SystemDynamicVersion>
-        <SystemReflectionVersion>4.7.0</SystemReflectionVersion>
-        <XUnitVersion>2.5.0</XUnitVersion>
+        <XUnitVersion>2.5.3</XUnitVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
Changed MongoDB configuration to support srv connection strings. This allows the runtime to use any cloud hosted MongoDB services, such as Atlas.
This is backwards compatible with old connection format, and does not require changing config for existing deployments.

In addition to this, internal dependencies have been upgraded as well.

### Added
- "connectionString" configuration for MongoDB
