### PR TITLE
EventHandler Stream position metadata

### DIFF
--- a/Configurations/consumer/.dolittle/runtime.yml
+++ b/Configurations/consumer/.dolittle/runtime.yml
@@ -2,7 +2,7 @@ opentelemetry:
   serviceName: "Consumer-Runtime"
 endpoints: 
   private:
-    port: 50055
+    port: 5055
   public:
     port: 5054
   management:

--- a/Configurations/producer/.dolittle/runtime.yml
+++ b/Configurations/producer/.dolittle/runtime.yml
@@ -2,7 +2,7 @@ opentelemetry:
   serviceName: "Producer-Runtime"
 endpoints:
   private:
-    port: 50053
+    port: 5053
   public:
     port: 5052
   management:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <ContractsVersion>7.8.0</ContractsVersion>
+    <ContractsVersion>7.8.1</ContractsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Dolittle.Contracts" Version="$(ContractsVersion)" />
@@ -12,14 +12,14 @@
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="ConsoleTables" Version="2.6.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.67.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.67.0" />
     <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.67.0" />
     <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Tools" Version="2.67.0">
+    <PackageVersion Include="Grpc.Tools" Version="2.68.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
@@ -45,7 +45,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
@@ -59,8 +59,8 @@
     <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.Cluster" Version="1.7.1-alpha.0.1" />
     <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.1-alpha.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.28.3" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.29.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
@@ -70,11 +70,11 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="Testcontainers.MongoDb" Version="4.0.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.1.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/Source/EventHorizon/Consumer/Processing/EventProcessor.cs
+++ b/Source/EventHorizon/Consumer/Processing/EventProcessor.cs
@@ -55,10 +55,10 @@ public class EventProcessor : IEventProcessor
     public EventProcessorId Identifier { get; }
 
     /// <inheritdoc/>
-    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, ExecutionContext executionContext, CancellationToken cancellationToken) => Process(@event, cancellationToken);
+    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, ExecutionContext executionContext, CancellationToken cancellationToken) => Process(@event, cancellationToken);
 
     /// <inheritdoc/>
-    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken)
+    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         Log.RetryProcessEvent(_logger, _subscriptionId);
         return Process(@event, cancellationToken);
@@ -70,7 +70,7 @@ public class EventProcessor : IEventProcessor
         Log.ProcessEvent(_logger, @event.Type.Id, Scope, _subscriptionId.ProducerMicroserviceId, _subscriptionId.ProducerTenantId);
         try
         {
-            await _externalEventsCommitter.Commit(new CommittedEvents(new []{@event}), _consentId, Scope).ConfigureAwait(false);
+            await _externalEventsCommitter.Commit(new CommittedEvents([@event]), _consentId, Scope).ConfigureAwait(false);
             return SuccessfulProcessing.Instance;
         }
         catch (Exception e)

--- a/Source/Events/Processing/EventHandlers/Actors/ProcessorBase.cs
+++ b/Source/Events/Processing/EventHandlers/Actors/ProcessorBase.cs
@@ -113,7 +113,7 @@ public abstract class ProcessorBase<T> where T : IStreamProcessorState<T>
     {
         var before = Stopwatch.GetTimestamp();
 
-        var processingResult = await _processor.Process(evt.Event, evt.Partition, GetExecutionContextForEvent(evt), cancellationToken).ConfigureAwait(false);
+        var processingResult = await _processor.Process(evt.Event, evt.Partition, evt.Position, GetExecutionContextForEvent(evt), cancellationToken).ConfigureAwait(false);
         var elapsed = Stopwatch.GetElapsedTime(before);
         return (processingResult, elapsed);
     }
@@ -137,7 +137,7 @@ public abstract class ProcessorBase<T> where T : IStreamProcessorState<T>
     {
         var before = Stopwatch.GetTimestamp();
         var processingResult = await _processor.Process(
-            evt.Event, evt.Partition, failureReason, processingAttempts - 1, GetExecutionContextForEvent(evt), cancellationToken).ConfigureAwait(false);
+            evt.Event, evt.Partition, evt.Position, failureReason, processingAttempts - 1, GetExecutionContextForEvent(evt), cancellationToken).ConfigureAwait(false);
         var elapsed = Stopwatch.GetElapsedTime(before);
         return (processingResult, elapsed);
     }

--- a/Source/Events/Processing/EventHandlers/EventProcessor.cs
+++ b/Source/Events/Processing/EventHandlers/EventProcessor.cs
@@ -54,24 +54,24 @@ public class EventProcessor : IEventProcessor
     public CancellationToken? DeadlineToken => _dispatcher.DeadlineToken;
 
     /// <inheritdoc />
-    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, ExecutionContext executionContext, CancellationToken cancellationToken)
+    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         _logger.EventProcessorIsProcessing(Identifier, @event.Type.Id, partitionId);
 
         var request = new HandleEventRequest
         {
-            Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.Value, ScopeId = Scope.ToProtobuf() },
+            Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.Value, ScopeId = Scope.ToProtobuf(), StreamPosition = position.Value },
         };
         return Process(request, executionContext, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken)
+    public Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         _logger.EventProcessorIsProcessingAgain(Identifier, @event.Type.Id, partitionId, retryCount, failureReason);
         var request = new HandleEventRequest
         {
-            Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.Value, ScopeId = Scope.ToProtobuf() },
+            Event = new Contracts.StreamEvent { Event = @event.ToProtobuf(), PartitionId = partitionId.Value, ScopeId = Scope.ToProtobuf(), StreamPosition = position.Value },
             RetryProcessingState = new RetryProcessingState { FailureReason = failureReason, RetryCount = retryCount }
         };
         return Process(request, executionContext, cancellationToken);

--- a/Source/Events/Processing/Filters/AbstractFilterProcessor.cs
+++ b/Source/Events/Processing/Filters/AbstractFilterProcessor.cs
@@ -60,7 +60,7 @@ public abstract class AbstractFilterProcessor<TDefinition> : IFilterProcessor<TD
     public abstract Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken);
 
     /// <inheritdoc />
-    public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, ExecutionContext executionContext, CancellationToken cancellationToken)
+    public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         _logger.FilteringEvent(Identifier, Scope, @event.Type.Id, partitionId);
         var result = await Filter(@event, partitionId, Identifier, executionContext, cancellationToken).ConfigureAwait(false);
@@ -69,7 +69,7 @@ public abstract class AbstractFilterProcessor<TDefinition> : IFilterProcessor<TD
     }
 
     /// <inheritdoc/>
-    public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken)
+    public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, string failureReason, uint retryCount, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         _logger.FilteringEventAgain(Identifier, Scope, @event.Type.Id, partitionId, retryCount, failureReason);
         var result = await Filter(@event, partitionId, Identifier, failureReason, retryCount, executionContext, cancellationToken).ConfigureAwait(false);

--- a/Source/Events/Processing/IEventProcessor.cs
+++ b/Source/Events/Processing/IEventProcessor.cs
@@ -39,21 +39,23 @@ public interface IEventProcessor
     /// </summary>
     /// <param name="event">The <see cref="CommittedEvent" />.</param>
     /// <param name="partitionId">The <see cref="PartitionId" />.</param>
+    /// <param name="position">The number of processed events in the stream.</param>
     /// <param name="executionContext">The execution context to process the event in.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns><see cref="IProcessingResult" />.</returns>
-    Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, ExecutionContext executionContext, CancellationToken cancellationToken);
+    Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, ExecutionContext executionContext, CancellationToken cancellationToken);
 
     /// <summary>
     /// Processes an <see cref="CommittedEvent" /> for a <see cref="PartitionId"> partition </see>.
     /// </summary>
     /// <param name="event">The <see cref="CommittedEvent" />.</param>
     /// <param name="partitionId">The <see cref="PartitionId" />.</param>
+    /// <param name="position">The number of processed events in the stream.</param>
     /// <param name="failureReason">The reason the processor was failing.</param>
     /// <param name="retryCount">The retry count.</param>
     /// <param name="executionContext">The execution context to process the event in.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
     /// <returns><see cref="IProcessingResult" />.</returns>
-    Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, string failureReason, uint retryCount, ExecutionContext executionContext,
+    Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, StreamPosition position, string failureReason, uint retryCount, ExecutionContext executionContext,
         CancellationToken cancellationToken);
 }

--- a/Source/Events/Processing/Streams/AbstractScopedStreamProcessor.cs
+++ b/Source/Events/Processing/Streams/AbstractScopedStreamProcessor.cs
@@ -227,7 +227,7 @@ public abstract class AbstractScopedStreamProcessor
     protected async Task<(IStreamProcessorState, IProcessingResult)> ProcessEvent(StreamEvent @event, IStreamProcessorState currentState, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
-        var processingResult = await _processor.Process(@event.Event, @event.Partition, executionContext, cancellationToken).ConfigureAwait(false);
+        var processingResult = await _processor.Process(@event.Event, @event.Partition, @event.Position, executionContext, cancellationToken).ConfigureAwait(false);
         stopwatch.Stop();
         return (await HandleProcessingResult(processingResult, @event, stopwatch.Elapsed, currentState).ConfigureAwait(false), processingResult);
     }
@@ -275,7 +275,7 @@ public abstract class AbstractScopedStreamProcessor
     protected async Task<IStreamProcessorState> RetryProcessingEvent(StreamEvent @event, string failureReason, uint processingAttempts, IStreamProcessorState currentState, ExecutionContext executionContext, CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
-        var processingResult = await _processor.Process(@event.Event, @event.Partition, failureReason, processingAttempts - 1, executionContext, cancellationToken).ConfigureAwait(false);
+        var processingResult = await _processor.Process(@event.Event, @event.Partition, @event.Position, failureReason, processingAttempts - 1, executionContext, cancellationToken).ConfigureAwait(false);
         stopwatch.Stop();
         return await HandleProcessingResult(processingResult, @event, stopwatch.Elapsed, currentState).ConfigureAwait(false);
     }

--- a/Source/Events/Processing/Streams/Partitioned/FailingPartitions.cs
+++ b/Source/Events/Processing/Streams/Partitioned/FailingPartitions.cs
@@ -123,6 +123,7 @@ public class FailingPartitions : IFailingPartitions
                     failingPartitionState,
                     streamEvent.Event,
                     partition,
+                    streamEvent.Position,
                     _createExecutionContextForEvent(streamEvent),
                     cancellationToken).ConfigureAwait(false);
 
@@ -230,9 +231,9 @@ public class FailingPartitions : IFailingPartitions
         return (newState, newFailingPartitionState);
     }
 
-    Task<IProcessingResult> RetryProcessingEvent(FailingPartitionState failingPartitionState, CommittedEvent @event, PartitionId partition,
+    Task<IProcessingResult> RetryProcessingEvent(FailingPartitionState failingPartitionState, CommittedEvent @event, PartitionId partition, StreamPosition position,
         ExecutionContext executionContext, CancellationToken cancellationToken) =>
-        _eventProcessor.Process(@event, partition, failingPartitionState.Reason,
+        _eventProcessor.Process(@event, partition, position, failingPartitionState.Reason,
             failingPartitionState.ProcessingAttempts == 0 ? 0 : failingPartitionState.ProcessingAttempts - 1, executionContext, cancellationToken);
 
     Task PersistNewState(IStreamProcessorId streamProcessorId, StreamProcessorState newState, CancellationToken cancellationToken) =>

--- a/Specifications/EventHorizon/Consumer/Processing/for_EventProcessor/when_processing/an_event.cs
+++ b/Specifications/EventHorizon/Consumer/Processing/for_EventProcessor/when_processing/an_event.cs
@@ -3,6 +3,7 @@
 
 using Dolittle.Runtime.Events.Processing;
 using Dolittle.Runtime.Events.Store;
+using Dolittle.Runtime.Events.Store.Streams;
 using Machine.Specifications;
 
 namespace Dolittle.Runtime.EventHorizon.Consumer.Processing.for_EventProcessor.when_processing;
@@ -14,7 +15,7 @@ public class an_event : given.all_dependencies
 
     Establish context = () => processor = new EventProcessor(consent_id, subscription_id, external_events_committer.Object, metrics, logger);
 
-    Because of = () => result = processor.Process(@event, partition, execution_context, default).GetAwaiter().GetResult();
+    Because of = () => result = processor.Process(@event, partition, StreamPosition.Start, execution_context, default).GetAwaiter().GetResult();
 
     It should_commit_event = () => external_events_committer.Verify(_ => _.Commit(Moq.It.Is<CommittedEvents>(events => events.Count == 1 && events[0].Equals(@event)), consent_id, subscription_id.ScopeId), Moq.Times.Once);
     It should_return_succeeded_processing_result = () => result.Succeeded.ShouldBeTrue();

--- a/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_processing/an_event.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_processing/an_event.cs
@@ -39,7 +39,7 @@ public class an_event : given.all_dependencies
         partition = "some partition";
     };
 
-    Because of = () => event_processor.Process(@event, partition, execution_context, default).GetAwaiter().GetResult();
+    Because of = () => event_processor.Process(@event, partition, StreamPosition.Start, execution_context, default).GetAwaiter().GetResult();
 
     It should_call_the_dispatcher_once = () => dispatcher.Verify(_ => _.Call(Moq.It.IsAny<Contracts.HandleEventRequest>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 }

--- a/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_retrying_processing/an_event.cs
+++ b/Specifications/Events.Processing/EventHandlers/for_EventProcessor/when_retrying_processing/an_event.cs
@@ -38,7 +38,7 @@ public class an_event : given.all_dependencies
         partition = "a partition";
     };
 
-    Because of = () => event_processor.Process(@event, partition, execution_context, default).GetAwaiter().GetResult();
+    Because of = () => event_processor.Process(@event, partition, StreamPosition.Start, execution_context, default).GetAwaiter().GetResult();
 
     It should_call_the_dispatcher_once = () => dispatcher.Verify(_ => _.Call(Moq.It.IsAny<Contracts.HandleEventRequest>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 }

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_included.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_included.cs
@@ -30,7 +30,7 @@ public class and_event_is_included : given.all_dependencies
             .Returns(Task.FromResult<IFilterResult>(new SuccessfulFiltering(true, partition)));
     };
 
-    Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
+    Because of = () => result = filter_processor.Object.Process(committed_event, partition, StreamPosition.Start, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
     It should_write_it_to_target_stream = () => events_to_streams_writer.Verify(_ => _.Write(committed_event, scope_id, filter_processor.Object.Definition.TargetStream, partition, Moq.It.IsAny<CancellationToken>()), Times.Once);
     It should_returned_successful_processing_result = () => result.Succeeded.ShouldBeTrue();
 }

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_not_included.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_event_is_not_included.cs
@@ -30,7 +30,7 @@ public class and_event_is_not_included : given.all_dependencies
             .Returns(Task.FromResult<IFilterResult>(new SuccessfulFiltering(false, partition)));
     };
 
-    Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
+    Because of = () => result = filter_processor.Object.Process(committed_event, partition, StreamPosition.Start, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
     It should_not_write_stream = () => events_to_streams_writer.Verify(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Times.Never);
     It should_return_successful_processing_result = () => result.Succeeded.ShouldBeTrue();
 }

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_filtering_failed.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_filtering_failed.cs
@@ -33,7 +33,7 @@ public class and_filtering_failed : given.all_dependencies
             .Returns(Task.FromResult(failed_result));
     };
 
-    Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
+    Because of = () => result = filter_processor.Object.Process(committed_event, partition, StreamPosition.Start, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
     It should_not_write_stream = () => events_to_streams_writer.Verify(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Times.Never);
     It should_return_the_failed_result = () => result.ShouldEqual(failed_result);
 }

--- a/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_writing_filtered_event_fails.cs
+++ b/Specifications/Events.Processing/Filters/for_AbstractFilterProcessor/when_processing/and_writing_filtered_event_fails.cs
@@ -31,7 +31,7 @@ public class and_writing_filtered_event_fails : given.all_dependencies
                 Moq.It.IsAny<CancellationToken>())).ReturnsAsync(new SuccessfulFiltering(true));
     };
 
-    Because of = () => result = filter_processor.Object.Process(committed_event, partition, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
+    Because of = () => result = filter_processor.Object.Process(committed_event, partition, StreamPosition.Start, committed_event.ExecutionContext, CancellationToken.None).GetAwaiter().GetResult();
     It should_write_stream = () => events_to_streams_writer.Verify(_ => _.Write(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<ScopeId>(), Moq.It.IsAny<StreamId>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<CancellationToken>()), Times.Once);
     It should_return_failed_result = () => result.Succeeded.ShouldBeFalse();
 }

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_fails_processing.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_fails_processing.cs
@@ -21,7 +21,7 @@ public class and_fails_processing : given.all_dependencies
         stream_processor_state_repository.Persist(stream_processor_id, stream_processor_state, CancellationToken.None).GetAwaiter().GetResult();
         
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(),
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(),
                 Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(new_failing_reason)));
     };
@@ -43,6 +43,7 @@ public class and_fails_processing : given.all_dependencies
         _ => _.Process(
             eventStream[0].Event,
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -52,6 +53,7 @@ public class and_fails_processing : given.all_dependencies
         _ => _.Process(
             eventStream[1].Event,
             second_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_must_retry_processing_twice_before_failing.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_must_retry_processing_twice_before_failing.cs
@@ -24,11 +24,12 @@ public class and_must_retry_processing_twice_before_failing : given.all_dependen
             .Setup(_ => _.Process(
                 Moq.It.IsAny<CommittedEvent>(),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<string>(),
                 Moq.It.IsAny<uint>(),
                 Moq.It.IsAny<ExecutionContext>(),
                 Moq.It.IsAny<CancellationToken>()))
-            .Returns<CommittedEvent, PartitionId, string, uint, ExecutionContext, CancellationToken>((@event, partition, reason, retryCount, _, _) =>
+            .Returns<CommittedEvent, PartitionId, StreamPosition, string, uint, ExecutionContext, CancellationToken>((@event, partition, position, reason, retryCount, _, _) =>
                 Task.FromResult<IProcessingResult>(retryCount >= 1 ? new FailedProcessing(last_failure_reason) : new FailedProcessing(new_failing_reason, true, TimeSpan.Zero)));
         stream_processor_state_repository.Persist(stream_processor_id,stream_processor_state, CancellationToken.None).GetAwaiter().GetResult();
     };
@@ -48,6 +49,7 @@ public class and_must_retry_processing_twice_before_failing : given.all_dependen
         _ => _.Process(
             eventStream[0].Event,
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -57,6 +59,7 @@ public class and_must_retry_processing_twice_before_failing : given.all_dependen
         _ => _.Process(
             eventStream[1].Event,
             second_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/all_events.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/all_events.cs
@@ -55,7 +55,7 @@ public class all_events : given.all_dependencies
             Moq.It.IsAny<ExecutionContext>(),
             Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(1));
 
-    It should_have_retried_processeing_three_times = () => event_processor.Verify(
+    It should_have_retried_processing_three_times = () => event_processor.Verify(
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/all_events.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/all_events.cs
@@ -20,6 +20,7 @@ public class all_events : given.all_dependencies
             .Setup(_ => _.Process(
                 Moq.It.IsAny<CommittedEvent>(),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<string>(),
                 Moq.It.IsAny<uint>(),
                 Moq.It.IsAny<ExecutionContext>(),
@@ -38,6 +39,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -47,6 +49,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             second_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -56,6 +59,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -65,6 +69,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             eventStream[0].Event,
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -74,6 +79,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             eventStream[1].Event,
             second_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -83,6 +89,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             eventStream[2].Event,
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/but_fails_on_last_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/but_fails_on_last_event.cs
@@ -42,7 +42,7 @@ public class but_fails_on_last_event : given.all_dependencies
     It should_have_new_failing_partition_reason = () => failing_partition(first_failing_partition_id).Reason.ShouldEqual(new_failure_reason);
     It should_not_retry_failing_partition = () => failing_partition(first_failing_partition_id).RetryTime.ShouldEqual(DateTimeOffset.MaxValue);
 
-    It should_have_retried_processeing_three_times = () => event_processor.Verify(
+    It should_have_retried_processing_three_times = () => event_processor.Verify(
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/but_fails_on_last_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_be_retried/and_succeeds_in_processing/but_fails_on_last_event.cs
@@ -22,11 +22,12 @@ public class but_fails_on_last_event : given.all_dependencies
             .Setup(_ => _.Process(
                 Moq.It.IsAny<CommittedEvent>(),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<string>(),
                 Moq.It.IsAny<uint>(),
                 Moq.It.IsAny<ExecutionContext>(),
                 Moq.It.IsAny<CancellationToken>()))
-            .Returns<CommittedEvent, PartitionId, string, uint, ExecutionContext, CancellationToken>((@event, partition, reason, retryCount, _, _) =>
+            .Returns<CommittedEvent, PartitionId, StreamPosition, string, uint, ExecutionContext, CancellationToken>((@event, partition, position, reason, retryCount, _, _) =>
                 @event == eventStream[2].Event ? Task.FromResult<IProcessingResult>(new FailedProcessing(new_failure_reason)) : Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         stream_processor_state_repository.Persist(stream_processor_id, stream_processor_state, CancellationToken.None).GetAwaiter().GetResult();
 
@@ -45,6 +46,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -54,6 +56,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             eventStream[0].Event,
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -63,6 +66,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             eventStream[1].Event,
             second_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -72,6 +76,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             eventStream[2].Event,
             first_failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_never_be_retried.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_multiple_failing_partitions/that_should_never_be_retried.cs
@@ -49,6 +49,7 @@ public class that_should_never_be_retried : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<ExecutionContext>(),
             Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
@@ -56,6 +57,7 @@ public class that_should_never_be_retried : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_no_failing_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_are_no_failing_partitions.cs
@@ -27,6 +27,6 @@ public class and_there_are_no_failing_partitions : given.all_dependencies
 
     It should_not_process_any_events = () =>
         event_processor.Verify(
-            _ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()),
+            _ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()),
             Moq.Times.Never);
 }

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_fails_processing.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_fails_processing.cs
@@ -22,6 +22,7 @@ public class and_fails_processing : given.all_dependencies
             .Setup(_ => _.Process(
                 Moq.It.IsAny<CommittedEvent>(),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<string>(),
                 Moq.It.IsAny<uint>(),
                 Moq.It.IsAny<ExecutionContext>(),
@@ -44,6 +45,7 @@ public class and_fails_processing : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<ExecutionContext>(),
             Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
@@ -51,6 +53,7 @@ public class and_fails_processing : given.all_dependencies
         _ => _.Process(
             eventStream[(int)(result as StreamProcessorState).FailingPartitions[failing_partition_id].Position.StreamPosition.Value].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_must_retry_processing_twice_before_failing.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_must_retry_processing_twice_before_failing.cs
@@ -22,11 +22,12 @@ public class and_must_retry_processing_twice_before_failing : given.all_dependen
             .Setup(_ => _.Process(
                 Moq.It.IsAny<CommittedEvent>(),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<string>(),
                 Moq.It.IsAny<uint>(),
                 Moq.It.IsAny<ExecutionContext>(),
                 Moq.It.IsAny<CancellationToken>()))
-            .Returns<CommittedEvent, PartitionId, string, uint, ExecutionContext, CancellationToken>((@event, partition, reason, _, retryCount, _) => Task.FromResult<IProcessingResult>(num_processed++ >= 2 ? new FailedProcessing(new_failing_reason) : new FailedProcessing(new_failing_reason, true, TimeSpan.Zero)));
+            .Returns<CommittedEvent, PartitionId, StreamPosition, string, uint, ExecutionContext, CancellationToken>((@event, partition, position, reason, _, retryCount, _) => Task.FromResult<IProcessingResult>(num_processed++ >= 2 ? new FailedProcessing(new_failing_reason) : new FailedProcessing(new_failing_reason, true, TimeSpan.Zero)));
 
     Because of = () => result = failing_partitions.CatchupFor(stream_processor_id, stream_processor_state, CancellationToken.None).GetAwaiter().GetResult() as StreamProcessorState;
 
@@ -41,6 +42,7 @@ public class and_must_retry_processing_twice_before_failing : given.all_dependen
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -50,6 +52,7 @@ public class and_must_retry_processing_twice_before_failing : given.all_dependen
         _ => _.Process(
             eventStream[(int)failing_partition(failing_partition_id).Position.StreamPosition.Value].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_succeeds_in_processing/all_events.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_succeeds_in_processing/all_events.cs
@@ -16,7 +16,7 @@ public class all_events : given.all_dependencies
 
     Establish context = () =>
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
 
     Because of = () => result = failing_partitions.CatchupFor(stream_processor_id, stream_processor_state, CancellationToken.None).GetAwaiter().GetResult() as StreamProcessorState;
@@ -29,6 +29,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<ExecutionContext>(),
             Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
@@ -36,6 +37,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -45,6 +47,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             eventStream[0].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -54,6 +57,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             eventStream[1].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -63,6 +67,7 @@ public class all_events : given.all_dependencies
         _ => _.Process(
             eventStream[2].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_succeeds_in_processing/but_fails_on_last_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_be_retried/and_succeeds_in_processing/but_fails_on_last_event.cs
@@ -15,17 +15,18 @@ public class but_fails_on_last_event : given.all_dependencies
 {
     static string new_failure_reason = "new reason";
     static StreamProcessorState result;
+    
 
     Establish context = () =>
     {
         event_processor
-            .Setup(_ => _.Process(eventStream[0].Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(eventStream[0].Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         event_processor
-            .Setup(_ => _.Process(eventStream[1].Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(eventStream[1].Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         event_processor
-            .Setup(_ => _.Process(eventStream[2].Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(eventStream[2].Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(new_failure_reason)));
     };
 
@@ -42,6 +43,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<ExecutionContext>(),
             Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
@@ -49,6 +51,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -58,6 +61,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             eventStream[0].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -67,6 +71,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             eventStream[1].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),
@@ -76,6 +81,7 @@ public class but_fails_on_last_event : given.all_dependencies
         _ => _.Process(
             eventStream[2].Event,
             failing_partition_id,
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_never_be_retried.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_FailingPartitions/when_catching_up/and_there_is_one_failing_partition/that_should_never_be_retried.cs
@@ -43,6 +43,7 @@ public class that_should_never_be_retried : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<ExecutionContext>(),
             Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
@@ -50,6 +51,7 @@ public class that_should_never_be_retried : given.all_dependencies
         _ => _.Process(
             Moq.It.IsAny<CommittedEvent>(),
             Moq.It.IsAny<PartitionId>(),
+            Moq.It.IsAny<StreamPosition>(),
             Moq.It.IsAny<string>(),
             Moq.It.IsAny<uint>(),
             Moq.It.IsAny<ExecutionContext>(),

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_at_second_event_in_both_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_at_second_event_in_both_partitions.cs
@@ -33,6 +33,7 @@ public class and_processing_fails_at_second_event_in_both_partitions : given.all
             .Setup(_ => _.Process(
                 Moq.It.Is<CommittedEvent>(_ => _ == first_event.Event || _ == second_event.Event),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<ExecutionContext>(),
                 Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
@@ -40,6 +41,7 @@ public class and_processing_fails_at_second_event_in_both_partitions : given.all
             .Setup(_ => _.Process(
                 Moq.It.Is<CommittedEvent>(_ => _ == third_event.Event || _ == fourth_event.Event),
                 Moq.It.IsAny<PartitionId>(),
+                Moq.It.IsAny<StreamPosition>(),
                 Moq.It.IsAny<ExecutionContext>(),
                 Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
@@ -48,13 +50,13 @@ public class and_processing_fails_at_second_event_in_both_partitions : given.all
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
     
-    It should_process_two_events_in_first_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_process_two_events_in_second_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_third_event = () => event_processor.Verify(_ => _.Process(third_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_fourth_event = () => event_processor.Verify(_ => _.Process(fourth_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_process_two_events_in_first_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_two_events_in_second_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, first_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, second_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_third_event = () => event_processor.Verify(_ => _.Process(third_event.Event, first_partition_id, third_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_fourth_event = () => event_processor.Verify(_ => _.Process(fourth_event.Event, second_partition_id, fourth_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(4));
     It should_have_persisted_state_with_two_failing_partitions = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(2);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_both_partitions.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_both_partitions.cs
@@ -26,18 +26,18 @@ public class and_processing_fails_in_both_partitions : given.all_dependencies
         first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
         second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         setup_event_stream(first_event, second_event);
     };
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_one_event_in_first_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_one_event_in_second_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_process_one_event_in_first_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_one_event_in_second_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, first_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, second_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(2));
     It should_have_persisted_state_with_two_failing_partitions = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(2);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_one_partition.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/a_stream_that_has_events_in_two_partitions/and_processing_fails_in_one_partition.cs
@@ -30,23 +30,23 @@ public class and_processing_fails_in_one_partition : given.all_dependencies
         third_event = new StreamEvent(committed_events.single(), 2u, Guid.NewGuid(), second_partition_id, true);
         fourth_event = new StreamEvent(committed_events.single(), 3u, Guid.NewGuid(), second_partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         setup_event_stream(first_event, second_event, third_event, fourth_event);
     };
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_event_in_first_partition_once = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_three_events_in_second_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(3));
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_third_event = () => event_processor.Verify(_ => _.Process(third_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_fourth_event = () => event_processor.Verify(_ => _.Process(fourth_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_process_event_in_first_partition_once = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), first_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_three_events_in_second_partition = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), second_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(3));
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, first_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, second_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_third_event = () => event_processor.Verify(_ => _.Process(third_event.Event, second_partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_fourth_event = () => event_processor.Verify(_ => _.Process(fourth_event.Event, second_partition_id, fourth_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
 
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(4));
     It should_have_persisted_state_with_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_first_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_event_processing_failed_at_first_event.cs
@@ -21,15 +21,15 @@ public class and_event_processing_failed_at_first_event : given.all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         setup_event_stream(event_with_partition);
     };
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
 
     It should_have_current_position_equal_zero = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_have_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_stream_processor_must_retry_processing_an_event_three_times.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_processing/and_stream_has_only_one_partition/and_stream_processor_must_retry_processing_an_event_three_times.cs
@@ -21,27 +21,27 @@ public class and_stream_processor_must_retry_processing_an_event_three_times : g
     Establish context = () =>
     {
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(retry_reason, true, TimeSpan.Zero)));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), 0, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), 0, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Callback(() => Console.WriteLine("HELLO"))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(retry_reason, true, TimeSpan.Zero)));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), 1, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), 1, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(retry_reason, true, TimeSpan.Zero)));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), 2, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), 2, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(failure_reason)));
         setup_event_stream(new StreamEvent(first_event, 0, Guid.NewGuid(), partition_id, true));
     };
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(100)).GetAwaiter().GetResult();
 
-    It should_process_first_event_normally_once = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_retry_processing_first_event_first_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, retry_reason, 0, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_retry_processing_first_event_second_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, retry_reason, 1, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_retry_processing_first_event_third_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, retry_reason, 2, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_first_event_normally_once = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_retry_processing_first_event_first_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), retry_reason, 0, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_retry_processing_first_event_second_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id,Moq.It.IsAny<StreamPosition>(), retry_reason, 1, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_retry_processing_first_event_third_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), retry_reason, 2, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
 
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_have_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_everything_is_ok.cs
@@ -29,17 +29,17 @@ public class and_everything_is_ok : all_dependencies
         first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
         second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(first_event, second_event);
     };
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
-    It should_process_four_times = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
-    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_process_four_times = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
+    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, first_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, second_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(2));
     It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
     It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_performing_action_fails.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_performing_action_fails.cs
@@ -30,7 +30,7 @@ public class and_performing_action_fails : all_dependencies
         first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
         second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(first_event, second_event);
 
@@ -41,10 +41,10 @@ public class and_performing_action_fails : all_dependencies
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
-    It should_process_two_times = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_not_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_not_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_process_two_times = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_not_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, first_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, second_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(2));
     It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
     It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_setting_position_after_a_failing_partition.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/a_stream_that_has_events_in_two_partitions/and_setting_position_after_a_failing_partition.cs
@@ -29,19 +29,19 @@ public class and_processing_fails_at_second_event_in_both_partitions : all_depen
         first_event = new StreamEvent(committed_events.single(), StreamPosition.Start, Guid.NewGuid(), first_partition_id, true);
         second_event = new StreamEvent(committed_events.single(), 1u, Guid.NewGuid(), second_partition_id, true);
         event_processor
-            .Setup(_ => _.Process(first_event.Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(first_event.Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         event_processor
-            .Setup(_ => _.Process(second_event.Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(second_event.Event, Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(first_event, second_event);
     };
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), new ProcessingPosition(1,1), action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
-    It should_process_first_event_once = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
+    It should_process_first_event_once = () => event_processor.Verify(_ => _.Process(first_event.Event, first_partition_id, first_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event.Event, second_partition_id, second_event.Position, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_not_retry_processing = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), Moq.It.IsAny<uint>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Never);
     It should_have_persisted_the_correct_position = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(2));
     It should_have_persisted_state_with_one_failing_partitions = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);
     It should_have_persisted_state_with_correct_failing_partition = () => current_stream_processor_state.FailingPartitions.ContainsKey(first_partition_id).ShouldBeTrue();

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_event_processing_failed_at_second_event.cs
@@ -24,10 +24,10 @@ public class and_event_processing_failed_at_second_event : all_dependencies
     Establish context = () =>
     {
         event_processor
-            .Setup(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         event_processor
-            .Setup(_ => _.Process(second_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(second_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         setup_event_stream(
             new StreamEvent(first_event, 0, Guid.NewGuid(), partition_id, true),
@@ -36,9 +36,9 @@ public class and_event_processing_failed_at_second_event : all_dependencies
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_four_events = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
-    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_four_events = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(4));
+    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_second_event_twice = () => event_processor.Verify(_ => _.Process(second_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_have_current_position_equal_2 = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(2));
     It should_have_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);
     It should_have_the_correct_failing_partition = () => current_stream_processor_state.FailingPartitions.ContainsKey(partition_id).ShouldBeTrue();

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_everything_is_ok.cs
@@ -24,15 +24,15 @@ public class and_everything_is_ok : all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(event_with_partition);
     };
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_two_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_two_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
     It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_performing_action_fails.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_performing_action_fails.cs
@@ -25,7 +25,7 @@ public class and_performing_action_fails : all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, true);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(event_with_partition);
 
@@ -36,8 +36,8 @@ public class and_performing_action_fails : all_dependencies
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_not_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_not_have_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(0);
     It should_perform_the_action = () => action_to_perform_before_reprocessing.Verify(_ => _(tenant_id, Moq.It.IsAny<CancellationToken>()), Times.Once);

--- a/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_setting_position_to_failing_event.cs
+++ b/Specifications/Events.Processing/Streams/Partitioned/for_ScopedStreamProcessor/when_setting_position/and_stream_has_only_one_partition/and_setting_position_to_failing_event.cs
@@ -24,14 +24,14 @@ public class and_setting_position_to_failing_event : all_dependencies
     Establish context = () =>
     {
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(failure_reason)));
         setup_event_stream(new StreamEvent(first_event, 0, Guid.NewGuid(), partition_id, true));
     };
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100), ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
 
-    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_first_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_have_one_failing_partition = () => current_stream_processor_state.FailingPartitions.Count.ShouldEqual(1);
     It should_have_the_correct_failing_partition = () => current_stream_processor_state.FailingPartitions.ContainsKey(partition_id).ShouldBeTrue();

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_first_event.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_first_event.cs
@@ -21,7 +21,7 @@ public class and_event_processing_failed_at_first_event : given.all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, false);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         setup_event_stream(event_with_partition);
             
@@ -29,8 +29,8 @@ public class and_event_processing_failed_at_first_event : given.all_dependencies
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(250)).GetAwaiter().GetResult();
 
-    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_one_event = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
     It should_have_current_position_equal_zero = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(0));
     It should_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeTrue();
     It should_have_the_correct_retry_time = () => current_stream_processor_state.RetryTime.ShouldEqual(DateTimeOffset.MaxValue);

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_second_event.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_event_processing_failed_at_second_event.cs
@@ -21,10 +21,10 @@ public class and_event_processing_failed_at_second_event : given.all_dependencie
     Establish context = () =>
     {
         event_processor
-            .Setup(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         event_processor
-            .Setup(_ => _.Process(second_event, partition_id, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(second_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(reason)));
         setup_event_stream(
             new StreamEvent(first_event, 0, Guid.NewGuid(), partition_id, true),
@@ -34,9 +34,9 @@ public class and_event_processing_failed_at_second_event : given.all_dependencie
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(250)).GetAwaiter().GetResult();
 
-    It should_process_two_events = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
-    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event, partition_id, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_two_events = () => event_processor.Verify(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_second_event = () => event_processor.Verify(_ => _.Process(second_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeTrue();
     It should_have_the_correct_retry_time = () => current_stream_processor_state.RetryTime.ShouldEqual(DateTimeOffset.MaxValue);

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_stream_processor_must_retry_processing_an_event_three_times.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/and_stream_processor_must_retry_processing_an_event_three_times.cs
@@ -20,16 +20,16 @@ public class and_stream_processor_must_retry_processing_an_event_three_times : g
     Establish context = () =>
     {
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(retry_reason, true, TimeSpan.Zero)));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), 0, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), 0, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(retry_reason, true, TimeSpan.Zero)));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), 1, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), 1, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(new FailedProcessing(retry_reason, true, TimeSpan.Zero)));
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<string>(), 2, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<string>(), 2, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()))
             .Returns(() =>
             {
                 Task.Run(async () =>
@@ -44,11 +44,11 @@ public class and_stream_processor_must_retry_processing_an_event_three_times : g
 
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(250)).GetAwaiter().GetResult();
 
-    It should_process_first_event_normally_once = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_retry_processing_first_event_first_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, retry_reason, 0, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_retry_processing_first_event_second_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, retry_reason, 1, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_retry_processing_first_event_third_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, retry_reason, 2, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
-    It should_have_current_position_equal_zero = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(0));
+    It should_process_first_event_normally_once = () => event_processor.Verify(_ => _.Process(first_event, partition_id, StreamPosition.Start, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_retry_processing_first_event_first_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, StreamPosition.Start,retry_reason, 0, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_retry_processing_first_event_second_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, StreamPosition.Start, retry_reason, 1, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_retry_processing_first_event_third_time_with_correct_reason = () => event_processor.Verify(_ => _.Process(first_event, partition_id, StreamPosition.Start,retry_reason, 2, Moq.It.IsAny<ExecutionContext>(),Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_have_current_position_equal_zero = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(StreamPosition.Start);
     It should_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeTrue();
     It should_have_the_correct_retry_time = () => current_stream_processor_state.RetryTime.ShouldEqual(DateTimeOffset.MaxValue);
     It should_have_the_correct_reason = () => current_stream_processor_state.FailureReason.ShouldEqual(failure_reason);

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/stream_with_one_event/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_processing/stream_with_one_event/and_everything_is_ok.cs
@@ -20,14 +20,14 @@ public class and_everything_is_ok : given.all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, false);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(event_with_partition);
     };
     
     Because of = () => start_stream_processor_and_cancel_after(TimeSpan.FromMilliseconds(500)).GetAwaiter().GetResult();
 
-    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
+    It should_process_first_event = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once());
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_not_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeFalse();
     It should_try_fetching_next_event = () => events_fetcher.Verify(_ => _.Fetch(1, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_everything_is_ok.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_everything_is_ok.cs
@@ -23,14 +23,14 @@ public class and_everything_is_ok : all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, false);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(event_with_partition);
     };
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100),ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
-    It should_process_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
+    It should_process_event_twice = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_fetch_event_twice = () => events_fetcher.Verify(_ => _.Fetch(0, Moq.It.IsAny<CancellationToken>()), Moq.Times.Exactly(2));
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.StreamPosition.ShouldEqual(new StreamPosition(1));
     It should_not_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeFalse();

--- a/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_performing_action_fails.cs
+++ b/Specifications/Events.Processing/Streams/for_ScopedStreamProcessor/when_setting_position/and_performing_action_fails.cs
@@ -24,7 +24,7 @@ public class and_performing_action_fails : all_dependencies
     {
         var event_with_partition = new StreamEvent(first_event, StreamPosition.Start, Guid.NewGuid(), partition_id, false);
         event_processor
-            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
+            .Setup(_ => _.Process(Moq.It.IsAny<CommittedEvent>(), Moq.It.IsAny<PartitionId>(), Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<IProcessingResult>(SuccessfulProcessing.Instance));
         setup_event_stream(event_with_partition);
 
@@ -35,7 +35,7 @@ public class and_performing_action_fails : all_dependencies
 
     Because of = () => start_stream_processor_set_position_after_and_cancel_after(TimeSpan.FromMilliseconds(100),ProcessingPosition.Initial, action_to_perform_before_reprocessing.Object, TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
         
-    It should_not_process_event_again = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
+    It should_not_process_event_again = () => event_processor.Verify(_ => _.Process(first_event, partition_id, Moq.It.IsAny<StreamPosition>(), Moq.It.IsAny<ExecutionContext>(), Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
     It should_not_fetch_event_again = () => events_fetcher.Verify(_ => _.Fetch(0, Moq.It.IsAny<CancellationToken>()), Moq.Times.Once);
     It should_have_current_position_equal_one = () => current_stream_processor_state.Position.ShouldEqual(new ProcessingPosition(1,1));
     It should_not_be_failing = () => current_stream_processor_state.IsFailing.ShouldBeFalse();

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <ContractsVersion>7.8.0</ContractsVersion>
+        <ContractsVersion>7.8.1</ContractsVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

In addition to updating the runtime dependencies, this adds stream position metadata to events being processed by event handlers. This allows services to better reason about the number of processed events for a given handler.


### Added
- `Dolittle.Runtime.Events.Processing.Contracts.StreamEvent`: Added StreamPosition metadata

