### PR TITLE
Optimized MongoDB event storage

### DIFF
--- a/Integration/Tests/Events.Store/should_extensions.cs
+++ b/Integration/Tests/Events.Store/should_extensions.cs
@@ -200,7 +200,7 @@ static class should_extensions
         stored_events.ShouldEachConformTo(_ => _.Aggregate.TypeGeneration.Equals(ArtifactGeneration.First.Value));
         stored_events.ShouldEachConformTo(_ => _.Aggregate.TypeId.Equals(aggregate_events.AggregateRoot.Value));
         stored_events.ShouldEachConformTo(_ => _.Metadata.EventSource.Equals(aggregate_events.EventSource));
-        stored_events.ShouldEachConformTo(_ => _.EventHorizon.FromEventHorizon == false);
+        stored_events.ShouldEachConformTo(_ => _.EventHorizon == null);
 
         for (var i = 0; i < stored_events.Count; i++)
         {
@@ -219,8 +219,8 @@ static class should_extensions
         {
             return;
         }
-        stored_events.ShouldEachConformTo(_ => _.Aggregate.WasAppliedByAggregate == false);
-        stored_events.ShouldEachConformTo(_ => _.EventHorizon.FromEventHorizon == false);
+        stored_events.ShouldEachConformTo(_ => _.WasAppliedByAggregate == false);
+        stored_events.ShouldEachConformTo(_ => _.IsFromEventHorizon == false);
         
         for (var i = 0; i < stored_events.Count; i++)
         {

--- a/Source/Bootstrap/BoostrapProcedures.cs
+++ b/Source/Bootstrap/BoostrapProcedures.cs
@@ -28,20 +28,19 @@ public class BoostrapProcedures : IBootstrapProcedures
     }
 
     /// <inheritdoc />
-    public Task PerformAll()
+    public async Task PerformAll()
     {
         if (_performedBootstrap)
         {
             throw new BootstrapProceduresAlreadyPerformed();
         }
 
-        _performedBootstrap = true;
-        var tasks = new List<Task>();
-        foreach (var procedure in _procedures)
+        foreach (var procedure in _procedures.OrderByDescending(it => it.Priority))
         {
-            tasks.Add(procedure.Perform());
-            tasks.AddRange(_tenants.Select(procedure.PerformForTenant));
+            await procedure.Perform();
+            await Task.WhenAll(_tenants.Select(procedure.PerformForTenant));
         }
-        return Task.WhenAll(tasks);
+
+        _performedBootstrap = true;
     }
 }

--- a/Source/Bootstrap/ICanPerformBoostrapProcedure.cs
+++ b/Source/Bootstrap/ICanPerformBoostrapProcedure.cs
@@ -22,4 +22,6 @@ public interface ICanPerformBoostrapProcedure
     /// </summary>
     /// <returns>The <see cref="Task"/> representing the asynchronous action.</returns>
     Task PerformForTenant(TenantId tenant);
+    
+    int Priority => 0;
 }

--- a/Source/Events.Store.MongoDB/DatabaseMigrator.cs
+++ b/Source/Events.Store.MongoDB/DatabaseMigrator.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Domain.Tenancy;
+using Dolittle.Runtime.Server.Bootstrap;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB;
+
+public class DatabaseMigrator : ICanPerformBoostrapProcedure
+{
+    readonly Func<TenantId, IDatabaseConnection> _getDatabase;
+
+    public DatabaseMigrator(Func<TenantId, IDatabaseConnection> getDatabase)
+    {
+        _getDatabase = getDatabase;
+    }
+
+    public Task Perform() => Task.CompletedTask;
+
+    public async Task PerformForTenant(TenantId tenant)
+    {
+        var db = _getDatabase(tenant).Database;
+        var streams = await GetStreams(db);
+        await CleanupDefaultMetadata(db, streams);
+    }
+
+    async Task CleanupDefaultMetadata(IMongoDatabase db, IList<string> streams)
+    {
+        foreach (var stream in streams)
+        {
+            var collection = db.GetCollection<BsonDocument>(stream);
+            await RemoveEventHorizonDefaultMetadata(collection);
+            await RemoveAggregateDefaultDefaultMetadata(collection);
+        }
+    }
+
+    static async Task<IList<string>> GetStreams(IMongoDatabase db)
+    {
+        var collections = await (await db.ListCollectionNamesAsync()).ToListAsync();
+        var streams = collections.Where(StreamIdMatcher.IsMatch).ToList();
+        return streams;
+    }
+
+    /// <summary>
+    /// Removes the event log default values for the EventHorizon metadata property for events not sent via the Event Horizon.
+    /// </summary>
+    /// <param name="collection"></param>
+    Task RemoveEventHorizonDefaultMetadata<T>(IMongoCollection<T> collection)
+    {
+        var filter = Builders<T>.Filter.Eq("EventHorizon.FromEventHorizon", false);
+        var update = Builders<T>.Update.Unset("EventHorizon");
+
+        return collection.UpdateManyAsync(filter, update);
+    }
+
+    /// <summary>
+    /// Removes the event log default values for the Aggregate metadata property for events not applied by an Aggregate.
+    /// </summary>
+    /// <param name="collection"></param>
+    Task RemoveAggregateDefaultDefaultMetadata<T>(IMongoCollection<T> collection)
+    {
+        var filter = Builders<T>.Filter.Eq("Aggregate.WasAppliedByAggregate", false);
+        var update = Builders<T>.Update.Unset("Aggregate");
+
+        return collection.UpdateManyAsync(filter, update);
+    }
+
+    public int Priority => 1000;
+}

--- a/Source/Events.Store.MongoDB/Events/Event.cs
+++ b/Source/Events.Store.MongoDB/Events/Event.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -57,13 +58,20 @@ public class Event
     /// Gets or sets the event sourcing specific <see cref="AggregateMetadata"/>.
     /// </summary>
     [BsonIgnoreIfNull]
+    [MemberNotNullWhen(true, nameof(WasAppliedByAggregate))]
     public AggregateMetadata? Aggregate { get; set; }
+
+    [BsonIgnore] public bool WasAppliedByAggregate => Aggregate is { WasAppliedByAggregate: true };
 
     /// <summary>
     /// Gets or sets the <see cref="EventHorizonMetadata" />.
     /// </summary>
     [BsonIgnoreIfNull]
+    [MemberNotNullWhen(true, nameof(IsFromEventHorizon))]
+
     public EventHorizonMetadata? EventHorizon { get; set; }
+
+    [BsonIgnore] public bool IsFromEventHorizon => EventHorizon is { FromEventHorizon: true };
 
     /// <summary>
     /// Gets or sets the domain specific event data.

--- a/Source/Events.Store.MongoDB/Events/Event.cs
+++ b/Source/Events.Store.MongoDB/Events/Event.cs
@@ -24,8 +24,8 @@ public class Event
         ulong eventLogSequenceNumber,
         ExecutionContext executionContext,
         EventMetadata metadata,
-        AggregateMetadata aggregate,
-        EventHorizonMetadata eventHorizonMetadata,
+        AggregateMetadata? aggregate,
+        EventHorizonMetadata? eventHorizonMetadata,
         BsonDocument content)
     {
         EventLogSequenceNumber = eventLogSequenceNumber;
@@ -56,12 +56,14 @@ public class Event
     /// <summary>
     /// Gets or sets the event sourcing specific <see cref="AggregateMetadata"/>.
     /// </summary>
-    public AggregateMetadata Aggregate { get; set; }
+    [BsonIgnoreIfNull]
+    public AggregateMetadata? Aggregate { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="EventHorizonMetadata" />.
     /// </summary>
-    public EventHorizonMetadata EventHorizon { get; set; }
+    [BsonIgnoreIfNull]
+    public EventHorizonMetadata? EventHorizon { get; set; }
 
     /// <summary>
     /// Gets or sets the domain specific event data.

--- a/Source/Events.Store.MongoDB/Events/EventConverter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventConverter.cs
@@ -73,9 +73,9 @@ public class EventConverter : IEventConverter
             partitioned);
 
     public runtime.CommittedEvent ToRuntimeCommittedEvent(mongoDB.Event @event) =>
-        @event.Aggregate?.WasAppliedByAggregate == true
+        @event.WasAppliedByAggregate
             ? ToRuntimeCommittedAggregateEvent(@event)
-            : @event.EventHorizon?.FromEventHorizon == true
+            : @event.IsFromEventHorizon
                 ? ToRuntimeCommittedExternalEvent(@event)
                 : new runtime.CommittedEvent(
                     @event.EventLogSequenceNumber,
@@ -122,9 +122,9 @@ public class EventConverter : IEventConverter
             @event.EventHorizon.Consent);
 
     runtime.CommittedEvent ToRuntimeCommittedEvent(mongoDB.StreamEvent @event) =>
-        @event.Aggregate?.WasAppliedByAggregate == true
+        @event.WasAppliedByAggregate
             ? ToRuntimeCommittedAggregateEvent(@event)
-            : @event.EventHorizon?.FromEventHorizon == true
+            : @event.IsFromEventHorizon
                 ? ToRuntimeCommittedExternalEvent(@event)
                 : new runtime.CommittedEvent(
                     @event.Metadata.EventLogSequenceNumber,

--- a/Source/Events.Store.MongoDB/Events/EventConverter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventConverter.cs
@@ -73,9 +73,9 @@ public class EventConverter : IEventConverter
             partitioned);
 
     public runtime.CommittedEvent ToRuntimeCommittedEvent(mongoDB.Event @event) =>
-        @event.Aggregate.WasAppliedByAggregate
+        @event.Aggregate?.WasAppliedByAggregate == true
             ? ToRuntimeCommittedAggregateEvent(@event)
-            : @event.EventHorizon.FromEventHorizon
+            : @event.EventHorizon?.FromEventHorizon == true
                 ? ToRuntimeCommittedExternalEvent(@event)
                 : new runtime.CommittedEvent(
                     @event.EventLogSequenceNumber,
@@ -88,10 +88,11 @@ public class EventConverter : IEventConverter
                     @event.Metadata.Public,
                     _contentConverter.ToJson(@event.Content));
 
-    runtime.CommittedAggregateEvent ToRuntimeCommittedAggregateEvent(mongoDB.Event @event) =>
-        new(
+    runtime.CommittedAggregateEvent ToRuntimeCommittedAggregateEvent(mongoDB.Event @event)
+    {
+        return new CommittedAggregateEvent(
             new Artifact(
-                @event.Aggregate.TypeId,
+                @event.Aggregate!.TypeId,
                 @event.Aggregate.TypeGeneration),
             @event.Aggregate.Version,
             @event.EventLogSequenceNumber,
@@ -103,6 +104,7 @@ public class EventConverter : IEventConverter
                 @event.Metadata.TypeGeneration),
             @event.Metadata.Public,
             _contentConverter.ToJson(@event.Content));
+    }
 
     runtime.CommittedExternalEvent ToRuntimeCommittedExternalEvent(mongoDB.Event @event) =>
         new(
@@ -115,14 +117,14 @@ public class EventConverter : IEventConverter
                 @event.Metadata.TypeGeneration),
             @event.Metadata.Public,
             _contentConverter.ToJson(@event.Content),
-            @event.EventHorizon.ExternalEventLogSequenceNumber,
+            @event.EventHorizon!.ExternalEventLogSequenceNumber,
             @event.EventHorizon.Received,
             @event.EventHorizon.Consent);
 
     runtime.CommittedEvent ToRuntimeCommittedEvent(mongoDB.StreamEvent @event) =>
-        @event.Aggregate.WasAppliedByAggregate
+        @event.Aggregate?.WasAppliedByAggregate == true
             ? ToRuntimeCommittedAggregateEvent(@event)
-            : @event.EventHorizon.FromEventHorizon
+            : @event.EventHorizon?.FromEventHorizon == true
                 ? ToRuntimeCommittedExternalEvent(@event)
                 : new runtime.CommittedEvent(
                     @event.Metadata.EventLogSequenceNumber,
@@ -137,7 +139,7 @@ public class EventConverter : IEventConverter
 
     runtime.CommittedAggregateEvent ToRuntimeCommittedAggregateEvent(mongoDB.StreamEvent @event) =>
         new(
-            new Artifact(@event.Aggregate.TypeId, @event.Aggregate.TypeGeneration),
+            new Artifact(@event.Aggregate!.TypeId, @event.Aggregate.TypeGeneration),
             @event.Aggregate.Version,
             @event.Metadata.EventLogSequenceNumber,
             @event.Metadata.Occurred,
@@ -158,7 +160,7 @@ public class EventConverter : IEventConverter
             new Artifact(@event.Metadata.TypeId, @event.Metadata.TypeGeneration),
             @event.Metadata.Public,
             _contentConverter.ToJson(@event.Content),
-            @event.EventHorizon.ExternalEventLogSequenceNumber,
+            @event.EventHorizon!.ExternalEventLogSequenceNumber,
             @event.EventHorizon.Received,
             @event.EventHorizon.Consent);
 }

--- a/Source/Events.Store.MongoDB/Events/StreamEvent.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEvent.cs
@@ -68,12 +68,16 @@ public class StreamEvent
     [BsonIgnoreIfNull]
     public AggregateMetadata? Aggregate { get; set; }
 
+    [BsonIgnore] public bool WasAppliedByAggregate => Aggregate is { WasAppliedByAggregate: true };
+    
     /// <summary>
     /// Gets or sets the <see cref="EventHorizonMetadata" />.
     /// </summary>
     [BsonIgnoreIfNull]
     public EventHorizonMetadata? EventHorizon { get; set; }
 
+    [BsonIgnore] public bool IsFromEventHorizon => EventHorizon is { FromEventHorizon: true };
+    
     /// <summary>
     /// Gets or sets the domain specific event data.
     /// </summary>

--- a/Source/Events.Store.MongoDB/Events/StreamEvent.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEvent.cs
@@ -27,8 +27,8 @@ public class StreamEvent
         PartitionId partition,
         ExecutionContext executionContext,
         StreamEventMetadata metadata,
-        AggregateMetadata aggregate,
-        EventHorizonMetadata eventHorizonMetadata,
+        AggregateMetadata? aggregate,
+        EventHorizonMetadata? eventHorizonMetadata,
         BsonDocument content)
     {
         StreamPosition = streamPosition;
@@ -65,12 +65,14 @@ public class StreamEvent
     /// <summary>
     /// Gets or sets the event sourcing specific <see cref="AggregateMetadata"/>.
     /// </summary>
-    public AggregateMetadata Aggregate { get; set; }
+    [BsonIgnoreIfNull]
+    public AggregateMetadata? Aggregate { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="EventHorizonMetadata" />.
     /// </summary>
-    public EventHorizonMetadata EventHorizon { get; set; }
+    [BsonIgnoreIfNull]
+    public EventHorizonMetadata? EventHorizon { get; set; }
 
     /// <summary>
     /// Gets or sets the domain specific event data.

--- a/Source/Events.Store.MongoDB/Persistence/ConvertCommitToEvents.cs
+++ b/Source/Events.Store.MongoDB/Persistence/ConvertCommitToEvents.cs
@@ -25,12 +25,10 @@ public class ConvertCommitToEvents : IConvertCommitToEvents
         }
 
         var eventsToStore = new List<MongoDB.Events.Event>();
-        var eventHorizonMetadata = new EventHorizonMetadata();
 
         foreach (var committedEvents in eventsInCommit)
         {
             var executionContext = committedEvents.First().ExecutionContext.ToStoreRepresentation();
-            var aggregateMetadata = new AggregateMetadata();
             eventsToStore.AddRange(committedEvents.Select(_ => new Events.Event(
                 _.EventLogSequenceNumber,
                 executionContext,
@@ -40,13 +38,13 @@ public class ConvertCommitToEvents : IConvertCommitToEvents
                     _.Type.Id,
                     _.Type.Generation,
                     _.Public),
-                aggregateMetadata,
-                eventHorizonMetadata,
+                aggregate:null,
+                eventHorizonMetadata:null,
                 BsonDocument.Parse(_.Content))));
         }
         foreach (var committedEvents in aggregateEventsInCommit)
         {
-            var executionContext = committedEvents.First().ExecutionContext.ToStoreRepresentation();
+            var executionContext = committedEvents[0].ExecutionContext.ToStoreRepresentation();
             eventsToStore.AddRange(committedEvents.Select(_ => new Events.Event(
                 _.EventLogSequenceNumber,
                 executionContext,
@@ -57,7 +55,7 @@ public class ConvertCommitToEvents : IConvertCommitToEvents
                     _.Type.Generation,
                     _.Public),
                 new AggregateMetadata(true, _.AggregateRoot.Id, _.AggregateRoot.Generation, _.AggregateRootVersion),
-                eventHorizonMetadata,
+                null,
                 BsonDocument.Parse(_.Content))));
         }
         return eventsToStore;

--- a/Source/Events.Store.MongoDB/StreamIdMatcher.cs
+++ b/Source/Events.Store.MongoDB/StreamIdMatcher.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB;
+
+public static partial class StreamIdMatcher
+{
+    public static bool IsMatch(string input)
+    {
+        return StreamIdRegex().IsMatch(input);
+    }
+
+    [GeneratedRegex("^stream-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex StreamIdRegex();
+}

--- a/Source/Events.Store.MongoDB/Streams/Streams.cs
+++ b/Source/Events.Store.MongoDB/Streams/Streams.cs
@@ -38,6 +38,8 @@ public class Streams : EventStoreConnection, IStreams
 
         CreateCollectionsAndIndexesForEventLog();
         CreateCollectionsAndIndexesForStreamDefinitions();
+        RemoveAggregateDefaultDefaultMetadata();
+        RemoveEventHorizonDefaultMetadata();
     }
 
     /// <inheritdoc/>
@@ -236,5 +238,29 @@ public class Streams : EventStoreConnection, IStreams
                 Builders<MongoDB.Streams.StreamDefinition>.IndexKeys
                     .Ascending(_ => _.StreamId)),
             cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+    
+    /// <summary>
+    /// Removes the event log default values for the EventHorizon property for events not sent via the Event Horizon.
+    /// </summary>
+    /// <param name="db"></param>
+    void RemoveEventHorizonDefaultMetadata()
+    {
+        var filter = Builders<MongoDB.Events.Event>.Filter.Eq("EventHorizon.FromEventHorizon", false);
+        var update = Builders<MongoDB.Events.Event>.Update.Unset("EventHorizon");
+
+        DefaultEventLog.UpdateMany(filter, update);
+    }
+    
+    /// <summary>
+    /// Removes the event log default values for the Aggregate property for events not applied by an Aggregate.
+    /// </summary>
+    /// <param name="db"></param>
+    void RemoveAggregateDefaultDefaultMetadata()
+    {
+        var filter = Builders<MongoDB.Events.Event>.Filter.Eq("Aggregate.WasAppliedByAggregate", false);
+        var update = Builders<MongoDB.Events.Event>.Update.Unset("Aggregate");
+
+        DefaultEventLog.UpdateMany(filter, update);
     }
 }

--- a/Source/Events/Store/Actors/BootstrapProcedures.cs
+++ b/Source/Events/Store/Actors/BootstrapProcedures.cs
@@ -19,7 +19,7 @@ public class BootstrapProcedures : ICanPerformBoostrapProcedure
 {
     readonly ActorSystem _actorSystem;
     readonly Func<TenantId, ICreateProps> _getPropsCreator;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BootstrapProcedures"/> class.
     /// </summary>

--- a/Source/Events/Store/Actors/IMetricsCollector.cs
+++ b/Source/Events/Store/Actors/IMetricsCollector.cs
@@ -51,4 +51,14 @@ public interface IMetricsCollector
     /// Increments the total number of <see cref="AggregateRootConcurrencyConflict"/> errors received when persisting commits.
     /// </summary>
     void IncrementTotalAggregateRootConcurrencyConflicts(TenantId tenant, ArtifactId aggregateRoot);
+    
+    /// <summary>
+    /// Increments the number of events streamed in-memory per subscription.
+    /// </summary>
+    void IncrementStreamedSubscriptionEvents(string subscriptionName, int incBy);
+    
+    /// <summary>
+    /// Increments the number of catch-up events (read from DB) per subscription.
+    /// </summary>
+    void IncrementCatchupSubscriptionEvents(string eventProcessorKind, int incBy);
 }

--- a/Source/Events/Store/Actors/MetricsCollector.cs
+++ b/Source/Events/Store/Actors/MetricsCollector.cs
@@ -30,6 +30,8 @@ public class MetricsCollector : IMetricsCollector
     readonly Counter _totalCommittedEvents;
     readonly Counter _totalCommittedAggregateEvents;
     readonly Counter _totalAggregateConcurrencyConflicts;
+    readonly Counter _streamedSubscriptionEventsTotal;
+    readonly Counter _catchupSubscriptionEventsTotal;
 
     public MetricsCollector(IMetricFactory metricFactory, IEventTypes eventTypes, IAggregateRoots aggregateRoots)
     {
@@ -81,6 +83,16 @@ public class MetricsCollector : IMetricsCollector
             "dolittle_customer_runtime_events_store_aggregate_concurrency_conflicts_total",
             "EventStore total number of aggregate concurrency conflicts by aggregate root",
             new[] {"tenantId", "aggregateRootId", "aggregateRootAlias"});
+        
+        _streamedSubscriptionEventsTotal = metricFactory.CreateCounter(
+            "dolittle_customer_runtime_events_store_streamed_events_total",
+            "Total number of directly streamed events",
+            new[] { "subscriptionName" });
+
+        _catchupSubscriptionEventsTotal = metricFactory.CreateCounter(
+            "dolittle_customer_runtime_events_store_catchup_events_total",
+            "Total number of catchup-events (events that are not streamed directly, but read from DB)",
+            new[] { "subscriptionName" });
     }
 
     /// <inheritdoc />
@@ -166,4 +178,11 @@ public class MetricsCollector : IMetricsCollector
             ? string.Empty
             : aggregateRootInfo.Alias.Value;
     }
+    
+    
+    public void IncrementStreamedSubscriptionEvents(string subscriptionName, int incBy)
+        => _streamedSubscriptionEventsTotal.WithLabels(subscriptionName).Inc(incBy);
+
+    public void IncrementCatchupSubscriptionEvents(string subscriptionName, int incBy)
+        => _catchupSubscriptionEventsTotal.WithLabels(subscriptionName).Inc(incBy);
 }

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_event_log_event/an_external_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_event_log_event/an_external_event.cs
@@ -21,7 +21,7 @@ public class an_external_event : given.an_event_content_converter
 
     It should_represent_the_same_event = () => result.ShouldBeTheSameAs(committed_event);
     It should_not_be_applied_by_aggregate = () => result.Aggregate.WasAppliedByAggregate.ShouldBeFalse();
-    It should_come_from_event_horizon = () => result.EventHorizon.FromEventHorizon.ShouldBeTrue();
+    It should_come_from_event_horizon = () => result.IsFromEventHorizon.ShouldBeTrue();
     It should_have_the_same_consent = () => result.EventHorizon.Consent.ShouldEqual(committed_event.Consent.Value);
     It should_have_the_same_external_event_log_sequence_number = () => result.EventHorizon.ExternalEventLogSequenceNumber.ShouldEqual(committed_event.ExternalEventLogSequenceNumber.Value);
     It shoul_have_the_same_received_value = () => result.EventHorizon.Received.ShouldEqual(committed_event.Received.UtcDateTime);

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/a_non_aggregate_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/a_non_aggregate_event.cs
@@ -27,8 +27,8 @@ public class a_non_aggregate_event : given.an_event_content_converter
     It should_represent_the_same_event = () => result.ShouldBeTheSameAs(committed_event);
     It should_have_the_correct_stream_position = () => result.StreamPosition.ShouldEqual(stream_position.Value);
     It should_have_the_correct_partition = () => result.Partition.ShouldEqual(partition.Value);
-    It should_not_be_applied_by_aggregate = () => result.Aggregate.WasAppliedByAggregate.ShouldBeFalse();
-    It should_not_come_from_event_horizon = () => result.EventHorizon.FromEventHorizon.ShouldBeFalse();
+    It should_not_be_applied_by_aggregate = () => result.WasAppliedByAggregate.ShouldBeFalse();
+    It should_not_come_from_event_horizon = () => result.IsFromEventHorizon.ShouldBeFalse();
     It should_have_the_content_returned_by_the_content_converter = () => result.Content.ShouldBeTheSameAs(bson_returned_by_event_converter);
     It should_call_the_content_converter_with_the_content = () => event_content_converter.VerifyOnlyCall(_ => _.ToBson(committed_event.Content));
 }

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_aggregate_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_aggregate_event.cs
@@ -31,7 +31,7 @@ public class an_aggregate_event : given.an_event_content_converter
     It should_have_the_same_aggregate_root_type_generation = () => result.Aggregate.TypeGeneration.ShouldEqual(committed_event.AggregateRoot.Generation.Value);
     It should_have_the_same_aggregate_root_type_id = () => result.Aggregate.TypeId.ShouldEqual(committed_event.AggregateRoot.Id.Value);
     It should_have_the_same_aggregate_root_version = () => result.Aggregate.Version.ShouldEqual(committed_event.AggregateRootVersion.Value);
-    It should_not_come_from_event_horizon = () => result.EventHorizon.FromEventHorizon.ShouldBeFalse();
+    It should_not_come_from_event_horizon = () => result.IsFromEventHorizon.ShouldBeFalse();
     It should_have_the_content_returned_by_the_content_converter = () => result.Content.ShouldBeTheSameAs(bson_returned_by_event_converter);
     It should_call_the_content_converter_with_the_content = () => event_content_converter.VerifyOnlyCall(_ => _.ToBson(committed_event.Content));
 }

--- a/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_external_event.cs
+++ b/Specifications/Events.Store.MongoDB/Events/for_EventConverter/when_converting_to_store_stream_event/an_external_event.cs
@@ -27,7 +27,7 @@ public class an_external_event : given.an_event_content_converter
     It should_represent_the_same_event = () => result.ShouldBeTheSameAs(committed_event);
     It should_have_the_correct_stream_position = () => result.StreamPosition.ShouldEqual(stream_position.Value);
     It should_not_be_applied_by_aggregate = () => result.Aggregate.WasAppliedByAggregate.ShouldBeFalse();
-    It should_come_from_event_horizon = () => result.EventHorizon.FromEventHorizon.ShouldBeTrue();
+    It should_come_from_event_horizon = () => result.IsFromEventHorizon.ShouldBeTrue();
     It should_have_the_same_consent = () => result.EventHorizon.Consent.ShouldEqual(committed_event.Consent.Value);
     It should_have_the_same_external_event_log_sequence_number = () => result.EventHorizon.ExternalEventLogSequenceNumber.ShouldEqual(committed_event.ExternalEventLogSequenceNumber.Value);
     It shoul_have_the_same_received_value = () => result.EventHorizon.Received.ShouldEqual(committed_event.Received.UtcDateTime);

--- a/Specifications/Rudimentary/for_TaskGroup/when_both_tasks_fail.cs
+++ b/Specifications/Rudimentary/for_TaskGroup/when_both_tasks_fail.cs
@@ -19,8 +19,8 @@ public class when_both_tasks_fail : given.a_group_and_inputs
         first_task_failure = new Exception();
         second_task_failure = new Exception();
         
-        first_task = Task.Delay(5).ContinueWith(_ => throw first_task_failure);
-        second_task = Task.Delay(1).ContinueWith(_ => throw second_task_failure);
+        first_task = Task.Delay(50).ContinueWith(_ => throw first_task_failure);
+        second_task = Task.Delay(10).ContinueWith(_ => throw second_task_failure);
 
     };
 


### PR DESCRIPTION
## Summary
This release optimizes how events are stored in MongoDB, by only including relevant metadata for the events. This means that only events produced by aggregates will store aggregate metadata, and event horizon metadata is excluded for normal events. 

In addition, this adds metrics to stream subscriptions showing how many events are streamed / buffered directly from commits, and how many are done as catch-up events via the database.

### Added
- Metric `dolittle_customer_runtime_events_store_streamed_events_total`
- Metric `dolittle_customer_runtime_events_store_catchup_events_total`

### Removed
- For non-aggregate events: Removed `Aggregate` object from MongoDB
- For non-EventHorizon events: Removed `EventhorizonMetadata` object from MongoDB
