### PR TITLE
Moved DB-optimizations & migrations to background tasks.

### DIFF
--- a/Source/Events.Store.MongoDB/Migrations/V6EventSourceMigrator.cs
+++ b/Source/Events.Store.MongoDB/Migrations/V6EventSourceMigrator.cs
@@ -62,12 +62,6 @@ public static class V6EventSourceMigrator
     public static async Task ConvertUuidFieldsToStringAsync(IMongoCollection<BsonDocument> collection, params string[] uuidFieldNames)
     {
         var collectionName = collection.CollectionNamespace.CollectionName;
-        var tempCollectionName = $"{collectionName}_temp";
-        // Create a temporary collection
-        var tempCollection = collection.Database.GetCollection<BsonDocument>(tempCollectionName);
-        // Backup the original collection to the temporary collection
-
-
         // Create a projection to include only the fields that need to be converted
         var projection = Builders<BsonDocument>.Projection.Include("_id");
         foreach (var fieldName in uuidFieldNames)

--- a/Source/Events.Store.MongoDB/Migrations/V9Migrations.cs
+++ b/Source/Events.Store.MongoDB/Migrations/V9Migrations.cs
@@ -82,13 +82,9 @@ public class V9Migrations : IDbMigration
         await V6EventSourceMigrator.MigrateEventsourceId(eventCollection);
     }
 
-    async Task MigrateEventCollections(IList<string> streams)
+    Task MigrateEventCollections(IList<string> streams)
     {
-        foreach (var collectionNames in streams)
-        {
-            _logger.LogInformation("Migrating {CollectionName}", collectionNames);
-            await MigrateEventCollection(collectionNames);
-        }
+        return Task.WhenAll(streams.AsParallel().WithDegreeOfParallelism(16).Select(MigrateEventCollection));
     }
 
     static async Task<IList<string>> GetEventCollections(IMongoDatabase db)


### PR DESCRIPTION
## Summary

The runtime performs some housekeeping tasks when starting after being upgraded from an older version. Since the runtime has a compatibility layer supporting the older database formats, it is possible to process and commit events while the migration is being performed. 
This changes the behavior from 9.3.1, where the runtime would wait for the migrations to complete before starting.

### Changed

- Allow migrations to be performed in the background
- Parallelized migrations.