### PR TITLE
CLI build fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,18 +255,6 @@ jobs:
           asset_path: ./Source/CLI/bin/Release/net8.0/win-arm64/publish/Dolittle.Runtime.CLI.exe
           asset_name: dolittle-win-arm64.exe
           asset_content_type: application/octet-stream
-      - name: Publish for Windows arm
-        working-directory: ./Source/CLI
-        run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=win-arm
-      - name: Upload Windows arm
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/win-arm/publish/Dolittle.Runtime.CLI.exe
-          asset_name: dolittle-win-arm.exe
-          asset_content_type: application/octet-stream
       - name: Publish for Linux x64
         working-directory: ./Source/CLI
         run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=linux-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,14 +209,14 @@ jobs:
           asset_content_type: application/octet-stream
       - name: Publish for macOS arm64
         working-directory: ./Source/CLI
-        run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=osx.11.0-arm64
+        run: dotnet publish --configuration Release -p:Version=${{ needs.setup.outputs.next-version }} -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true -p:RuntimeIdentifier=osx-arm64
       - name: Upload macOS arm64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/osx.11.0-arm64/publish/Dolittle.Runtime.CLI
+          asset_path: ./Source/CLI/bin/Release/net8.0/osx-arm64/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-macos-arm64
           asset_content_type: application/octet-stream
       - name: Publish for Windows x64

--- a/Integration/Benchmarks/Benchmarks.csproj
+++ b/Integration/Benchmarks/Benchmarks.csproj
@@ -2,6 +2,7 @@
     <Import Project="../../default.props" />
 
     <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>Benchmarks</AssemblyName>
         <RootNamespace>Integration.Benchmarks</RootNamespace>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary

This fixes the build scripts for the Dolittle CLI and switches the performance benchmarks to be only built for dotnet 8.

### Fixed

- CLI builds
- Benchmark runner