### PR TITLE
Fix: Improve memory usage when reprocessing

### DIFF
--- a/Source/Events/Store/Actors/StreamSubscriptionActor.cs
+++ b/Source/Events/Store/Actors/StreamSubscriptionActor.cs
@@ -217,7 +217,13 @@ public sealed class StreamSubscriptionActor : IActor
     void RequestMoreCatchupEvents(IContext context, ulong fromOffset, ulong toOffset)
     {
         _isCatchingUp = true;
+        if (_publishRequestsInFlight > 1)
+        {
+            // Too many events in-flight, wait for them to finish before catching up
+            return;
+        }
         _catchUpRequestsInFlight++;
+
         context.Request(_catchupPid, new EventLogCatchupRequest(_scope, fromOffset, toOffset, _artifactSet));
     }
 

--- a/Source/Events/Store/Streams/StreamEventSubscriber.cs
+++ b/Source/Events/Store/Streams/StreamEventSubscriber.cs
@@ -17,7 +17,7 @@ namespace Dolittle.Runtime.Events.Store.Streams;
 [Singleton, PerTenant]
 public class StreamEventSubscriber : IStreamEventSubscriber
 {
-    const int ChannelCapacity = 100;
+    const int ChannelCapacity = 20;
     readonly IEventLogStream _eventLogStream;
 
     public StreamEventSubscriber(IEventLogStream eventLogStream) => _eventLogStream = eventLogStream;

--- a/Source/Events/Store/Streams/StreamEventSubscriber.cs
+++ b/Source/Events/Store/Streams/StreamEventSubscriber.cs
@@ -22,19 +22,6 @@ public class StreamEventSubscriber : IStreamEventSubscriber
 
     public StreamEventSubscriber(IEventLogStream eventLogStream) => _eventLogStream = eventLogStream;
 
-    // public ChannelReader<StreamEvent> SubscribePublic(ProcessingPosition position, CancellationToken cancellationToken)
-    // {
-    //     var channel = Channel.CreateBounded<StreamEvent>(ChannelCapacity);
-    //     ToStreamEvents(
-    //         _eventLogStream.SubscribePublic(position.EventLogPosition, cancellationToken),
-    //         channel.Writer,
-    //         position,
-    //         evt => evt.Public,
-    //         false,
-    //         cancellationToken);
-    //     return channel.Reader;
-    // }
-
     public ChannelReader<StreamEvent> Subscribe(ScopeId scopeId,
         IReadOnlyCollection<ArtifactId> artifactIds,
         ProcessingPosition from,


### PR DESCRIPTION
## Summary
Fixes an issue where the runtime could use large amounts of memory when reprocessing. Also tuned the pipeline to use slightly less memory overall.


## Fixed
- Ensured that the stream processor subscriptions do not request loading additional events unless the pipeline has < 2 un-acknowledged batches.

