### PR TITLE
Support sparse event logs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,77 +1,75 @@
 <Project>
-
-<!--    <Import Project="versions.props"/>-->
-    
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <ContractsVersion>7.8.0</ContractsVersion>
-    </PropertyGroup>
-    
-    <ItemGroup>
-        <PackageVersion Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageVersion Include="Autofac" Version="8.1.0" />
-        <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-        
-        <PackageVersion Include="ConsoleTables" Version="2.6.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
-        <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
-        <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.65.0" />
-        <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.65.0" />
-        <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.65.0" />
-        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
-        <PackageVersion Include="Grpc.Tools" Version="2.65.0" />
-        <PackageVersion Include="Grpc.Net.Client" Version="2.65.0" />
-        <PackageVersion Include="Machine.Specifications" Version="1.1.2" />
-        <PackageVersion Include="Machine.Specifications.Should" Version="1.0.0" />
-        <PackageVersion Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
-        <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-        <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
-        <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
-        <PackageVersion Include="Moq" Version="4.18.4" />
-        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-        <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
-        <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
-        <PackageVersion Include="Polly" Version="8.4.1" />
-        <PackageVersion Include="prometheus-net" Version="8.2.1" />
-        <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
-        <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
-        <PackageVersion Include="Proto.Actor" Version="1.7.1-alpha.0.1" />
-        <PackageVersion Include="Proto.Remote" Version="1.7.1-alpha.0.1" />
-        <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.1-alpha.0.1" />
-        <PackageVersion Include="Proto.Cluster" Version="1.7.1-alpha.0.1" />
-        <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.1-alpha.0.1" />
-        <PackageVersion Include="Google.Protobuf" Version="3.28.1" />
-        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
-        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-        <PackageVersion Include="System.Security.Claims" Version="4.3.0" />
-        <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
-        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-        <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-        <PackageVersion Include="xunit" Version="2.9.0" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    </ItemGroup>
+  <!--    <Import Project="versions.props"/>-->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ContractsVersion>7.8.0</ContractsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+    <PackageVersion Include="Autofac" Version="8.1.0" />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="ConsoleTables" Version="2.6.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.65.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.65.0" />
+    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
+    <PackageVersion Include="Grpc.Tools" Version="2.66.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Grpc.Net.Client" Version="2.65.0" />
+    <PackageVersion Include="Machine.Specifications" Version="1.1.2" />
+    <PackageVersion Include="Machine.Specifications.Should" Version="1.0.0" />
+    <PackageVersion Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
+    <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
+    <PackageVersion Include="Polly" Version="8.4.1" />
+    <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
+    <PackageVersion Include="Proto.Actor" Version="1.7.1-alpha.0.1" />
+    <PackageVersion Include="Proto.Remote" Version="1.7.1-alpha.0.1" />
+    <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.1-alpha.0.1" />
+    <PackageVersion Include="Proto.Cluster" Version="1.7.1-alpha.0.1" />
+    <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.1-alpha.0.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.28.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Security.Claims" Version="4.3.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,6 +69,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="3.10.0" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,77 @@
+<Project>
+
+<!--    <Import Project="versions.props"/>-->
+    
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ContractsVersion>7.8.0</ContractsVersion>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageVersion Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+        <PackageVersion Include="Autofac" Version="8.1.0" />
+        <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+        
+        <PackageVersion Include="ConsoleTables" Version="2.6.1" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+        <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+        <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
+        <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.65.0" />
+        <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.65.0" />
+        <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.65.0" />
+        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
+        <PackageVersion Include="Grpc.Tools" Version="2.65.0" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.65.0" />
+        <PackageVersion Include="Machine.Specifications" Version="1.1.2" />
+        <PackageVersion Include="Machine.Specifications.Should" Version="1.0.0" />
+        <PackageVersion Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
+        <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+        <PackageVersion Include="Moq" Version="4.18.4" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+        <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
+        <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
+        <PackageVersion Include="Polly" Version="8.4.1" />
+        <PackageVersion Include="prometheus-net" Version="8.2.1" />
+        <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
+        <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
+        <PackageVersion Include="Proto.Actor" Version="1.7.1-alpha.0.1" />
+        <PackageVersion Include="Proto.Remote" Version="1.7.1-alpha.0.1" />
+        <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.1-alpha.0.1" />
+        <PackageVersion Include="Proto.Cluster" Version="1.7.1-alpha.0.1" />
+        <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.1-alpha.0.1" />
+        <PackageVersion Include="Google.Protobuf" Version="3.28.1" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+        <PackageVersion Include="System.Security.Claims" Version="4.3.0" />
+        <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+        <PackageVersion Include="xunit" Version="2.9.0" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    </ItemGroup>
+</Project>

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -6,6 +6,7 @@ ARG TARGETARCH
 
 COPY default.props /app/
 COPY versions.props /app/
+COPY Directory.Packages.props /app/
 COPY Runtime.sln /app/
 COPY Source /app/Source/
 COPY Specifications /app/Specifications/

--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -6,6 +6,7 @@ ARG TARGETARCH
 
 COPY default.props /app/
 COPY versions.props /app/
+COPY Directory.Packages.props /app/
 COPY Runtime.sln /app/
 COPY Source /app/Source/
 COPY Specifications /app/Specifications/

--- a/Integration/Benchmarks/Benchmarks.csproj
+++ b/Integration/Benchmarks/Benchmarks.csproj
@@ -13,6 +13,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageReference Include="BenchmarkDotNet"/>
     </ItemGroup>
 </Project>

--- a/Integration/Shared/Shared.csproj
+++ b/Integration/Shared/Shared.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="Moq" Version="$(MoqVersion)" />
+        <PackageReference Include="MongoDB.Driver"/>
+        <PackageReference Include="Moq"/>
     </ItemGroup>
 </Project>

--- a/Integration/Tests/Services/Services.csproj
+++ b/Integration/Tests/Services/Services.csproj
@@ -11,9 +11,9 @@
         <ProjectReference Include="..\..\Shared\Shared.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
+        <PackageReference Include="Google.Protobuf"/>
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Runtime.sln
+++ b/Runtime.sln
@@ -115,6 +115,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".meta", ".meta", "{CAF1D781
 		specs.props = specs.props
 		tests.props = tests.props
 		README.md = README.md
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{89A4E435-785F-4CDF-91B4-A14EAB91084B}"

--- a/Source/Actors/Actors.csproj
+++ b/Source/Actors/Actors.csproj
@@ -6,16 +6,15 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Proto.Actor" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Remote" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Cluster" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Cluster.TestProvider" Version="$(ProtoActorVersion)" />
+        <PackageReference Include="Proto.Actor"/>
+        <PackageReference Include="Proto.Remote"/>
+        <PackageReference Include="Proto.OpenTelemetry"/>
+        <PackageReference Include="Proto.Cluster"/>
+        <PackageReference Include="Proto.Cluster.CodeGen"/>
     </ItemGroup>
     
     <ItemGroup>

--- a/Source/CLI/CLI.csproj
+++ b/Source/CLI/CLI.csproj
@@ -21,13 +21,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ConsoleTables" Version="$(ConsoleTablesVersion)" />
-        <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="ConsoleTables"/>
+        <PackageReference Include="Docker.DotNet"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
     </ItemGroup>
 
 </Project>

--- a/Source/Client/Client.csproj
+++ b/Source/Client/Client.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Configuration.Management/Configuration.Management.csproj
+++ b/Source/Configuration.Management/Configuration.Management.csproj
@@ -12,12 +12,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="NetEscapades.Configuration.Yaml" Version="$(NetEscapadesYaml)" />
-        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
+        <PackageReference Include="NetEscapades.Configuration.Yaml"/>
+        <PackageReference Include="Newtonsoft.Json"/>
     </ItemGroup>
 </Project>

--- a/Source/Configuration/Configuration.csproj
+++ b/Source/Configuration/Configuration.csproj
@@ -12,13 +12,13 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="NetEscapades.Configuration.Yaml" Version="$(NetEscapadesYaml)" />
-        <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
+        <PackageReference Include="Autofac" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
+        <PackageReference Include="NetEscapades.Configuration.Yaml"/>
+        <PackageReference Include="Newtonsoft.Json"/>
     </ItemGroup>
 </Project>

--- a/Source/DependencyInversion/DependencyInversion.csproj
+++ b/Source/DependencyInversion/DependencyInversion.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="$(AutofacVersion)" />
-        <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="$(AutofacExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="Autofac" />
+        <PackageReference Include="Autofac.Extensions.DependencyInjection"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/Source/Diagnostics/Diagnostics.csproj
+++ b/Source/Diagnostics/Diagnostics.csproj
@@ -11,16 +11,16 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="$(MongoDBDiagnosticSourcesVersion)" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-        <PackageReference Include="Proto.OpenTelemetry" Version="$(ProtoActorVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
+        <PackageReference Include="MongoDB.Driver"/>
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources"/>
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http"/>
+        <PackageReference Include="Proto.OpenTelemetry"/>
     </ItemGroup>
 
 </Project>

--- a/Source/EventHorizon/Consumer/Connections/IEventHorizonConnection.cs
+++ b/Source/EventHorizon/Consumer/Connections/IEventHorizonConnection.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store.Streams;
-using Nito.AsyncEx;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.Connections;
 
@@ -22,7 +22,7 @@ public interface IEventHorizonConnection : IDisposable
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the connection attempt.</param>
     /// <returns>
     /// A task that, when resolved returns the <see cref="SubscriptionResponse"/> from the connection to the producer Runtime.
-    /// If <see cref="SubscriptionResponse.Success"/> is true, the connection is started and <see cref="StartRecevingEventsInto(AsyncProducerConsumerQueue{StreamEvent}, CancellationToken)"/> should be called.
+    /// If <see cref="SubscriptionResponse.Success"/> is true, the connection is started and <see cref="StartRecevingEventsInto(Channel{StreamEvent}, CancellationToken)"/> should be called.
     /// Else, the connection failed and should it should not be used.
     /// </returns>
     Task<SubscriptionResponse> Connect(
@@ -37,6 +37,6 @@ public interface IEventHorizonConnection : IDisposable
     /// <param name="cancellationToken">A cancellation token that can be used to close the connection.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task StartReceivingEventsInto(
-        AsyncProducerConsumerQueue<StreamEvent> connectionToStreamProcessorQueue,
+        Channel<StreamEvent> connectionToStreamProcessorQueue,
         CancellationToken cancellationToken);
 }

--- a/Source/EventHorizon/EventHorizon.csproj
+++ b/Source/EventHorizon/EventHorizon.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Contracts"/>
-        <PackageReference Include="Nito.AsyncEx"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/EventHorizon/EventHorizon.csproj
+++ b/Source/EventHorizon/EventHorizon.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Nito.AsyncEx" Version="$(NitoAsyncVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Nito.AsyncEx"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Events.Store.MongoDB/CommittedEventsFetcher.cs
+++ b/Source/Events.Store.MongoDB/CommittedEventsFetcher.cs
@@ -88,7 +88,7 @@ public class CommittedEventsFetcher : IFetchCommittedEvents
 
         if (nextSequenceNumber != eventCount)
         {
-            _logger.LogError("Last event sequence number was {LastEventSequenceNumber}, but event count was {EventCount}", lastEvent.EventLogSequenceNumber,
+            _logger.LogInformation("Sparse event log: Last event sequence number was {LastEventSequenceNumber}, but event count was {EventCount}", lastEvent.EventLogSequenceNumber,
                 eventCount);
         }
 

--- a/Source/Events.Store.MongoDB/CommittedEventsFetcher.cs
+++ b/Source/Events.Store.MongoDB/CommittedEventsFetcher.cs
@@ -69,7 +69,7 @@ public class CommittedEventsFetcher : IFetchCommittedEvents
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        if (eventCount == 0) return 0ul; // No events means no need to double check
+        if (eventCount == 0) return 0ul; // No events means no need to double-check
 
         var lastEvent = await eventLog
             .Find(_eventFilter.Empty)

--- a/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
+++ b/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
@@ -6,8 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store.EventHorizon;
 using Dolittle.Runtime.Events.Store.MongoDB.Events;
+using Dolittle.Runtime.Events.Store.MongoDB.Persistence;
 using Dolittle.Runtime.Events.Store.MongoDB.Streams;
 using Dolittle.Runtime.Events.Store.Streams;
+using MongoDB.Driver;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon;
 

--- a/Source/Events.Store.MongoDB/Events.Store.MongoDB.csproj
+++ b/Source/Events.Store.MongoDB/Events.Store.MongoDB.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="$(MongoDBDiagnosticSourcesVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="MongoDB.Driver"/>
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Events.Store.MongoDB/Events/EventLogMetadata.cs
+++ b/Source/Events.Store.MongoDB/Events/EventLogMetadata.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB.Events;
+
+/// <summary>
+/// Keeps the offset metadata for an event log.
+/// </summary>
+public class EventLogMetadata
+{
+    [BsonId] public required Guid Scope { get; init; }
+    
+    [BsonRepresentation(BsonType.Decimal128)]
+    public ulong NextEventOffset { get; init; }
+}

--- a/Source/Events.Store.MongoDB/Events/StreamMetadata.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamMetadata.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB.Events;
 
 /// <summary>
-/// Keeps the offset metadata for an event log.
+/// Keeps the offset metadata for a specific stream.
 /// </summary>
-public class EventLogMetadata
+public class StreamMetadata
 {
-    [BsonId] public required Guid Scope { get; init; }
+    [BsonId] public required string StreamName { get; init; }
     
     [BsonRepresentation(BsonType.Decimal128)]
     public ulong NextEventOffset { get; init; }

--- a/Source/Events.Store.MongoDB/Persistence/CommitWriter.cs
+++ b/Source/Events.Store.MongoDB/Persistence/CommitWriter.cs
@@ -58,7 +58,7 @@ public class CommitWriter : IPersistCommits
             await _aggregateVersions.UpdateAggregateVersions(session, commit, cancellationToken).ConfigureAwait(false);
             await session.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
             //TODO: Notifying for events should be a concern handled by actors
-            _streamWatcher.NotifyForEvent(ScopeId.Default, StreamId.EventLog, eventsToStore.Max(_ => _.EventLogSequenceNumber));
+            _streamWatcher.NotifyForEvent(ScopeId.Default, StreamId.EventLog, commit.LastSequenceNumber.Value);
             return Try.Succeeded;
         }
         catch (MongoWaitQueueFullException ex)

--- a/Source/Events.Store.MongoDB/Persistence/EventLogOffsetStore.cs
+++ b/Source/Events.Store.MongoDB/Persistence/EventLogOffsetStore.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.DependencyInversion.Lifecycle;
+using Dolittle.Runtime.DependencyInversion.Scoping;
+using Dolittle.Runtime.Events.Store.MongoDB.Events;
+using Dolittle.Runtime.Events.Store.Persistence;
+using MongoDB.Driver;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB.Persistence;
+
+[Singleton, PerTenant]
+public class EventLogOffsetStore: EventStoreConnection, IEventLogOffsetStore
+{
+    static readonly FilterDefinitionBuilder<EventLogMetadata> _filterBuilder = new();
+    static readonly FilterDefinition<EventLogMetadata> _defaultScopeFilter = _filterBuilder.Eq(metadata => metadata.Scope, ScopeId.Default.Value);
+    
+    
+    const string EventLogMetadataCollectionName = "event-log-metadata";
+
+    public IMongoCollection<EventLogMetadata> Collection { get; }
+
+    public EventLogOffsetStore(IDatabaseConnection connection):base(connection)
+    {
+        Collection = Database.GetCollection<EventLogMetadata>(EventLogMetadataCollectionName);
+    }
+
+    public Task UpdateOffset(IClientSessionHandle session, ScopeId scopeId, ulong nextEventOffset,
+        CancellationToken cancellationToken)
+    {
+        var metadata = new EventLogMetadata
+        {
+            Scope = scopeId.Value,
+            NextEventOffset = nextEventOffset,
+        };
+        
+        var updateDefinition = new UpdateDefinitionBuilder<EventLogMetadata>()
+            .SetOnInsert(it => it.Scope, metadata.Scope)
+            .Set(it => it.NextEventOffset, metadata.NextEventOffset);
+
+        return Collection.UpdateOneAsync(
+            session:session,
+            filter: GetFilter(scopeId),
+            updateDefinition,
+            options: new UpdateOptions
+            {
+                IsUpsert = true,
+            }, cancellationToken);
+    }
+
+    public Task<ulong> GetNextOffset(ScopeId scopeId, CancellationToken cancellationToken)
+        => Collection
+            .Find(GetFilter(scopeId))
+            .Project(metadata => metadata.NextEventOffset)
+            .FirstOrDefaultAsync(cancellationToken);
+
+    static FilterDefinition<EventLogMetadata> GetFilter(ScopeId scopeId) => scopeId.IsDefaultScope ? _defaultScopeFilter : _filterBuilder.Eq(metadata => metadata.Scope, scopeId.Value);
+}

--- a/Source/Events.Store.MongoDB/Persistence/EventLogOffsetStore.cs
+++ b/Source/Events.Store.MongoDB/Persistence/EventLogOffsetStore.cs
@@ -25,6 +25,17 @@ public class EventLogOffsetStore: EventStoreConnection, IEventLogOffsetStore
     public EventLogOffsetStore(IDatabaseConnection connection):base(connection)
     {
         Collection = Database.GetCollection<EventLogMetadata>(EventLogMetadataCollectionName);
+
+        CreateCollectionIfNotExists();
+    }
+
+    void CreateCollectionIfNotExists()
+    {
+        var collectionNames = Database.ListCollectionNames().ToList();
+        if (!collectionNames.Contains(EventLogMetadataCollectionName))
+        {
+            Database.CreateCollection(EventLogMetadataCollectionName);
+        }
     }
 
     public Task UpdateOffset(IClientSessionHandle session, ScopeId scopeId, ulong nextEventOffset,

--- a/Source/Events.Store.MongoDB/Persistence/IEventLogOffsetStore.cs
+++ b/Source/Events.Store.MongoDB/Persistence/IEventLogOffsetStore.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Store.Persistence;
+using MongoDB.Driver;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB.Persistence;
+
+/// <summary>
+/// Defines a system that can update the high watermark offset for an event log.
+/// </summary>
+public interface IEventLogOffsetStore
+{
+    /// <summary>
+    /// Updates the next offset for a given event log.
+    /// </summary>
+    /// <param name="session">The <see cref="IClientSessionHandle"/> for the MongoDB transaction.</param>
+    /// <param name="scopeId">The <see cref="ScopeId"/>.</param>
+    /// <param name="nextOffset">The next offset to write to this eventlog</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="Task{TResult}"/> that, when resolved, returns the result of the operation.</returns>
+    Task UpdateOffset(IClientSessionHandle session, ScopeId scopeId, ulong nextOffset, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Gets the next offset for a given event log.
+    /// </summary>
+    /// <param name="scopeId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<ulong> GetNextOffset(ScopeId scopeId, CancellationToken cancellationToken);
+}

--- a/Source/Events.Store.MongoDB/Persistence/IOffsetStore.cs
+++ b/Source/Events.Store.MongoDB/Persistence/IOffsetStore.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Dolittle.Runtime.Events.Store.Persistence;
 using MongoDB.Driver;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB.Persistence;
@@ -11,23 +10,25 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Persistence;
 /// <summary>
 /// Defines a system that can update the high watermark offset for an event log.
 /// </summary>
-public interface IEventLogOffsetStore
+public interface IOffsetStore
 {
     /// <summary>
-    /// Updates the next offset for a given event log.
+    /// Updates the next offset for a given event log / stream.
     /// </summary>
+    /// <param name="stream"></param>
     /// <param name="session">The <see cref="IClientSessionHandle"/> for the MongoDB transaction.</param>
-    /// <param name="scopeId">The <see cref="ScopeId"/>.</param>
-    /// <param name="nextOffset">The next offset to write to this eventlog</param>
+    /// <param name="writtenOffset">The offset that was just written</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="Task{TResult}"/> that, when resolved, returns the result of the operation.</returns>
-    Task UpdateOffset(IClientSessionHandle session, ScopeId scopeId, ulong nextOffset, CancellationToken cancellationToken);
-    
+    Task UpdateOffset(string stream, IClientSessionHandle session, ulong writtenOffset,
+        CancellationToken cancellationToken);
+
     /// <summary>
-    /// Gets the next offset for a given event log.
+    /// Gets the next offset for a given stream
     /// </summary>
-    /// <param name="scopeId"></param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="stream">The stream to get the next offset for</param>
+    /// <param name="session">The <see cref="IClientSessionHandle"/> for the MongoDB transaction.(Optional)</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
     /// <returns></returns>
-    public Task<ulong> GetNextOffset(ScopeId scopeId, CancellationToken cancellationToken);
+    public Task<ulong> GetNextOffset(string stream, IClientSessionHandle? session, CancellationToken cancellationToken);
 }

--- a/Source/Events.Store.MongoDB/Streams/CollectionExtensions.cs
+++ b/Source/Events.Store.MongoDB/Streams/CollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB.Streams;
+
+public static class CollectionExtensions
+{
+    public static async Task<ulong> CountDocuments<TEvent>(this IMongoCollection<TEvent> collection, IClientSessionHandle session, CancellationToken cancellationToken) =>
+        (ulong) await collection.CountDocumentsAsync(
+            session,
+            Builders<TEvent>.Filter.Empty,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+}

--- a/Source/Events.Store.MongoDB/Streams/IStreams.cs
+++ b/Source/Events.Store.MongoDB/Streams/IStreams.cs
@@ -18,6 +18,8 @@ public interface IStreams : IEventStoreConnection
     /// </summary>
     IMongoCollection<MongoDB.Events.Event> DefaultEventLog { get; }
 
+    IMongoCollection<MongoDB.Events.EventLogMetadata> EventLogMetadata { get; }
+
     /// <summary>
     /// Gets a non-public and non-event-log Stream.
     /// </summary>

--- a/Source/Events.Store.MongoDB/Streams/IStreams.cs
+++ b/Source/Events.Store.MongoDB/Streams/IStreams.cs
@@ -18,8 +18,6 @@ public interface IStreams : IEventStoreConnection
     /// </summary>
     IMongoCollection<MongoDB.Events.Event> DefaultEventLog { get; }
 
-    IMongoCollection<MongoDB.Events.EventLogMetadata> EventLogMetadata { get; }
-
     /// <summary>
     /// Gets a non-public and non-event-log Stream.
     /// </summary>

--- a/Source/Events.Store.MongoDB/Streams/IWriteEventsToStreamCollection.cs
+++ b/Source/Events.Store.MongoDB/Streams/IWriteEventsToStreamCollection.cs
@@ -28,7 +28,7 @@ public interface IWriteEventsToStreamCollection
         IMongoCollection<TEvent> stream,
         Func<StreamPosition, TEvent> createStoreEvent,
         CancellationToken cancellationToken) where TEvent : IEvent<TEvent>;
-    
+
     /// <summary>
     /// Writes multiple <typeparamref name="TEvent">Event</typeparamref> to <see cref="IMongoCollection{TDocument}" /> Stream collection.
     /// </summary>

--- a/Source/Events.Store.MongoDB/Streams/Streams.cs
+++ b/Source/Events.Store.MongoDB/Streams/Streams.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.DependencyInversion.Lifecycle;
 using Dolittle.Runtime.DependencyInversion.Scoping;
+using Dolittle.Runtime.Events.Store.MongoDB.Events;
 using Dolittle.Runtime.Events.Store.Streams;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
@@ -42,6 +43,7 @@ public class Streams : EventStoreConnection, IStreams
 
     /// <inheritdoc/>
     public IMongoCollection<MongoDB.Events.Event> DefaultEventLog { get; }
+    public IMongoCollection<MongoDB.Events.EventLogMetadata> EventLogMetadata { get; }
 
     /// <inheritdoc/>
     public Task<IMongoCollection<MongoDB.Events.StreamEvent>> Get(ScopeId scopeId, StreamId streamId, CancellationToken token)

--- a/Source/Events.Store.MongoDB/Streams/Streams.cs
+++ b/Source/Events.Store.MongoDB/Streams/Streams.cs
@@ -18,7 +18,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams;
 [Singleton, PerTenant]
 public class Streams : EventStoreConnection, IStreams
 {
-    const string EventLogCollectionName = "event-log";
+    public const string EventLogCollectionName = "event-log";
     const string StreamDefinitionCollectionName = "stream-definitions";
 
     readonly ILogger _logger;
@@ -43,7 +43,7 @@ public class Streams : EventStoreConnection, IStreams
 
     /// <inheritdoc/>
     public IMongoCollection<MongoDB.Events.Event> DefaultEventLog { get; }
-    public IMongoCollection<MongoDB.Events.EventLogMetadata> EventLogMetadata { get; }
+    public IMongoCollection<MongoDB.Events.StreamMetadata> EventLogMetadata { get; }
 
     /// <inheritdoc/>
     public Task<IMongoCollection<MongoDB.Events.StreamEvent>> Get(ScopeId scopeId, StreamId streamId, CancellationToken token)

--- a/Source/Events.Store.Services.Grpc/Events.Store.Services.Grpc.csproj
+++ b/Source/Events.Store.Services.Grpc/Events.Store.Services.Grpc.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+    <PackageReference Include="Dolittle.Contracts"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Events/Events.csproj
+++ b/Source/Events/Events.csproj
@@ -17,7 +17,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Nito.AsyncEx.Tasks"/>
         <PackageReference Include="Proto.Cluster.CodeGen"/>
     </ItemGroup>
    

--- a/Source/Events/Events.csproj
+++ b/Source/Events/Events.csproj
@@ -8,17 +8,17 @@
 
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
-        <PackageReference Include="Polly" Version="$(PollyVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />
-        <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsVersion)">
+        <PackageReference Include="OpenTelemetry.Api"/>
+        <PackageReference Include="Polly"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="System.Linq.Async"/>
+        <PackageReference Include="Grpc.Tools">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Nito.AsyncEx.Tasks" Version="$(NitoAsyncVersion)" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="$(ProtoActorVersion)" />
+        <PackageReference Include="Nito.AsyncEx.Tasks"/>
+        <PackageReference Include="Proto.Cluster.CodeGen"/>
     </ItemGroup>
    
     <ItemGroup>

--- a/Source/Events/Store/ScopeId.cs
+++ b/Source/Events/Store/ScopeId.cs
@@ -27,4 +27,6 @@ public record ScopeId(Guid Value) : ConceptAs<Guid>(Value)
     /// </summary>
     /// <param name="scopeId">ScopeId as <see cref="string"/>.</param>
     public static implicit operator ScopeId(string scopeId) => new(Guid.Parse(scopeId));
+    
+    public bool IsDefaultScope => Value.Equals(Guid.Empty);
 }

--- a/Source/Execution/Execution.csproj
+++ b/Source/Execution/Execution.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Security.Claims" Version="$(SystemSecurityVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="System.Security.Claims"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" />
     </ItemGroup>
 </Project>

--- a/Source/Hosting/Hosting.csproj
+++ b/Source/Hosting/Hosting.csproj
@@ -12,6 +12,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 </Project>

--- a/Source/Metrics/Metrics.csproj
+++ b/Source/Metrics/Metrics.csproj
@@ -13,10 +13,10 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="prometheus-net" Version="$(PrometheusVersion)" />
-        <PackageReference Include="prometheus-net.AspNetCore" Version="$(PrometheusVersion)" />
-        <PackageReference Include="prometheus-net.DotNetRuntime" Version="$(PrometheusNetDotNetRuntimeVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="prometheus-net"/>
+        <PackageReference Include="prometheus-net.AspNetCore"/>
+        <PackageReference Include="prometheus-net.DotNetRuntime"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Source/MongoDB/MongoDB.csproj
+++ b/Source/MongoDB/MongoDB.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="$(MongoDBDiagnosticSourcesVersion)" />
+        <PackageReference Include="MongoDB.Driver"/>
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources"/>
     </ItemGroup>
 </Project>

--- a/Source/Protobuf/Protobuf.csproj
+++ b/Source/Protobuf/Protobuf.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Google.Protobuf"/>
     </ItemGroup>
 </Project>

--- a/Source/Resources/Resources.csproj
+++ b/Source/Resources/Resources.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="MongoDB.Driver"/>
+        <PackageReference Include="Dolittle.Contracts"/>
     </ItemGroup>
 </Project>

--- a/Source/Rudimentary/Rudimentary.csproj
+++ b/Source/Rudimentary/Rudimentary.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-        <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />
+        <PackageReference Include="Google.Protobuf"/>
+        <PackageReference Include="System.Linq.Async"/>
     </ItemGroup>
 </Project>

--- a/Source/Server/Server.csproj
+++ b/Source/Server/Server.csproj
@@ -13,15 +13,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleVersion)" />
-        <PackageReference Include="Proto.Actor" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Remote" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Cluster" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="$(ProtoActorVersion)" />
-        <PackageReference Include="Proto.Cluster.TestProvider" Version="$(ProtoActorVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+        <PackageReference Include="Swashbuckle.AspNetCore"/>
+        <PackageReference Include="Proto.Actor"/>
+        <PackageReference Include="Proto.Remote"/>
+        <PackageReference Include="Proto.Cluster"/>
+        <PackageReference Include="Proto.Cluster.CodeGen"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Services.Clients/Services.Clients.csproj
+++ b/Source/Services.Clients/Services.Clients.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-        <PackageReference Include="Grpc.Net.Client" Version="$(GrpcVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Google.Protobuf"/>
+        <PackageReference Include="Grpc.Net.Client"/>
     </ItemGroup>
 </Project>

--- a/Source/Services/Services.csproj
+++ b/Source/Services/Services.csproj
@@ -16,13 +16,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
-        <PackageReference Include="Grpc.AspNetCore" Version="$(GrpcVersion)" />
-        <PackageReference Include="Grpc.AspNetCore.Web" Version="$(GrpcVersion)" />
-        <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="$(GrpcVersion)" />
-        <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="$(GrpcVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Proto.Actor" Version="$(ProtoActorVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Google.Protobuf"/>
+        <PackageReference Include="Grpc.AspNetCore"/>
+        <PackageReference Include="Grpc.AspNetCore.Web"/>
+        <PackageReference Include="Grpc.AspNetCore.Server.Reflection"/>
+        <PackageReference Include="Grpc.AspNetCore.HealthChecks"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Proto.Actor"/>
     </ItemGroup>
 </Project>

--- a/Source/Tenancy/Tenancy.csproj
+++ b/Source/Tenancy/Tenancy.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" />
     </ItemGroup>
 </Project>

--- a/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/and_2_requests_are_handled.cs
+++ b/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/and_2_requests_are_handled.cs
@@ -28,6 +28,6 @@ public class and_2_requests_are_handled : given.all_dependencies
     };
 
     It should_be_completed = () => result.IsCompleted.ShouldBeTrue();
-    It should_not_have_put_anything_in_event_queue = () => event_queue.OutputAvailable().ShouldBeTrue();
-    It should_have_2_events_in_queue = () => event_queue.GetConsumingEnumerable().Count().ShouldEqual(2);
+    It should_not_have_put_anything_in_event_queue = () => event_queue.Reader.TryPeek(out _).ShouldBeTrue();
+    It should_have_2_events_in_queue = () => event_queue.Reader.ReadAllAsync().ToListAsync().GetAwaiter().GetResult().Count.ShouldEqual(2);
 }

--- a/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/and_cancellation_is_requested.cs
+++ b/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/and_cancellation_is_requested.cs
@@ -22,5 +22,11 @@ public class and_cancellation_is_requested : given.all_dependencies
     };
 
     It should_be_completed = () => result.IsCompleted.ShouldBeTrue();
-    It should_not_have_put_anything_in_event_queue = () => event_queue.OutputAvailable().ShouldBeFalse();
+    It should_not_have_put_anything_in_event_queue = () =>
+    {
+        var wasRead = event_queue.Reader.TryPeek(out var evt);
+        evt.ShouldBeNull();
+        wasRead.ShouldBeFalse();
+        
+    };
 }

--- a/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/given/all_dependencies.cs
+++ b/Specifications/EventHorizon/Consumer/Connections/for_EventHorizonConnection/when_starting_receiving_events_into/given/all_dependencies.cs
@@ -7,8 +7,8 @@ using System;
 
 using Machine.Specifications;
 using System.Threading;
+using System.Threading.Channels;
 using Dolittle.Runtime.Events.Store.Streams;
-using Nito.AsyncEx;
 using Dolittle.Runtime.Services.Clients;
 using Dolittle.Runtime.EventHorizon.Contracts;
 using System.Threading.Tasks;
@@ -22,13 +22,13 @@ namespace Dolittle.Runtime.EventHorizon.Consumer.Connections.for_EventHorizonCon
 
 public class all_dependencies : for_EventHorizonConnection.given.all_dependencies
 {
-    protected static AsyncProducerConsumerQueue<StreamEvent> event_queue;
+    protected static Channel<StreamEvent> event_queue;
     protected static CancellationTokenSource cts;
 
     Establish context = () =>
     {
         cts = new CancellationTokenSource();
-        event_queue = new AsyncProducerConsumerQueue<StreamEvent>();
+        event_queue = Channel.CreateBounded<StreamEvent>(1000);
     };
 
     protected static void SetupReverseCallClient(params ConsumerRequest[] requests)
@@ -45,7 +45,7 @@ public class all_dependencies : for_EventHorizonConnection.given.all_dependencie
                     await Task.Delay(10).ConfigureAwait(false);
                     i++;
                 }
-                event_queue.CompleteAdding();
+                event_queue.Writer.Complete();
             }));
     protected static ConsumerRequest CreateRequest()
     {

--- a/Specifications/EventHorizon/Consumer/Processing/for_StreamProcessor/given/all_dependencies.cs
+++ b/Specifications/EventHorizon/Consumer/Processing/for_StreamProcessor/given/all_dependencies.cs
@@ -8,7 +8,7 @@ using Dolittle.Runtime.Events.Processing.Streams;
 using System.Threading;
 using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Store.Streams;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 using Microsoft.Extensions.Logging.Abstractions;
 using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
 
@@ -20,7 +20,7 @@ public class all_dependencies
     protected static CancellationToken cancellation_token;
     protected static Mock<IEventProcessor> event_processor;
     protected static EventsFromEventHorizonFetcher event_fetcher;
-    protected static AsyncProducerConsumerQueue<StreamEvent> event_queue;
+    protected static Channel<StreamEvent> event_queue;
     protected static Mock<IStreamProcessorStates> stream_processor_states;
     protected static StreamProcessor stream_processor;
     protected static ExecutionContext execution_context;
@@ -38,7 +38,7 @@ public class all_dependencies
         );
         cancellation_token = CancellationToken.None;
         event_processor = new Mock<IEventProcessor>();
-        event_queue = new AsyncProducerConsumerQueue<StreamEvent>();
+        event_queue = Channel.CreateBounded<StreamEvent>(1000);
         event_fetcher = new EventsFromEventHorizonFetcher(event_queue, Mock.Of<IMetricsCollector>());
         stream_processor_states = new Mock<IStreamProcessorStates>();
         stream_processor = new StreamProcessor(

--- a/Specifications/EventHorizon/Consumer/for_Subscription/given/all_dependencies.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/given/all_dependencies.cs
@@ -12,7 +12,7 @@ using System.Threading;
 using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Events.Store.EventHorizon;
 using Microservices;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 using Polly;
 using ExecutionContext = Dolittle.Runtime.Execution.ExecutionContext;
 
@@ -132,8 +132,8 @@ public class all_dependencies
                 }
             }));
         event_horizon_connection
-            .Setup(_ => _.StartReceivingEventsInto(Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(), Moq.It.IsAny<CancellationToken>()))
-            .Returns<AsyncProducerConsumerQueue<StreamEvent>, CancellationToken>((_, cancellationToken) => Task.Run(async () =>
+            .Setup(_ => _.StartReceivingEventsInto(Moq.It.IsAny<Channel<StreamEvent>>(), Moq.It.IsAny<CancellationToken>()))
+            .Returns<Channel<StreamEvent>, CancellationToken>((_, cancellationToken) => Task.Run(async () =>
             {
                 while (!event_horizon_connection_cts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_fails/and_it_has_already_started.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_fails/and_it_has_already_started.cs
@@ -10,7 +10,7 @@ using Dolittle.Runtime.Events.Store.Streams;
 using Dolittle.Runtime.Protobuf;
 using Machine.Specifications;
 using Microservices;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_fails;
 
@@ -49,7 +49,7 @@ public class and_it_has_already_started : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
     It should_not_start_receiving_events = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
     It should_not_be_connected = () => subscription.State.ShouldNotEqual(SubscriptionState.Connected);

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_connection_completes.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_connection_completes.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Dolittle.Runtime.EventHorizon.Consumer.Processing;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -38,7 +38,7 @@ public class and_connection_completes : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_start_receiving_events_at_least_twice = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_get_the_successfull_response = () => subscription.ConnectionResponse.Result.Success.ShouldBeTrue();

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_connection_response_changes_once.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_connection_response_changes_once.cs
@@ -8,7 +8,7 @@ using Dolittle.Runtime.EventHorizon.Consumer.Processing;
 using Dolittle.Runtime.Events.Store.EventHorizon;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -80,7 +80,7 @@ public class and_connection_response_changes_once : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
 
     It should_start_receiving_events_twice = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
 
     It should_be_connected = () => subscription.State.ShouldEqual(SubscriptionState.Connected);

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_everything_works.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_everything_works.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Dolittle.Runtime.EventHorizon.Consumer.Processing;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -34,7 +34,7 @@ public class and_everything_works : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 
     It should_start_receiving_events_once = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 
     It should_be_connected = () => subscription.State.ShouldEqual(SubscriptionState.Connected);

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_it_has_already_started.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_it_has_already_started.cs
@@ -8,7 +8,7 @@ using Dolittle.Runtime.Events.Store.EventHorizon;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
 using Microservices;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -42,7 +42,7 @@ public class and_it_has_already_started : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 
     It should_start_receiving_events_once = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 
     It should_be_connected = () => subscription.State.ShouldEqual(SubscriptionState.Connected);

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_receiving_events_fails.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_receiving_events_fails.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Dolittle.Runtime.EventHorizon.Consumer.Processing;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -16,7 +16,7 @@ public class and_receiving_events_fails : given.all_dependencies
     Establish context = () =>
     {
         event_horizon_connection
-            .Setup(_ => _.StartReceivingEventsInto(Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.StartReceivingEventsInto(Moq.It.IsAny<Channel<StreamEvent>>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.Run(() => throw new Exception()));
     };
     Because of = () =>
@@ -41,7 +41,7 @@ public class and_receiving_events_fails : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_start_receiving_events_at_least_twice = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_get_the_successfull_response = () => subscription.ConnectionResponse.Result.Success.ShouldBeTrue();

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_stream_processor_completes.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_stream_processor_completes.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Dolittle.Runtime.EventHorizon.Consumer.Processing;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -38,7 +38,7 @@ public class and_stream_processor_completes : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_start_receiving_events_at_least_twice = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_get_the_successfull_response = () => subscription.ConnectionResponse.Result.Success.ShouldBeTrue();

--- a/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_stream_processor_fails.cs
+++ b/Specifications/EventHorizon/Consumer/for_Subscription/when_starting/and_connection_succeeds/and_stream_processor_fails.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Dolittle.Runtime.EventHorizon.Consumer.Processing;
 using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
-using Nito.AsyncEx;
+using System.Threading.Channels;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.for_Subscription.when_starting.and_connection_succeeds;
 
@@ -41,7 +41,7 @@ public class and_stream_processor_fails : given.all_dependencies
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_start_receiving_events_at_least_twice = () => event_horizon_connection.Verify(_ => _.StartReceivingEventsInto(
-        Moq.It.IsAny<AsyncProducerConsumerQueue<StreamEvent>>(),
+        Moq.It.IsAny<Channel<StreamEvent>>(),
         Moq.It.IsAny<CancellationToken>()), Moq.Times.AtLeast(2));
 
     It should_get_the_successfull_response = () => subscription.ConnectionResponse.Result.Success.ShouldBeTrue();

--- a/Specifications/Events.Store.MongoDB.Tests/EventStoreOffsetTests.cs
+++ b/Specifications/Events.Store.MongoDB.Tests/EventStoreOffsetTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.MongoDB.Persistence;
+using FluentAssertions;
+using Xunit;
+
+namespace Events.Store.MongoDB.Tests;
+
+public class EventStoreOffsetTests(MongoDatabaseFixture fixture): IClassFixture<MongoDatabaseFixture>
+{
+    [Fact]
+    public async Task WhenNoOffsetExists()
+    {
+        var nextOffset = await Sut.GetNextOffset(new ScopeId(Guid.NewGuid()), CancellationToken.None);
+
+        nextOffset.Should().Be(0);
+    }
+    
+    [Fact]
+    public async Task WhenStoringDefaultScopeOffset()
+    {
+        ulong nextOffset = 9;
+        await StoreOffset(ScopeId.Default, nextOffset);
+        
+        var nextOffsetRetrieved = await Sut.GetNextOffset(ScopeId.Default, CancellationToken.None);
+
+        nextOffsetRetrieved.Should().Be(nextOffset);
+    }
+    
+    [Fact]
+    public async Task WhenUpdatingOffset()
+    {
+        var scope = new ScopeId(Guid.NewGuid());
+        ulong nextOffset = 99;
+        await StoreOffset(scope, nextOffset);
+        await StoreOffset(scope, ++nextOffset);
+
+        var nextOffsetRetrieved = await Sut.GetNextOffset(scope, CancellationToken.None);
+
+        nextOffsetRetrieved.Should().Be(nextOffset);
+    }
+    
+    [Fact]
+    public async Task WhenRollingBackOffset()
+    {
+        var scope = new ScopeId(Guid.NewGuid());
+        ulong nextOffset = 999;
+        await StoreOffset(scope, nextOffset);
+        await StoreOffsetButRollBack(scope, nextOffset + 1);
+
+        var nextOffsetRetrieved = await Sut.GetNextOffset(scope, CancellationToken.None);
+
+        nextOffsetRetrieved.Should().Be(nextOffset);
+    }
+
+    private async Task StoreOffset(ScopeId scope, ulong nextOffset)
+    {
+        using var session = await fixture.Connection.MongoClient.StartSessionAsync();
+        session.StartTransaction();
+        await Sut.UpdateOffset(session, scope, nextOffset, CancellationToken.None);
+        await session.CommitTransactionAsync();
+    }
+    
+    private async Task StoreOffsetButRollBack(ScopeId scope, ulong nextOffset)
+    {
+        using var session = await fixture.Connection.MongoClient.StartSessionAsync();
+        session.StartTransaction();
+        await Sut.UpdateOffset(session, scope, nextOffset, CancellationToken.None);
+        await session.AbortTransactionAsync();
+    }
+
+    private EventLogOffsetStore Sut { get; } =  new(fixture.Connection);
+}

--- a/Specifications/Events.Store.MongoDB.Tests/Events.Store.MongoDB.Tests.csproj
+++ b/Specifications/Events.Store.MongoDB.Tests/Events.Store.MongoDB.Tests.csproj
@@ -7,7 +7,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
+      <PackageReference Include="Machine.Specifications.Should"/>
     </ItemGroup>
 
 </Project>

--- a/Specifications/Events.Store.MongoDB.Tests/Events.Store.MongoDB.Tests.csproj
+++ b/Specifications/Events.Store.MongoDB.Tests/Events.Store.MongoDB.Tests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Machine.Specifications.Should"/>
+      <PackageReference Include="Testcontainers.MongoDb" />
     </ItemGroup>
 
 </Project>

--- a/Specifications/Events.Store.MongoDB.Tests/MongoDatabaseFixture.cs
+++ b/Specifications/Events.Store.MongoDB.Tests/MongoDatabaseFixture.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Runtime.Events.Store.MongoDB;
+using Dolittle.Runtime.Events.Store.MongoDB.Legacy;
+using Microsoft.Extensions.Options;
+using Testcontainers.MongoDb;
+using Xunit;
+
+namespace Events.Store.MongoDB.Tests;
+
+public class MongoDatabaseFixture: IAsyncLifetime
+{
+    IDatabaseConnection? _connection;
+    
+    public IDatabaseConnection Connection => _connection ?? throw new Exception("Connection not initialized");
+    
+    MongoDbContainer MongoDbContainer { get; }
+
+    public MongoDatabaseFixture()
+    {
+        MongoDbContainer = new MongoDbBuilder()
+            .WithReplicaSet("rs0")
+            .Build();
+    }
+
+    public async Task InitializeAsync()
+    {
+        await MongoDbContainer.StartAsync();
+        var connectionString = MongoDbContainer.GetConnectionString();
+        var eventStoreConfiguration = new EventStoreConfiguration
+        {
+            ConnectionString = connectionString,
+            Database = "EventStore"
+        };
+        _connection = new DatabaseConnection(Options.Create<EventStoreConfiguration>(eventStoreConfiguration), new BackwardsCompatibility());
+    }
+
+    public async Task DisposeAsync()
+    {
+        _connection = null;
+        await MongoDbContainer.DisposeAsync();
+    }
+}

--- a/Specifications/Events.Store/Events.Store.csproj
+++ b/Specifications/Events.Store/Events.Store.csproj
@@ -8,7 +8,7 @@
     <Import Project="../../specs.props" />
 
     <ItemGroup>
-        <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+        <PackageReference Include="Dolittle.Contracts"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Specifications/MongoDB/MongoDB.csproj
+++ b/Specifications/MongoDB/MongoDB.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Linq.Async" Version="$(SystemLinqAsyncVersion)" />
+    <PackageReference Include="System.Linq.Async"/>
   </ItemGroup>
 
 </Project>

--- a/Specifications/Services.Clients/Services.Clients.csproj
+++ b/Specifications/Services.Clients/Services.Clients.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="../../Source/Services.Clients/Services.Clients.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+    <PackageReference Include="Dolittle.Contracts"/>
   </ItemGroup>
 </Project>

--- a/Specifications/Services/Services.csproj
+++ b/Specifications/Services/Services.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="../../Source/Services/Services.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
+    <PackageReference Include="Dolittle.Contracts"/>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="for_ReverseCallDispatcherActor" />

--- a/specs.props
+++ b/specs.props
@@ -1,22 +1,23 @@
 <Project>
+    
     <Import Project="versions.props"/>
     
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <IsTestProject>true</IsTestProject>
         <NoWarn>IDE1006;IDE0044;IDE0051;IDE0052;CA2211;CS0612;CS0169;CS8981;RCS1169;RCS1018;RCS1213</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" />
-        <PackageReference Include="Machine.Specifications" Version="1.1.2" />
-        <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-        <PackageReference Include="moq" Version="$(MoqVersion)" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftDotNetTestVersion)" />
-        <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="$(MachineSpecificationsRunnerVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
-        <PackageReference Include="Grpc.Core.Testing" Version="$(GrpcTestingVersion)" />
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Machine.Specifications"/>
+        <PackageReference Include="Machine.Specifications.Should"/>
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="moq"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Machine.Specifications.Runner.VisualStudio"/>
+        <PackageReference Include="Microsoft.Extensions.Logging"/>
+        <PackageReference Include="Grpc.Core.Testing"/>
     </ItemGroup>
     <PropertyGroup>
         <ContractsRootPath>$(NuGetPackageRoot)dolittle.contracts/$(ContractsVersion)/protos/</ContractsRootPath>

--- a/tests.props
+++ b/tests.props
@@ -16,12 +16,12 @@
         <PackageReference Include="Moq" Version="$(MoqVersion)"/>
         <PackageReference Include="xunit" Version="$(XUnitVersion)"/>
         <PackageReference Include="Grpc.Core.Testing" Version="$(GrpcTestingVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)"/>
+        <PackageReference Include="Microsoft.Extensions.Logging"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/versions.props
+++ b/versions.props
@@ -1,34 +1,5 @@
 <Project>
     <PropertyGroup>
-        <AutofacVersion>8.0.0</AutofacVersion>
-        <AutofacExtensionsVersion>9.0.0</AutofacExtensionsVersion>
-        <ConsoleTablesVersion>2.6.1</ConsoleTablesVersion>
         <ContractsVersion>7.8.0</ContractsVersion>
-        <CoverletVersion>6.0.2</CoverletVersion>
-        <DolittleCommonSpecsVersion>2.*</DolittleCommonSpecsVersion>
-        <GrpcVersion>2.65.0</GrpcVersion>
-        <GrpcTestingVersion>2.46.6</GrpcTestingVersion>
-        <GrpcToolsVersion>2.65.0</GrpcToolsVersion>
-        <MachineSpecificationsRunnerVersion>2.10.2</MachineSpecificationsRunnerVersion>
-        <MachineSpecificationsVersion>1.1.2</MachineSpecificationsVersion>
-        <MicrosoftDotNetTestVersion>17.10.0</MicrosoftDotNetTestVersion>
-        <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
-        <MongoDBDriverVersion>2.28.0</MongoDBDriverVersion>
-        <MongoDBDiagnosticSourcesVersion>1.5.0</MongoDBDiagnosticSourcesVersion>
-        <MoqVersion>4.18.*</MoqVersion>
-        <FluentAssertionsVersion>6.12.0</FluentAssertionsVersion>
-        <NetEscapadesYaml>2.2.0</NetEscapadesYaml>
-        <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
-        <NitoAsyncVersion>5.1.2</NitoAsyncVersion>
-        <PollyVersion>8.4.1</PollyVersion>
-        <PrometheusVersion>8.2.1</PrometheusVersion>
-        <PrometheusNetDotNetRuntimeVersion>4.4.0</PrometheusNetDotNetRuntimeVersion>
-        <ProtoActorVersion>1.6.0</ProtoActorVersion>
-        <ProtobufVersion>3.27.3</ProtobufVersion>
-        <SwashbuckleVersion>6.7.1</SwashbuckleVersion>
-        <SystemLinqAsyncVersion>6.0.1</SystemLinqAsyncVersion>
-        <SystemSecurityVersion>4.3.0</SystemSecurityVersion>
-        <XUnitVersion>2.9.0</XUnitVersion>
-        <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
### External behavior
This release adds support for sparse event logs, which allows users to delete events that are no longer needed. Previously the runtime would not tolerate any events being removed. Now it will just info log the fact and process as normally

### Internal
The runtime has been refactored to use central package management, which reduces friction when upgrading dependency versions. It also removes a legacy dependency and replaces it with channels. In addition it will now enforce limits to work in progress by EventHorizon.


### Added

- Central package management
- Support for sparse event logs

### Removed

- Internal dependency on Nito.AsyncEx, rewritten to use channels
