### PR TITLE
.NET 9 release

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -163,3 +163,5 @@ csharp_style_prefer_range_operator = false:none
 dotnet_diagnostic.IDE0055.severity = none
 # prefere brace indentation when creating objects etc
 csharp_indent_braces = false
+
+resharper_remove_redundant_braces_highlighting = none

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
       - name: Run Mongo container
         run: docker run -p 27017:27017 -d dolittle/mongodb:4.2.2
       - name: Run Benchmarks

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run Mongo container
         run: docker run -p 27017:27017 -d dolittle/mongodb:4.2.2
       - name: Test
-        run: dotnet test --filter Tag=IntegrationTest -f net8.0 --configuration Release
+        run: dotnet test --filter Tag=IntegrationTest -f net9.0 --configuration Release

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
       - name: Run Mongo container
         run: docker run -p 27017:27017 -d dolittle/mongodb:4.2.2
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/osx-x64/publish/Dolittle.Runtime.CLI
+          asset_path: ./Source/CLI/bin/Release/net9.0/osx-x64/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-macos-x64
           asset_content_type: application/octet-stream
       - name: Publish for macOS arm64
@@ -215,7 +215,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/osx-arm64/publish/Dolittle.Runtime.CLI
+          asset_path: ./Source/CLI/bin/Release/net9.0/osx-arm64/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-macos-arm64
           asset_content_type: application/octet-stream
       - name: Publish for Windows x64
@@ -227,7 +227,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/win-x64/publish/Dolittle.Runtime.CLI.exe
+          asset_path: ./Source/CLI/bin/Release/net9.0/win-x64/publish/Dolittle.Runtime.CLI.exe
           asset_name: dolittle-win-x64.exe
           asset_content_type: application/octet-stream
       - name: Publish for Windows x86
@@ -239,7 +239,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/win-x86/publish/Dolittle.Runtime.CLI.exe
+          asset_path: ./Source/CLI/bin/Release/net9.0/win-x86/publish/Dolittle.Runtime.CLI.exe
           asset_name: dolittle-win-x86.exe
           asset_content_type: application/octet-stream
       - name: Publish for Windows arm64
@@ -251,7 +251,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/win-arm64/publish/Dolittle.Runtime.CLI.exe
+          asset_path: ./Source/CLI/bin/Release/net9.0/win-arm64/publish/Dolittle.Runtime.CLI.exe
           asset_name: dolittle-win-arm64.exe
           asset_content_type: application/octet-stream
       - name: Publish for Linux x64
@@ -263,7 +263,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/linux-x64/publish/Dolittle.Runtime.CLI
+          asset_path: ./Source/CLI/bin/Release/net9.0/linux-x64/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-linux-x64
           asset_content_type: application/octet-stream
       - name: Publish for Linux arm64
@@ -275,7 +275,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/linux-arm64/publish/Dolittle.Runtime.CLI
+          asset_path: ./Source/CLI/bin/Release/net9.0/linux-arm64/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-linux-arm64
           asset_content_type: application/octet-stream
       - name: Publish for Linux arm
@@ -287,6 +287,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.setup.outputs.release-upload-url }}
-          asset_path: ./Source/CLI/bin/Release/net8.0/linux-arm/publish/Dolittle.Runtime.CLI
+          asset_path: ./Source/CLI/bin/Release/net9.0/linux-arm/publish/Dolittle.Runtime.CLI
           asset_name: dolittle-linux-arm
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
       - name: Run Mongo container
         run: docker run -p 27017:27017 -d dolittle/mongodb:4.2.2
       - name: Run Benchmarks
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           file: ./Docker/Development/Dockerfile
           build-args: |
             VERSION=${{ needs.setup.outputs.next-version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: dolittle/runtime:${{ needs.setup.outputs.next-version }}-development
       - name: Push Latest Tag Of Development Image to Docker Hub
         uses: docker/build-push-action@v2
@@ -171,7 +171,7 @@ jobs:
           file: ./Docker/Development/Dockerfile
           build-args: |
             VERSION=${{ needs.setup.outputs.next-version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: dolittle/runtime:latest-development
 
   release-cli-tool:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
       - name: Build
         run: dotnet build --configuration Release -f net8.0
       - name: Test

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           dotnet-version: "9.0.x"
       - name: Build
-        run: dotnet build --configuration Release -f net8.0
+        run: dotnet build --configuration Release -f net9.0
       - name: Test
-        run: dotnet test --filter Tag!=IntegrationTest --no-build -f net8.0 --configuration Release --collect:"XPlat Code Coverage"
+        run: dotnet test --filter Tag!=IntegrationTest --no-build -f net9.0 --configuration Release --collect:"XPlat Code Coverage"
 
   build-prod-docker-image:
     name: Build Production Docker Image

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -64,4 +64,4 @@ jobs:
           file: ./Docker/Development/Dockerfile
           build-args: |
             VERSION=0.0.0
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,69 +8,73 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
-    <PackageVersion Include="Autofac" Version="8.1.0" />
+    <PackageVersion Include="Autofac" Version="8.1.1" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="ConsoleTables" Version="2.6.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.65.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.65.0" />
-    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.65.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.66.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.66.0" />
+    <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.66.0" />
     <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Tools" Version="2.66.0">
+    <PackageVersion Include="Grpc.Tools" Version="2.67.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Grpc.Net.Client" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
     <PackageVersion Include="Machine.Specifications" Version="1.1.2" />
     <PackageVersion Include="Machine.Specifications.Should" Version="1.0.0" />
     <PackageVersion Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
-    <PackageVersion Include="Polly" Version="8.4.1" />
+    <PackageVersion Include="Polly" Version="8.5.0" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
+    <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.1" />
     <PackageVersion Include="Proto.Actor" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.Remote" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.Cluster" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.1-alpha.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.28.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageVersion Include="Google.Protobuf" Version="3.28.3" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Security.Claims" Version="4.3.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="Testcontainers.MongoDb" Version="3.10.0" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Autofac" Version="8.1.1" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="ConsoleTables" Version="2.6.1" />
+    <PackageVersion Include="ConsoleTables" Version="2.6.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -26,8 +26,7 @@ ENV Logging__Console__FormatterName=""
 
 ENV \
     MONGODB_VERSION=7.0 \
-    MONGODB_PORT=27017 \
-    ASPNETCORE_URLS=http://+:8080
+    MONGODB_PORT=27017
 
 # Install MongoDB and tini
 RUN apt-get update \

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -1,5 +1,5 @@
 # DotNet Build
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS dotnet-build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS dotnet-build
 SHELL ["/bin/bash", "-c"]
 ARG VERSION
 ARG TARGETARCH
@@ -13,62 +13,57 @@ COPY Specifications /app/Specifications/
 
 WORKDIR /app/Source/Server
 RUN dotnet restore
-RUN dotnet publish -c "Release" -p:Version=${VERSION} -f net7.0 -p:RuntimeIdentifier="linux-${TARGETARCH/amd64/x64}" -o out
+RUN dotnet publish -c "Release" -p:Version=${VERSION} -f net9.0 -p:RuntimeIdentifier="linux-${TARGETARCH/amd64/x64}" -o out
 
 # Runtime Image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 SHELL ["/bin/bash", "-c"]
 ARG TARGETARCH
 
 ENV Logging__Console__FormatterName=""
 
-WORKDIR /app
-COPY --from=dotnet-build /app/Source/Server/out ./
-COPY --from=dotnet-build /app/Source/Server/.dolittle ./.dolittle
 
-# Install MongoDB dependencies
+
+ENV \
+    MONGODB_VERSION=7.0 \
+    MONGODB_PORT=27017 \
+    ASPNETCORE_URLS=http://+:8080
+
+# Install MongoDB and tini
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    wget \
-    gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-# Hack to get MongoDB to install even without systemctl
-# See https://www.julienrouse.com/blog/systemctl_not_found_while_installing_mongodb_server/#spoiler-a-solution
-RUN ln -s /bin/true /usr/local/sbin/systemctl
-RUN ln -s /bin/true /usr/local/bin/systemctl
-RUN ln -s /bin/true /usr/sbin/systemctl
-RUN ln -s /bin/true /usr/bin/systemctl
-RUN ln -s /bin/true /sbin/systemctl
-RUN ln -s /bin/true /bin/systemctl
-
-# Install MongoDB
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add - \
-    && echo "deb [ arch=$TARGETARCH ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" > /etc/apt/sources.list.d/mongodb-org-4.2.list \
+        ca-certificates \
+        curl \
+        gnupg \
+        tini \
+    # Add MongoDB repository
+    && curl -fsSL https://pgp.mongodb.com/server-${MONGODB_VERSION}.asc | gpg -o /usr/share/keyrings/mongodb-server-${MONGODB_VERSION}.gpg --dearmor \
+    && echo "deb [signed-by=/usr/share/keyrings/mongodb-server-${MONGODB_VERSION}.gpg] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/${MONGODB_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGODB_VERSION}.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    mongodb-org-server \
-    mongodb-org-shell \
+        mongodb-org \
     && rm -rf /var/lib/apt/lists/*
 
-# Setup MongoDB as single-node replicaset
+
+# Create directories for MongoDB
 RUN mkdir -p /data/db /data/configdb \
-    && chown -R mongodb:mongodb /data/db /data/configdb \
-    && mongod --logpath /var/log/mongodb/initdb.log --replSet "rs0" --bind_ip 0.0.0.0 --fork \
-    && mongo --eval 'rs.initiate({_id: "rs0", members: [{ _id: 0, host: "localhost:27017"}]})' \
-    && mongo admin --eval 'db.shutdownServer()'
+    && chown -R mongodb:mongodb /data/db /data/configdb
 
-VOLUME /data/db /data/configdb
+# Copy MongoDB configuration
+COPY Docker/Development/mongod.conf /etc/mongod.conf
+RUN chown mongodb:mongodb /etc/mongod.conf
 
-# Add Tini to get a real init process
-ADD "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH" /usr/bin/tini
-RUN chmod +x /usr/bin/tini
+
 
 # Create entrypoint that runs both MongoDB and Runtime
 COPY Docker/Development/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 RUN chmod +x /usr/bin/docker-entrypoint.sh
 
+WORKDIR /app
+COPY --from=dotnet-build /app/Source/Server/out ./
+COPY --from=dotnet-build /app/Source/Server/.dolittle ./.dolittle
+
 # Expose the ports
 EXPOSE 9700 50052 50053 51052 27017
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "/usr/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-v", "--", "docker-entrypoint.sh"]

--- a/Docker/Development/docker-entrypoint.sh
+++ b/Docker/Development/docker-entrypoint.sh
@@ -1,7 +1,75 @@
-#!/usr/bin/env bash
-set -e
+#!/bin/bash
 
-/usr/bin/mongod --replSet "rs0" --bind_ip 0.0.0.0 > /dev/null &
-/usr/bin/dotnet "Dolittle.Runtime.Server.dll" &
+echo "Starting MongoDB"
 
-wait -n
+
+
+# Start MongoDB as mongodb user in the background
+su -s /bin/bash mongodb -c "mongod --config /etc/mongod.conf --replSet rs0" &
+MONGO_PID=$!
+
+# Function to handle cleanup on exit
+cleanup() {
+    echo "Starting graceful shutdown..."
+
+    # Step 1: Stop the runtime gracefully
+    if [ -n "$DOTNET_PID" ]; then
+        echo "Stopping runtime (PID: $DOTNET_PID)"
+        kill -SIGTERM "$DOTNET_PID"  # Send SIGTERM to the .NET process
+        wait "$DOTNET_PID"  # Wait for .NET process to terminate
+        echo "runtime stopped."
+    fi
+
+    # Step 2: Stop MongoDB gracefully
+    if [ -n "$MONGO_PID" ]; then
+        echo "Stopping MongoDB (PID: $MONGO_PID)"
+        kill -SIGTERM "$MONGO_PID"  # Send SIGTERM to MongoDB process
+        wait "$MONGO_PID"  # Wait for MongoDB to terminate
+        echo "MongoDB stopped."
+    fi
+
+    echo "Graceful shutdown completed."
+}
+
+# Trap SIGTERM and call cleanup
+trap cleanup SIGTERM SIGINT
+
+
+# Wait for MongoDB to start
+until mongosh --eval "print(\"waited for connection\")"
+do
+    sleep 2
+done
+
+# Initialize replica set
+mongosh --eval '
+rsconf = {
+    _id: "rs0",
+    members: [
+        {
+            _id: 0,
+            host: "localhost:27017",
+            priority: 1
+        }
+    ]
+};
+rs.initiate(rsconf);
+'
+
+# Wait for replica set to be fully initialized
+until mongosh --eval "rs.isMaster().ismaster"
+do
+    sleep 2
+done
+
+echo "MongoDB replica set initialized and ready. Starting Runtime"
+
+
+dotnet Dolittle.Runtime.Server.dll &
+DOTNET_PID=$!
+
+# Wait for runtime to complete (or until terminated)
+wait "$DOTNET_PID"
+
+# If the runtime terminates or crashes, initiate cleanup
+cleanup

--- a/Docker/Development/mongod.conf
+++ b/Docker/Development/mongod.conf
@@ -1,0 +1,18 @@
+# mongod.conf
+storage:
+  dbPath: /data/db
+
+systemLog:
+  destination: file
+  path: /data/db/mongod.log
+  logAppend: true
+
+net:
+  port: 27017
+  bindIp: 0.0.0.0
+
+replication:
+  replSetName: rs0
+
+security:
+  authorization: disabled  # Enable this and set up authentication in production

--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -1,5 +1,5 @@
 # DotNet Build
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS dotnet-build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS dotnet-build
 SHELL ["/bin/bash", "-c"]
 ARG VERSION
 ARG TARGETARCH
@@ -13,10 +13,10 @@ COPY Specifications /app/Specifications/
 
 WORKDIR /app/Source/Server
 RUN dotnet restore
-RUN dotnet publish -c "Release" -p:Version=${VERSION} -f net8.0 -p:RuntimeIdentifier="linux-${TARGETARCH/amd64/x64}" -o out
+RUN dotnet publish -c "Release" -p:Version=${VERSION} -f net9.0 -p:RuntimeIdentifier="linux-${TARGETARCH/amd64/x64}" -o out
 
 # Runtime Image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 SHELL ["/bin/bash", "-c"]
 
 ENV Logging__Console__FormatterName=""

--- a/Integration/Benchmarks/Benchmarks.csproj
+++ b/Integration/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
     <Import Project="../../default.props" />
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AssemblyName>Benchmarks</AssemblyName>
         <RootNamespace>Integration.Benchmarks</RootNamespace>
         <OutputType>Exe</OutputType>

--- a/Runtime.sln
+++ b/Runtime.sln
@@ -148,6 +148,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "development", "development", "{AC1D9095-A820-4B4B-BD98-A88E08790C16}"
 	ProjectSection(SolutionItems) = preProject
 		Docker\Development\Dockerfile = Docker\Development\Dockerfile
+		Docker\Development\docker-entrypoint.sh = Docker\Development\docker-entrypoint.sh
+		Docker\Development\mongod.conf = Docker\Development\mongod.conf
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Events.Store.MongoDB", "Integration\Tests\Events.Store.MongoDB\Events.Store.MongoDB.csproj", "{02CE4263-12B0-4DDC-AB20-452D2257D4D5}"

--- a/Source/Actors/Actors.csproj
+++ b/Source/Actors/Actors.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Proto.OpenTelemetry"/>
         <PackageReference Include="Proto.Cluster"/>
         <PackageReference Include="Proto.Cluster.CodeGen"/>
+        <PackageReference Include="System.Text.Json"/>
     </ItemGroup>
     
     <ItemGroup>

--- a/Source/CLI/CLI.csproj
+++ b/Source/CLI/CLI.csproj
@@ -5,7 +5,6 @@
         <AssemblyName>Dolittle.Runtime.CLI</AssemblyName>
         <RootNamespace>Dolittle.Runtime.CLI</RootNamespace>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>dolittle</ToolCommandName>

--- a/Source/Configuration/Configuration.csproj
+++ b/Source/Configuration/Configuration.csproj
@@ -20,5 +20,6 @@
         <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
         <PackageReference Include="NetEscapades.Configuration.Yaml"/>
         <PackageReference Include="Newtonsoft.Json"/>
+        <PackageReference Include="System.Text.Json"/>
     </ItemGroup>
 </Project>

--- a/Source/Configuration/Parsing/ConfigurationParser.cs
+++ b/Source/Configuration/Parsing/ConfigurationParser.cs
@@ -37,7 +37,10 @@ public class ConfigurationParser : IParseConfigurationObjects
             using var reader = new JsonTextReader(new StreamReader(stream));
             var serializer = JsonSerializer.Create();
             parsed = serializer.Deserialize<TOptions>(reader);
-            return true;
+            if (parsed is not null) return true;
+            
+            error = new Exception("Failed to parse configuration");
+            return false;
         }
         catch (Exception ex)
         {

--- a/Source/DependencyInversion/Tenancy/GeneratedTenantFactoryRegistrationSource.cs
+++ b/Source/DependencyInversion/Tenancy/GeneratedTenantFactoryRegistrationSource.cs
@@ -29,7 +29,7 @@ public class GeneratedTenantFactoryRegistrationSource : IRegistrationSource
     {
         if (!IsDelegateWithTenantIdAsFirstParameter(service, out var delegateType, out var parameters, out var resolvedType))
         {
-            return Enumerable.Empty<IComponentRegistration>();
+            return [];
         }
 
         var tenantDelegateArguments = parameters.Skip(1).Select(_ => _.ParameterType).Append(resolvedType).ToArray();

--- a/Source/Events.Store.MongoDB/Legacy/StringOrGuidFilterDefinition.cs
+++ b/Source/Events.Store.MongoDB/Legacy/StringOrGuidFilterDefinition.cs
@@ -33,6 +33,8 @@ public class StringOrGuidFilterDefinition<TDocument> : FilterDefinition<TDocumen
         _value = value;
     }
 
+    public override BsonDocument Render(RenderArgs<TDocument> args) => Render(args.DocumentSerializer, args.SerializerRegistry);
+
     /// <inheritdoc />
     public override BsonDocument Render(IBsonSerializer<TDocument> documentSerializer, IBsonSerializerRegistry serializerRegistry)
     {

--- a/Source/Metrics/Hosting/HostBuilderExtensions.cs
+++ b/Source/Metrics/Hosting/HostBuilderExtensions.cs
@@ -29,9 +29,7 @@ public static class HostBuilderExtensions
             services.AddSingleton(provider =>
             {
                 foreach (var collector in provider.GetRequiredService<IEnumerable<MetricCollector>>())
-                {
                     provider.GetRequiredService(collector.CollectorType);
-                }
 
                 return registry;
             });

--- a/Source/Rudimentary/ConceptAs.cs
+++ b/Source/Rudimentary/ConceptAs.cs
@@ -21,7 +21,7 @@ public record ConceptAs<TValue>(TValue Value)
     /// Implicitly convert from <see cref="ConceptAs{TValue}"/> to type of the <see cref="ConceptAs{TValue}"/>.
     /// </summary>
     /// <param name="value">The converted value.</param>
-    public static implicit operator TValue(ConceptAs<TValue> value) => value == null ? default : value.Value;
+    public static implicit operator TValue(ConceptAs<TValue> value) => value is null ? default : value.Value;
 
     /// <inheritdoc/>
     public sealed override string ToString() => Value?.ToString() ?? "NULL";

--- a/Source/Rudimentary/Pipelines/IPipeline.cs
+++ b/Source/Rudimentary/Pipelines/IPipeline.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dolittle.Runtime.Rudimentary.Pipelines;
 
@@ -24,5 +25,5 @@ public interface IPipeline<TBatchItem, TBatch> : ICanGetNextReadyBatch<TBatch>
     /// <param name="batchedItem">The batched item.</param>
     /// <param name="error">The error.</param>
     /// <returns>True if successfully added to pipeline, false if not.</returns>
-    bool TryAdd(TBatchItem item, out BatchedItem<TBatchItem> batchedItem, out Exception error);
+    bool TryAdd(TBatchItem item, [NotNullWhen(true)] out BatchedItem<TBatchItem>? batchedItem, [NotNullWhen(false)] out Exception? error);
 }

--- a/Source/Rudimentary/Pipelines/Pipeline.cs
+++ b/Source/Rudimentary/Pipelines/Pipeline.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dolittle.Runtime.Rudimentary.Pipelines;
 
@@ -63,7 +64,7 @@ public class Pipeline<TBatchItem, TBatch, TBatchBuilder> : IPipeline<TBatchItem,
     public int BatchSize { get; }
 
     /// <inheritdoc />
-    public bool TryAdd(TBatchItem item, out BatchedItem<TBatchItem> batchedItem, out Exception error)
+    public bool TryAdd(TBatchItem item, [NotNullWhen(true)] out BatchedItem<TBatchItem>? batchedItem, [NotNullWhen(false)] out Exception? error)
     {
         batchedItem = default;
         error = default;

--- a/Source/Rudimentary/Rudimentary.csproj
+++ b/Source/Rudimentary/Rudimentary.csproj
@@ -8,5 +8,6 @@
     <ItemGroup>
         <PackageReference Include="Google.Protobuf"/>
         <PackageReference Include="System.Linq.Async"/>
+        <PackageReference Include="System.Private.Uri"/>
     </ItemGroup>
 </Project>

--- a/Source/Server/Web/HostBuilderExtensions.cs
+++ b/Source/Server/Web/HostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Dolittle.Runtime.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -31,7 +32,7 @@ public static class HostBuilderExtensions
                     services.AddSwaggerGen(options =>
                     {
                         // TODO: Fix JSON serializer so that Web APIs don't need copies of types
-                        options.SchemaGeneratorOptions.SchemaIdSelector = _ => _.FullName;
+                        options.SchemaGeneratorOptions.SchemaIdSelector = (Type type) => type.FullName;
                     });
                 });
                 webHost.Configure(app =>

--- a/Source/Server/appsettings.json
+++ b/Source/Server/appsettings.json
@@ -3,16 +3,16 @@
         "runtime": {
             "endpoints": {
                 "public": {
-                    "port": 50052
+                    "port": 5052
                 },
                 "private": {
-                    "port": 50053
+                    "port": 5053
                 },
                 "management": {
-                    "port": 51052
+                    "port": 5152
                 },
                 "managementweb": {
-                    "port": 51152
+                    "port": 5153
                 }
             }
         }

--- a/Source/Services.Clients/Services.Clients.csproj
+++ b/Source/Services.Clients/Services.Clients.csproj
@@ -16,5 +16,6 @@
         <PackageReference Include="Dolittle.Contracts"/>
         <PackageReference Include="Google.Protobuf"/>
         <PackageReference Include="Grpc.Net.Client"/>
+        <PackageReference Include="System.Private.Uri"/>
     </ItemGroup>
 </Project>

--- a/default.props
+++ b/default.props
@@ -2,7 +2,7 @@
     <Import Project="versions.props"/>
     
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net9.0</TargetFramework>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <NoWarn>$(NoWarn);SYSLIB1002;SYSLIB1006;SYSLIB1007</NoWarn>
         <Nullable>enable</Nullable>

--- a/specs.props
+++ b/specs.props
@@ -3,7 +3,7 @@
     <Import Project="versions.props"/>
     
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <IsTestProject>true</IsTestProject>
         <NoWarn>IDE1006;IDE0044;IDE0051;IDE0052;CA2211;CS0612;CS0169;CS8981;RCS1169;RCS1018;RCS1213</NoWarn>
     </PropertyGroup>
@@ -17,6 +17,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Machine.Specifications.Runner.VisualStudio"/>
         <PackageReference Include="Microsoft.Extensions.Logging"/>
+        <PackageReference Include="System.Net.Http"/>
+        <PackageReference Include="System.Text.Json"/>
+        <PackageReference Include="System.Text.RegularExpressions"/>
         <PackageReference Include="Grpc.Core.Testing"/>
     </ItemGroup>
     <PropertyGroup>

--- a/tests.props
+++ b/tests.props
@@ -2,7 +2,7 @@
     <Import Project="versions.props"/>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <IsTestProject>true</IsTestProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -25,6 +25,9 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="System.Net.Http"/>
+        <PackageReference Include="System.Text.Json"/>
+        <PackageReference Include="System.Text.RegularExpressions"/>
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
## Summary
This upgraded the Dolittle Runtime to .NET 9, with major improvements to memory usage and the performance increases provided by the new .NET release. Internal dependencies have also been updated.

For the dev image, the lifecycle management has been improved, and have also been updated to the latest version. Unfortunately, there is not currently available a MongoDB package for the arm64 version, so that is not available.


### Removed
- Dev builds for arm64. Since Mongodb did not provide an ARM compatible package, we only provide an adm64 dev image (where MongoDB is included on-image). ARM users will need to have MongoDB externally, for example via docker compose.
