### PR TITLE
GDPR redaction support

### DIFF
--- a/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
+++ b/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
@@ -6,10 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Events.Store.EventHorizon;
 using Dolittle.Runtime.Events.Store.MongoDB.Events;
-using Dolittle.Runtime.Events.Store.MongoDB.Persistence;
 using Dolittle.Runtime.Events.Store.MongoDB.Streams;
 using Dolittle.Runtime.Events.Store.Streams;
-using MongoDB.Driver;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon;
 

--- a/Source/Events.Store.MongoDB/Persistence/OffsetStore.cs
+++ b/Source/Events.Store.MongoDB/Persistence/OffsetStore.cs
@@ -10,7 +10,6 @@ using Dolittle.Runtime.DependencyInversion.Lifecycle;
 using Dolittle.Runtime.DependencyInversion.Scoping;
 using Dolittle.Runtime.Events.Store.MongoDB.Events;
 using Dolittle.Runtime.Events.Store.MongoDB.Migrations;
-using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Dolittle.Runtime.Events.Store.MongoDB.Persistence;

--- a/Source/Events.Store.MongoDB/Persistence/RedactionUtil.cs
+++ b/Source/Events.Store.MongoDB/Persistence/RedactionUtil.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dolittle.Runtime.Events.Store.Redactions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Dolittle.Runtime.Events.Store.MongoDB.Persistence;
+
+public static class RedactionUtil
+{
+    /// <summary>
+    /// This will redact specific personal data from the event log
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="collection"></param>
+    /// <param name="redactions"></param>
+    /// <param name="cancellationToken"></param>
+    public static async Task RedactEvents(IClientSessionHandle session, IMongoCollection<Events.Event> collection,
+        IReadOnlyCollection<Redaction> redactions, CancellationToken cancellationToken)
+    {
+        if (redactions.Count == 0) return;
+
+        var updateOperations = redactions.Select(redaction => redaction.CreateUpdateModel()).ToList();
+
+        await collection.BulkWriteAsync(session, updateOperations, new BulkWriteOptions
+        {
+            IsOrdered = true,
+            BypassDocumentValidation = false
+        }, cancellationToken: cancellationToken);
+    }
+
+    private static UpdateManyModel<Events.Event> CreateUpdateModel(this Redaction redaction)
+    {
+        var (updateDefinition, hasUpdateFilter) = CreateUpdateDefinition(redaction);
+        var matchesEventFilter = CreateFilter(redaction);
+        var filter = Builders<Events.Event>.Filter.And(matchesEventFilter, hasUpdateFilter);
+        return new UpdateManyModel<Events.Event>(filter, updateDefinition);
+    }
+
+    static (UpdateDefinition<Events.Event> updateDefinition, FilterDefinition<Events.Event> alreadyUpdatedFilter) CreateUpdateDefinition(this Redaction redaction)
+    {
+        var updates = new List<UpdateDefinition<Events.Event>>();
+        var filters = new List<FilterDefinition<Events.Event>>();
+
+        foreach (var (field, value) in redaction.Details.RedactedProperties)
+        {
+            var asBson = ToBsonValue(value);
+
+            FieldDefinition<Events.Event, BsonValue> contentField = $"Content.{field}";
+            if (asBson is null)
+            {
+                updates.Add(Builders<Events.Event>.Update.Unset(contentField));
+                filters.Add(Builders<Events.Event>.Filter.Exists(contentField));
+            }
+            else
+            {
+                updates.Add(Builders<Events.Event>.Update.Set(contentField, asBson));
+                filters.Add(Builders<Events.Event>.Filter.Ne(contentField, asBson));
+            }
+        }
+
+        // Point to the redaction event
+        updates.Add(Builders<Events.Event>.Update.AddToSet("RedactedBy", redaction.EventLogSequenceNumber.Value));
+
+        var matchesAnyFilter = Builders<Events.Event>.Filter.Or(filters);
+        return (Builders<Events.Event>.Update.Combine(updates), matchesAnyFilter);
+    }
+
+    static FilterDefinition<Events.Event> CreateFilter(this Redaction redaction)
+    {
+        return Builders<Events.Event>.Filter.And(
+            Builders<Events.Event>.Filter.Lt(evt => evt.EventLogSequenceNumber, redaction.EventLogSequenceNumber.Value),
+            Builders<Events.Event>.Filter.Eq(evt => evt.Metadata.EventSource, redaction.EventSourceId.Value),
+            Builders<Events.Event>.Filter.Eq(evt => evt.Metadata.TypeId, redaction.TypeId)
+        );
+    }
+
+    static BsonValue? ToBsonValue(object? element)
+    {
+        if (element is null)
+        {
+            return null;
+        }
+
+        if (element is JsonElement jsonElement)
+        {
+            return jsonElement.ToBsonValue();
+        }
+
+        switch (element)
+        {
+            case string str:
+                return new BsonString(str);
+
+            case int intValue:
+                return new BsonInt32(intValue);
+
+            case long longValue:
+                return new BsonInt64(longValue);
+
+            case double doubleValue:
+                return new BsonDouble(doubleValue);
+
+            case decimal decimalValue:
+                return new BsonDecimal128(decimalValue);
+
+            case bool boolValue:
+                return boolValue ? BsonBoolean.True : BsonBoolean.False;
+
+            default:
+                return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Converts supported JSON values to BSON values
+    /// Does not support arrays or objects
+    /// </summary>
+    /// <param name="element"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    static BsonValue? ToBsonValue(this JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                var str = element.GetString();
+
+                return new BsonString(str);
+
+            case JsonValueKind.Number:
+                if (element.TryGetInt32(out var intValue))
+                {
+                    return new BsonInt32(intValue);
+                }
+
+                if (element.TryGetInt64(out var longValue))
+                {
+                    return new BsonInt64(longValue);
+                }
+
+                if (element.TryGetDouble(out var doubleValue))
+                {
+                    return new BsonDouble(doubleValue);
+                }
+
+                if (element.TryGetDecimal(out var decimalValue))
+                {
+                    return new BsonDecimal128(decimalValue);
+                }
+
+                throw new ArgumentException("Unsupported numeric type");
+
+            case JsonValueKind.True:
+                return BsonBoolean.True;
+
+            case JsonValueKind.False:
+                return BsonBoolean.False;
+
+            case JsonValueKind.Null:
+            default:
+                return null;
+        }
+    }
+}

--- a/Source/Events.Store.MongoDB/Streams/Streams.cs
+++ b/Source/Events.Store.MongoDB/Streams/Streams.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dolittle.Runtime.DependencyInversion.Lifecycle;
 using Dolittle.Runtime.DependencyInversion.Scoping;
-using Dolittle.Runtime.Events.Store.MongoDB.Events;
 using Dolittle.Runtime.Events.Store.Streams;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;

--- a/Source/Events/Store/Actors/EventStore.cs
+++ b/Source/Events/Store/Actors/EventStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Dolittle.Runtime.Actors;
@@ -137,7 +138,8 @@ public class EventStore : EventStoreBase
             Array.Empty<CommittedAggregateEvents>(),
             committedEvents,
             request.Event.EventLogSequenceNumber,
-            request.Event.EventLogSequenceNumber));
+            request.Event.EventLogSequenceNumber,
+            ImmutableList<Redactions.Redaction>.Empty)); // TODO: Consider redaction via external event
 
         return Task.FromResult(new CommitExternalEventsResponse());
     }

--- a/Source/Events/Store/Persistence/Commit.cs
+++ b/Source/Events/Store/Persistence/Commit.cs
@@ -16,4 +16,6 @@ public record Commit(
     IReadOnlyCollection<CommittedAggregateEvents> AggregateEvents,
     IReadOnlyCollection<CommittedEvent> AllEvents,
     EventLogSequenceNumber FirstSequenceNumber,
-    EventLogSequenceNumber LastSequenceNumber);
+    EventLogSequenceNumber LastSequenceNumber,
+    IReadOnlyCollection<Redactions.Redaction> Redactions
+    );

--- a/Source/Events/Store/Redactions/Redaction.cs
+++ b/Source/Events/Store/Redactions/Redaction.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Dolittle.Runtime.Events.Store.Redactions;
+
+/// <summary>
+/// Event that triggers redaction of the given personal data
+/// It will target the given event type and redact the properties specified within the EventSourceId of the event
+/// </summary>
+public class Redaction
+{
+    public const string MagicRedactionId = "de1e7e17-bad5-da7a-fad4-fbc6ec3c0ea5";
+    public static readonly Guid MagicRedactionGuid = Guid.Parse(MagicRedactionId);
+
+    public EventSourceId EventSourceId { get; }
+    public Event Details { get; }
+    public EventLogSequenceNumber EventLogSequenceNumber { get; }
+
+    public Redaction(EventSourceId eventSourceId, Event @event, EventLogSequenceNumber eventLogSequenceNumber)
+    {
+        EventSourceId = eventSourceId;
+        Details = @event;
+        EventLogSequenceNumber = eventLogSequenceNumber;
+    }
+
+    public class Event
+    {
+        public required string EventId { get; init; }
+        public required string EventAlias { get; init; }
+
+        /// <summary>
+        /// The properties that will be redacted, and the replacement values.
+        /// Can be null, in which case the properties will be redacted with a default value
+        /// </summary>
+        public required Dictionary<string, object?> RedactedProperties { get; init; }
+
+        public required string RedactedBy { get; init; }
+        public required string Reason { get; init; }
+    }
+
+    public static bool TryGet(CommittedEvent evt, [NotNullWhen(true)] out Redaction? redaction)
+    {
+        redaction = default;
+        if (evt.Type.Id.Value != MagicRedactionGuid)
+        {
+            return false;
+        }
+
+        try
+        {
+            var payload = JsonSerializer.Deserialize<Event>(evt.Content);
+            if (payload == null)
+            {
+                return false;
+            }
+
+            redaction = new Redaction(evt.EventSource, payload, evt.EventLogSequenceNumber);
+            return true;
+        }
+        catch // Bad payload, ignore
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Runtime support for [GDPR redactions](https://github.com/dolittle/DotNET.SDK/releases/tag/v23.5.0). This adds support for redacting personal data from previously committed events.

Redactions are scoped to a single artifact-type (EventTypeId) and an EventSourceId. 

It will recognize events with the correct GUID prefix `"de1e7e17-bad5-da7a"` that match the event payload and is valid.

```csharp
    public class Event
    {
        public required string EventId { get; init; }
        public required string EventAlias { get; init; }

        /// <summary>
        /// The properties that will be redacted, and the replacement values.
        /// Can be null, in which case the properties will be redacted with a default value
        /// </summary>
        public required Dictionary<string, object?> RedactedProperties { get; init; }

        public required string RedactedBy { get; init; }
        public required string Reason { get; init; }

        public bool IsValid => !string.IsNullOrWhiteSpace(EventId)
                               && !string.IsNullOrWhiteSpace(EventAlias)
                               && RedactedProperties.Count > 0
                               && !string.IsNullOrWhiteSpace(RedactedBy)
                               && !string.IsNullOrWhiteSpace(Reason);
    }
```

Any valid redactions will then be performed in the same transaction as it writes the new events. Replays of these events will then return the updated version of the event, with the redactions performed.


### Added

- GDPR redaction support
