### PR TITLE
Filter processor self-correction

### DIFF
--- a/Configurations/compose/docker-compose.yml
+++ b/Configurations/compose/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 27017:27017
       
   runtime:
-    image: dolittle/runtime:9.4.0
+    image: dolittle/runtime:9.5.1
     volumes:
       - ./runtime.yml:/app/.dolittle/runtime.yml
       - ./appsettings.json:/app/appsettings.json

--- a/Configurations/consumer/.dolittle/runtime.yml
+++ b/Configurations/consumer/.dolittle/runtime.yml
@@ -2,7 +2,7 @@ opentelemetry:
   serviceName: "Consumer-Runtime"
 endpoints: 
   private:
-    port: 5055
+    port: 50055
   public:
     port: 5054
   management:
@@ -32,16 +32,6 @@ tenants:
         servers:
         - localhost
         database: "consumer_event_store"
-      projections:
-        servers:
-        - localhost
-        database: "consumer_projections"
-        maxConnectionPoolSize: 1000
-      embeddings:
-        servers:
-        - localhost
-        database: "consumer_embeddings"
-        maxConnectionPoolSize: 1000
       readModels:
         host: "mongodb://localhost:27017"
         database: "consumer_readmodels"

--- a/Configurations/producer/.dolittle/runtime.yml
+++ b/Configurations/producer/.dolittle/runtime.yml
@@ -2,7 +2,7 @@ opentelemetry:
   serviceName: "Producer-Runtime"
 endpoints:
   private:
-    port: 5053
+    port: 50053
   public:
     port: 5052
   management:
@@ -24,16 +24,6 @@ tenants:
         servers:
         - localhost
         database: "producer_event_store"
-      projections:
-        servers:
-        - localhost
-        database: "producer_projections"
-        maxConnectionPoolSize: 1000
-      embeddings:
-        servers:
-        - localhost
-        database: "producer_embeddings"
-        maxConnectionPoolSize: 1000
       readModels:
         host: "mongodb://localhost:27017"
         database: "producer_readmodels"

--- a/Integration/Shared/Runtime.cs
+++ b/Integration/Shared/Runtime.cs
@@ -81,6 +81,10 @@ public static class Runtime
                 {
                     builder.Port = 0;
                 });
+                coll.AddOptions<WebServerConfiguration>().Configure(builder =>
+                {
+                    builder.Port = 0;
+                });
             })
             .AddActorSystem()
             .AddMetrics()

--- a/Integration/Tests/Events.Store/when_writing_to_stream/that_is_not_scoped/when_writing_to_stream.cs
+++ b/Integration/Tests/Events.Store/when_writing_to_stream/that_is_not_scoped/when_writing_to_stream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
@@ -70,8 +71,8 @@ class when_writing_to_stream : given.a_clean_event_store
         
         Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
 
-        It should_not_fail = () => failure.ShouldBeNull();
-        It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(4);
+        It should_fail_with = () => failure.ShouldBeOfExactType<EventLogSequenceAlreadyWritten>();
+        It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(3);
     }
     
     [Tags("IntegrationTest")]
@@ -81,7 +82,7 @@ class when_writing_to_stream : given.a_clean_event_store
         
         Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Select(_ => (_, partition with {Value = "another partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
 
-        It should_fail = () => failure.ShouldNotBeNull();
+        It should_fail_with = () => failure.ShouldBeOfExactType<EventLogSequenceAlreadyWritten>();
         It should_have_only_3_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(3);
     }
     
@@ -92,7 +93,7 @@ class when_writing_to_stream : given.a_clean_event_store
         
         Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Skip(3).Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
 
-        It should_not_fail = () => failure.ShouldBeNull();
+        It should_fail_with = () => failure.ShouldBeOfExactType<EventLogSequenceAlreadyWritten>();
         It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(4);
     }
 }

--- a/Integration/Tests/Events.Store/when_writing_to_stream/that_is_scoped/when_writing_to_stream.cs
+++ b/Integration/Tests/Events.Store/when_writing_to_stream/that_is_scoped/when_writing_to_stream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Store;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
@@ -71,8 +72,8 @@ class when_writing_to_stream : given.a_clean_event_store
         
         Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
 
-        It should_not_fail = () => failure.ShouldBeNull();
-        It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(4);
+        It should_fail_with = () => failure.ShouldBeOfExactType<EventLogSequenceAlreadyWritten>();
+        It should_have_3_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(3);
     }
     
     [Tags("IntegrationTest")]
@@ -93,7 +94,7 @@ class when_writing_to_stream : given.a_clean_event_store
         
         Because of = () => failure = Catch.Exception(() => events_to_streams_writer.Write(committed_events.Skip(3).Select(_ => (_, partition with {Value = "partition"})), scope, stream, CancellationToken.None).GetAwaiter().GetResult());
 
-        It should_not_fail = () => failure.ShouldBeNull();
+        It should_fail_with = () => failure.ShouldBeOfExactType<EventLogSequenceAlreadyWritten>();
         It should_have_4_events_in_the_stream = () => mongo_stream.CountDocuments(all_filter).ShouldEqual(4);
     }
 }

--- a/Source/Events.Store.MongoDB/Events/Event.cs
+++ b/Source/Events.Store.MongoDB/Events/Event.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -10,7 +12,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events;
 /// <summary>
 /// Represents an event stored in the MongoDB event store.
 /// </summary>
-public class Event
+public class Event: IEvent<Event>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Event"/> class.
@@ -43,6 +45,11 @@ public class Event
     [BsonId]
     [BsonRepresentation(BsonType.Decimal128)]
     public ulong EventLogSequenceNumber { get; set; }
+
+    // Do not serialize
+    [BsonIgnore] public ulong StreamPosition => EventLogSequenceNumber;
+    
+    public static Expression<Func<Event, object>> StreamPositionExpression { get; } = e => e.EventLogSequenceNumber;
 
     /// <summary>
     /// Gets or sets the execution context.

--- a/Source/Events.Store.MongoDB/Events/IEvent.cs
+++ b/Source/Events.Store.MongoDB/Events/IEvent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB.Events;
+
+public interface IEvent<T> where T : IEvent<T>
+{
+    public ulong EventLogSequenceNumber { get; }
+    public ulong StreamPosition { get; }
+    
+    public static abstract Expression<Func<T, object>> StreamPositionExpression { get; }
+}
+

--- a/Source/Events.Store.MongoDB/Events/StreamEvent.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEvent.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq.Expressions;
 using Dolittle.Runtime.Events.Store.Streams;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -10,7 +12,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events;
 /// <summary>
 /// Represents an event stored in a stream in the MongoDB event store.
 /// </summary>
-public class StreamEvent
+public class StreamEvent: IEvent<StreamEvent>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamEvent"/> class.
@@ -46,6 +48,10 @@ public class StreamEvent
     [BsonId]
     [BsonRepresentation(BsonType.Decimal128)]
     public ulong StreamPosition { get; set; }
+
+    public static Expression<Func<StreamEvent, object>> StreamPositionExpression { get; } = e => e.StreamPosition;
+
+    [BsonIgnore] public ulong EventLogSequenceNumber => Metadata.EventLogSequenceNumber;
 
     /// <summary>
     /// Gets or sets the partition id.

--- a/Source/Events.Store.MongoDB/Streams/IWriteEventsToStreamCollection.cs
+++ b/Source/Events.Store.MongoDB/Streams/IWriteEventsToStreamCollection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Store.MongoDB.Events;
 using Dolittle.Runtime.Events.Store.Streams;
 using MongoDB.Driver;
 
@@ -26,7 +27,7 @@ public interface IWriteEventsToStreamCollection
     Task<StreamPosition> Write<TEvent>(
         IMongoCollection<TEvent> stream,
         Func<StreamPosition, TEvent> createStoreEvent,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken) where TEvent : IEvent<TEvent>;
     
     /// <summary>
     /// Writes multiple <typeparamref name="TEvent">Event</typeparamref> to <see cref="IMongoCollection{TDocument}" /> Stream collection.
@@ -39,5 +40,5 @@ public interface IWriteEventsToStreamCollection
     Task<StreamPosition> Write<TEvent>(
         IMongoCollection<TEvent> stream,
         Func<StreamPosition, IReadOnlyList<TEvent>> createStoreEvents,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken) where TEvent : IEvent<TEvent>;
 }

--- a/Source/Events/Processing/EventLogSequenceAlreadyWritten.cs
+++ b/Source/Events/Processing/EventLogSequenceAlreadyWritten.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.Runtime.Events.Processing;
+
+public class EventLogSequenceAlreadyWritten : Exception
+{
+    public ulong EventLogSequenceNumber { get; }
+
+    public EventLogSequenceAlreadyWritten(ulong eventLogSequenceNumber) : base($"Event log sequence number {eventLogSequenceNumber} has already been written.")
+    {
+        EventLogSequenceNumber = eventLogSequenceNumber;
+    }
+}

--- a/Source/Server/Web/WebServerConfiguration.cs
+++ b/Source/Server/Web/WebServerConfiguration.cs
@@ -14,10 +14,10 @@ public record WebServerConfiguration
     /// <summary>
     /// Gets a value indicating whether or not the endpoint should be enabled.
     /// </summary>
-    public bool Enabled { get; init; } = true; // TODO: It would be cool if this made it so that the scoped server host didn't start
+    public bool Enabled { get; set; } = true; // TODO: It would be cool if this made it so that the scoped server host didn't start
 
     /// <summary>
     /// Gets the port to serve the endpoint on.
     /// </summary>
-    public int Port { get; init; } = 8001;
+    public int Port { get; set; } = 8001;
 }


### PR DESCRIPTION
## Summary
Hardened the handling of already written stream events. Will now log and skip in filter processors. Previously it was able to get stuck while processing a filter that was in an inconsistent state.

### Fixed
- Improved error handling for filter processors, allowing the runtime to self-correct when the stream and processor state does not match

