### PR TITLE
Atlas stream order fix

### DIFF
--- a/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
@@ -31,7 +31,6 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
     readonly IMongoCollection<TEvent> _collection;
     readonly FilterDefinitionBuilder<TEvent> _filter;
     readonly Expression<Func<TEvent, ulong>> _sequenceNumberExpression;
-    // readonly Expression<Func<TEvent, object>> _sequenceNumberSortByExpression;
     readonly SortDefinition<TEvent> _sequenceNumberSortByExpressionAsc;
     readonly SortDefinition<TEvent> _sequenceNumberSortByExpressionDesc;
     readonly Func<TEvent, StreamEvent> _eventToStreamEvent;

--- a/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/StreamFetcher.cs
@@ -31,7 +31,9 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
     readonly IMongoCollection<TEvent> _collection;
     readonly FilterDefinitionBuilder<TEvent> _filter;
     readonly Expression<Func<TEvent, ulong>> _sequenceNumberExpression;
-    readonly Expression<Func<TEvent, object>> _sequenceNumberSortByExpression;
+    // readonly Expression<Func<TEvent, object>> _sequenceNumberSortByExpression;
+    readonly SortDefinition<TEvent> _sequenceNumberSortByExpressionAsc;
+    readonly SortDefinition<TEvent> _sequenceNumberSortByExpressionDesc;
     readonly Func<TEvent, StreamEvent> _eventToStreamEvent;
     readonly Expression<Func<TEvent, Guid>> _eventToArtifactId;
     readonly Expression<Func<TEvent, uint>> _eventToArtifactGeneration;
@@ -64,7 +66,8 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
         _collection = collection;
         _filter = filter;
         _sequenceNumberExpression = sequenceNumberExpression;
-        _sequenceNumberSortByExpression = sequenceNumberSortByExpression;
+        _sequenceNumberSortByExpressionAsc = Builders<TEvent>.Sort.Ascending(sequenceNumberSortByExpression);
+        _sequenceNumberSortByExpressionDesc = Builders<TEvent>.Sort.Descending(sequenceNumberSortByExpression);
         _eventToStreamEvent = eventToStreamEvent.Compile();
 
         _eventToArtifactId = eventToArtifactId;
@@ -106,6 +109,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
         try
         {
             var results = await _collection.Find(_filter.Gte(_sequenceNumberExpression, position.Value))
+                .Sort(_sequenceNumberSortByExpressionAsc)
                 .Limit(FetchEventsBatchSize)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
             var events = results.Select(_eventToStreamEvent).ToList();
@@ -143,7 +147,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
         try
         {
             var events = await _collection.Find(_filter.Empty)
-                .SortByDescending(_sequenceNumberSortByExpression)
+                .Sort(_sequenceNumberSortByExpressionDesc)
                 .FirstOrDefaultAsync(cancellationToken);
 
             return events is null
@@ -184,6 +188,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
             var results = await _collection.Find(
                     _filter.EqStringOrGuid(_partitionIdExpression, partitionId.Value)
                     & _filter.Gte(_sequenceNumberExpression, position.Value))
+                .Sort(_sequenceNumberSortByExpressionAsc)
                 .Limit(FetchEventsBatchSize)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
             var events = results.Select(_eventToStreamEvent).ToList();
@@ -215,6 +220,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
             }
 
             var results = await _collection.Find(composedFilter)
+                .Sort(_sequenceNumberSortByExpressionAsc)
                 .Limit(FetchEventsBatchSize)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
             var events = results.Select(_eventToStreamEvent).ToList();
@@ -243,6 +249,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
             }
 
             var results = await _collection.Find(composedFilter)
+                .Sort(_sequenceNumberSortByExpressionAsc)
                 .Limit(2)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -272,6 +279,7 @@ public class StreamFetcher<TEvent> : ICanFetchEventsFromStream, ICanFetchEventsF
             var results = _collection.Find(
                     _filter.Gte(_sequenceNumberExpression, range.From.Value)
                     & _filter.Lt(_sequenceNumberExpression, range.From.Value + range.Length))
+                .Sort(_sequenceNumberSortByExpressionAsc)
                 .ToAsyncEnumerable(cancellationToken);
             return results.Select(_eventToStreamEvent);
         }


### PR DESCRIPTION
## Summary
Fixed stream ordering when using  DB's that do not use the natural sort order of _id. This has been proven to be a potential issue on MongoDB Atlas.

### Fixed

- Added explicit sorting on _id when querying streams

